### PR TITLE
Manual init across all 9 problem types (supersedes #27)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -111,3 +111,23 @@ be re-pinned manually after any update.
 
 - 10 ADRs (0001–0010) in `docs/adrs/` — design decisions (see README there)
 - Automated workflow skills: `/orchestrate`, `/architect`, `/implement`, `/review`, `/gate-check`
+
+## Strategic Roadmap (>40 weeks)
+
+We work to a multi-quarter, four-track plan summarized in `docs/ROADMAP.md`. The
+load-bearing path is **A1 → A2 → B5**:
+
+- **A — Calibration core** (puzzle-rig-anchored). A1 = manual init (this is PR #32,
+  superseding PR #27); A2 = per-feature residuals on every `*Export`; A3 = Zhang init
+  robustness; A4 = EyeToHand for Scheimpflug; A5 = Python parity; A6 = rig_family
+  refactor.
+- **B — Tauri 2 + React + TypeScript desktop app**. B0 scaffold → B1 file load →
+  B2 detection wrap → B3 calibration runner → B4 3D rig viewer → **B5 diagnose mode
+  (the MVP)** → B6 polish.
+- **C — MVG** (postponed until B5). C1 PR #28 land → C2 N-view triangulation →
+  C3 BA frozen-intrinsics → C4 Scheimpflug-aware rectification → C5 dense matcher
+  (opencv-rust SGBM, feature-flagged).
+- **D — Earn v1.0** (continuous ratchet). Typed errors → doc-warning-free → Python
+  parity audit → v1.0 release.
+
+We are pre-1.0; breaking changes are acceptable.

--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vision-calibration-examples-private"
 description = "Private end-to-end calibration examples using private sensor datasets"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 authors = ["Vitaly Vorobyev <vit.vorobiev@gmail.com>"]
@@ -12,10 +12,10 @@ publish = false
 resolver = "2"
 
 [dependencies]
-vision-calibration = { path = "../vision-calibration", version = "0.3.0" }
-vision-calibration-core = { path = "../vision-calibration-core", version = "0.3.0" }
-vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.3.0" }
-vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.3.0" }
+vision-calibration = { path = "../vision-calibration", version = "0.4.0" }
+vision-calibration-core = { path = "../vision-calibration-core", version = "0.4.0" }
+vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.4.0" }
+vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.4.0" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/vision-calibration-pipeline/src/laserline_device/mod.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/mod.rs
@@ -15,5 +15,6 @@ pub use problem::{
 };
 pub use state::LaserlineDeviceState;
 pub use steps::{
-    DeviceInitOptions, DeviceOptimizeOptions, run_calibration, step_init, step_optimize,
+    DeviceInitOptions, DeviceOptimizeOptions, LaserlineDeviceManualInit, run_calibration,
+    step_init, step_optimize, step_set_init,
 };

--- a/crates/vision-calibration-pipeline/src/laserline_device/steps.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/steps.rs
@@ -1,16 +1,17 @@
 //! Step functions for single laserline device calibration.
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    Camera, CorrespondenceView, FxFyCxCySkew, Iso3, NoMeta, Pinhole, PlanarDataset, Pt2,
-    SensorModel, View,
+    BrownConrady5, Camera, CorrespondenceView, FxFyCxCySkew, Iso3, NoMeta, Pinhole, PlanarDataset,
+    Pt2, Real, SensorModel, View,
 };
 use vision_calibration_linear::laserline::{
     LaserlinePlaneSolver, LaserlineView as LinearLaserlineView,
 };
 use vision_calibration_linear::prelude::*;
 use vision_calibration_optim::{
-    LaserlineParams, LaserlineStats, compute_laserline_stats, optimize_laserline,
+    LaserPlane, LaserlineParams, LaserlineStats, compute_laserline_stats, optimize_laserline,
 };
 
 use crate::session::CalibrationSession;
@@ -26,6 +27,34 @@ use super::problem::{LaserlineDeviceConfig, LaserlineDeviceOutput, LaserlineDevi
 pub struct DeviceInitOptions {
     /// Override the number of iterations for iterative intrinsics estimation.
     pub iterations: Option<usize>,
+}
+
+/// Manual initialization seeds for laserline device calibration.
+///
+/// All fields are `Option<T>`:
+/// - `None` means *auto-initialize this group* (same path as plain `step_init`).
+/// - `Some(value)` means *use this value*; do not auto-initialize.
+///
+/// **Sensor is intentionally not in this struct** — for laserline devices the
+/// sensor model is a hardware property taken from `session.config.init.sensor_init`.
+/// See ADR 0011.
+///
+/// Partial-seed semantics:
+/// - `intrinsics: Some` skips `estimate_intrinsics_iterative`. Distortion defaults
+///   to `BrownConrady5::default()` (zeros) unless also seeded; poses recover from
+///   per-view homographies using the manual intrinsics.
+/// - `plane: Some` skips the linear plane fit. Note that `initial_plane_rmse` is
+///   recorded as `None` in this case (no fit RMSE is meaningful for a manual seed).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LaserlineDeviceManualInit {
+    /// Manual intrinsics seed.
+    pub intrinsics: Option<FxFyCxCySkew<Real>>,
+    /// Manual distortion seed.
+    pub distortion: Option<BrownConrady5<Real>>,
+    /// Manual per-view poses (`camera_se3_target`).
+    pub poses: Option<Vec<Iso3>>,
+    /// Manual laser plane seed (camera-frame `(n̂, d)`).
+    pub plane: Option<LaserPlane>,
 }
 
 /// Options for the optimization step.
@@ -121,13 +150,28 @@ fn update_state_with_stats(
 // Step Functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Initialize intrinsics, poses, and laser plane from observations.
-pub fn step_init(
+/// Initialize intrinsics, distortion, per-view poses, and laser plane from any
+/// combination of manual seeds and auto-estimation.
+///
+/// This is the load-bearing init function. [`step_init`] is a thin delegate that
+/// passes `LaserlineDeviceManualInit::default()` (all-`None`, full auto path).
+///
+/// See [`LaserlineDeviceManualInit`] for partial-seed semantics. The sensor model
+/// is always taken from `session.config.init.sensor_init` regardless.
+///
+/// # Errors
+///
+/// - Input not set, or fewer than 3 views.
+/// - Auto-init computation fails (homography / Zhang's / linear plane).
+/// - `manual.poses` is `Some` but its length does not match the view count.
+pub fn step_set_init(
     session: &mut CalibrationSession<LaserlineDeviceProblem>,
+    manual: LaserlineDeviceManualInit,
     opts: Option<DeviceInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
+    let view_count = input.len();
 
     let opts = opts.unwrap_or_default();
     let mut init_opts = session.config.init_opts();
@@ -135,33 +179,120 @@ pub fn step_init(
         init_opts.iterations = iters;
     }
 
-    let planar_dataset = planar_dataset_from_input(input)?;
-    let camera_init = estimate_intrinsics_iterative(&planar_dataset, init_opts)
-        .map_err(|e| Error::numerical(format!("intrinsics initialization failed: {e}")))?;
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
 
-    let poses = estimate_poses(input, &camera_init.k)?;
+    let (intrinsics, distortion) = if let Some(k) = manual.intrinsics {
+        manual_fields.push("intrinsics");
+        let d = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                BrownConrady5::default()
+            }
+        };
+        (k, d)
+    } else {
+        auto_fields.push("intrinsics");
+        let planar_dataset = planar_dataset_from_input(input)?;
+        let camera_init = estimate_intrinsics_iterative(&planar_dataset, init_opts)
+            .map_err(|e| Error::numerical(format!("intrinsics initialization failed: {e}")))?;
+        let d = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                camera_init.dist
+            }
+        };
+        (camera_init.k, d)
+    };
+
+    let poses = match manual.poses {
+        Some(p) => {
+            manual_fields.push("poses");
+            if p.len() != view_count {
+                let msg = format!(
+                    "manual poses count ({}) does not match view count ({})",
+                    p.len(),
+                    view_count
+                );
+                session.log_failure("init", msg.clone());
+                return Err(Error::invalid_input(msg));
+            }
+            p
+        }
+        None => {
+            auto_fields.push("poses");
+            estimate_poses(input, &intrinsics)?
+        }
+    };
 
     let sensor = session.config.init.sensor_init;
-    let camera = Camera::new(Pinhole, camera_init.dist, sensor.compile(), camera_init.k);
+    let camera = Camera::new(Pinhole, distortion, sensor.compile(), intrinsics);
 
-    let (plane, plane_rmse) = linear_plane_init(input, &camera, &poses)?;
+    let (plane, plane_rmse) = match manual.plane {
+        Some(p) => {
+            manual_fields.push("plane");
+            (p, None)
+        }
+        None => {
+            auto_fields.push("plane");
+            let (p, rmse) = linear_plane_init(input, &camera, &poses)?;
+            (p, Some(rmse))
+        }
+    };
 
-    let initial_params =
-        LaserlineParams::new(camera_init.k, camera_init.dist, sensor, poses, plane)?;
+    let initial_params = LaserlineParams::new(intrinsics, distortion, sensor, poses, plane)?;
 
     session.state.initial_params = Some(initial_params);
-    session.state.initial_plane_rmse = Some(plane_rmse);
+    session.state.initial_plane_rmse = plane_rmse;
     session.state.clear_optimization();
 
+    let source = format_init_source(&manual_fields, &auto_fields);
+    let plane_note = match plane_rmse {
+        Some(rmse) => format!("plane_rmse={:.4}", rmse),
+        None => "plane=manual".to_string(),
+    };
     session.log_success_with_notes(
         "init",
         format!(
-            "fx={:.1}, fy={:.1}, plane_rmse={:.4}",
-            camera_init.k.fx, camera_init.k.fy, plane_rmse
+            "fx={:.1}, fy={:.1}, {} {}",
+            intrinsics.fx, intrinsics.fy, plane_note, source
         ),
     );
 
     Ok(())
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
+}
+
+/// Initialize intrinsics, poses, and laser plane from observations using full
+/// auto-init.
+///
+/// Convenience wrapper around [`step_set_init`] with
+/// `LaserlineDeviceManualInit::default()`.
+pub fn step_init(
+    session: &mut CalibrationSession<LaserlineDeviceProblem>,
+    opts: Option<DeviceInitOptions>,
+) -> Result<(), Error> {
+    step_set_init(session, LaserlineDeviceManualInit::default(), opts)
 }
 
 /// Optimize laserline calibration using non-linear bundle adjustment.

--- a/crates/vision-calibration-pipeline/src/laserline_device/steps.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/steps.rs
@@ -272,11 +272,7 @@ pub fn step_set_init(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),

--- a/crates/vision-calibration-pipeline/src/planar_family.rs
+++ b/crates/vision-calibration-pipeline/src/planar_family.rs
@@ -37,7 +37,7 @@ pub(crate) fn bootstrap_planar_intrinsics(
     })
 }
 
-fn estimate_view_homographies(dataset: &PlanarDataset) -> Result<Vec<Mat3>> {
+pub(crate) fn estimate_view_homographies(dataset: &PlanarDataset) -> Result<Vec<Mat3>> {
     let mut homographies = Vec::with_capacity(dataset.num_views());
     for (idx, view) in dataset.views.iter().enumerate() {
         let (board_2d, pixel_2d) = board_and_pixel_points(&view.obs);
@@ -52,7 +52,7 @@ fn estimate_view_homographies(dataset: &PlanarDataset) -> Result<Vec<Mat3>> {
     Ok(homographies)
 }
 
-fn recover_planar_poses_from_homographies(
+pub(crate) fn recover_planar_poses_from_homographies(
     homographies: &[Mat3],
     intrinsics: &FxFyCxCySkew<Real>,
 ) -> Result<Vec<Iso3>> {

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/mod.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/mod.rs
@@ -41,8 +41,9 @@ mod steps;
 pub use problem::{PlanarIntrinsicsConfig, PlanarIntrinsicsExport, PlanarIntrinsicsProblem};
 pub use state::PlanarState;
 pub use steps::{
-    FilterOptions, IntrinsicsInitOptions, IntrinsicsOptimizeOptions, run_calibration,
-    run_calibration_with_filtering, step_filter, step_init, step_optimize,
+    FilterOptions, IntrinsicsInitOptions, IntrinsicsOptimizeOptions, PlanarManualInit,
+    run_calibration, run_calibration_with_filtering, step_filter, step_init, step_optimize,
+    step_set_init,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/steps.rs
@@ -36,14 +36,11 @@
 
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{
-    BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, Real, View,
-};
+use vision_calibration_core::{BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, Real, View};
 use vision_calibration_optim::optimize_planar_intrinsics;
 
 use crate::planar_family::{
-    bootstrap_planar_intrinsics, estimate_view_homographies,
-    recover_planar_poses_from_homographies,
+    bootstrap_planar_intrinsics, estimate_view_homographies, recover_planar_poses_from_homographies,
 };
 use crate::session::CalibrationSession;
 
@@ -287,11 +284,7 @@ pub fn step_set_init(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/steps.rs
@@ -35,10 +35,16 @@
 //! ```
 
 use crate::Error;
-use vision_calibration_core::{CorrespondenceView, View};
+use serde::{Deserialize, Serialize};
+use vision_calibration_core::{
+    BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, Real, View,
+};
 use vision_calibration_optim::optimize_planar_intrinsics;
 
-use crate::planar_family::bootstrap_planar_intrinsics;
+use crate::planar_family::{
+    bootstrap_planar_intrinsics, estimate_view_homographies,
+    recover_planar_poses_from_homographies,
+};
 use crate::session::CalibrationSession;
 
 use super::problem::PlanarIntrinsicsProblem;
@@ -65,6 +71,35 @@ pub struct IntrinsicsOptimizeOptions {
     pub max_iters: Option<usize>,
     /// Override verbosity level.
     pub verbosity: Option<usize>,
+}
+
+/// Manual initialization seeds for planar intrinsics calibration.
+///
+/// All fields are `Option<T>`:
+/// - `None` means *auto-initialize this group* (same path as plain `step_init`).
+/// - `Some(value)` means *use this value*; do not auto-initialize.
+///
+/// Partial-seed semantics:
+/// - When `intrinsics` is `Some` but `poses` is `None`, poses are recovered from
+///   homographies using the **manual** intrinsics (not auto-estimated ones). This keeps
+///   the geometric chain consistent with the seed.
+/// - When `intrinsics` is `Some` and `distortion` is `None`, distortion defaults to
+///   `BrownConrady5::default()` (zeros) — the auto distortion fit is coupled with the
+///   iterative intrinsics estimator and does not run when intrinsics are seeded.
+/// - When `intrinsics` is `None`, the bootstrap auto-fit runs and any `Some` field
+///   overrides the corresponding bootstrap output.
+///
+/// See ADR 0011 for the design rationale.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PlanarManualInit {
+    /// Manual intrinsics seed. `None` means auto-init via Zhang's method.
+    pub intrinsics: Option<FxFyCxCySkew<Real>>,
+    /// Manual distortion seed. `None` means auto-init (or zeros when intrinsics are
+    /// also seeded — see struct docs).
+    pub distortion: Option<BrownConrady5<Real>>,
+    /// Manual per-view poses (camera-from-target). `None` means recover from
+    /// homographies using whichever intrinsics are in effect.
+    pub poses: Option<Vec<Iso3>>,
 }
 
 /// Options for filtering observations based on reprojection error.
@@ -95,12 +130,179 @@ impl Default for FilterOptions {
 // Step Functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Initialize intrinsics and poses from observations.
+/// Initialize intrinsics, distortion, and per-view poses from any combination of
+/// manual seeds and auto-estimation.
 ///
-/// This step computes:
-/// 1. Homographies from each view's 2D-3D correspondences
-/// 2. Initial intrinsics using Zhang's method with iterative distortion estimation
-/// 3. Initial poses from homographies and estimated intrinsics
+/// This is the load-bearing init function. [`step_init`] is a thin delegate that
+/// passes `PlanarManualInit::default()` (all-`None`, full auto path).
+///
+/// # Field-by-field behavior
+///
+/// - `intrinsics`: `Some` skips Zhang's auto-fit and uses the seed; `None` runs the
+///   iterative auto-fit (`bootstrap_planar_intrinsics`).
+/// - `distortion`: `Some` overrides the bootstrap's fitted distortion; `None` keeps
+///   the bootstrap value (or `BrownConrady5::default()` when intrinsics are seeded
+///   and the bootstrap doesn't run).
+/// - `poses`: `Some` uses the seed verbatim (count must match view count); `None`
+///   recovers poses from homographies using the in-effect intrinsics — manual when
+///   seeded, auto otherwise.
+///
+/// Updates `session.state.{homographies, initial_intrinsics, initial_distortion,
+/// initial_poses}` and clears any previous optimization results. Same postcondition
+/// as `step_init`.
+///
+/// # Errors
+///
+/// - Input not set, or fewer than 3 views.
+/// - Homography or auto-init computation fails.
+/// - `manual.poses` is `Some` but its length does not match the view count.
+pub fn step_set_init(
+    session: &mut CalibrationSession<PlanarIntrinsicsProblem>,
+    manual: PlanarManualInit,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    session.validate()?;
+    let input = session.require_input()?;
+
+    let opts = opts.unwrap_or_default();
+    let mut init_opts = session.config.init_opts();
+    if let Some(iters) = opts.iterations {
+        init_opts.iterations = iters;
+    }
+
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+
+    let (intrinsics, distortion, homographies, poses) = if let Some(k) = manual.intrinsics {
+        manual_fields.push("intrinsics");
+
+        let dist = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                BrownConrady5::default()
+            }
+        };
+
+        let homographies = match estimate_view_homographies(input) {
+            Ok(hs) => hs,
+            Err(e) => {
+                session.log_failure("init", e.to_string());
+                return Err(Error::from(e));
+            }
+        };
+
+        let poses = match manual.poses {
+            Some(p) => {
+                manual_fields.push("poses");
+                if p.len() != input.num_views() {
+                    let msg = format!(
+                        "manual poses count ({}) does not match view count ({})",
+                        p.len(),
+                        input.num_views()
+                    );
+                    session.log_failure("init", msg.clone());
+                    return Err(Error::invalid_input(msg));
+                }
+                p
+            }
+            None => {
+                auto_fields.push("poses");
+                match recover_planar_poses_from_homographies(&homographies, &k) {
+                    Ok(ps) => ps,
+                    Err(e) => {
+                        session.log_failure("init", e.to_string());
+                        return Err(Error::from(e));
+                    }
+                }
+            }
+        };
+
+        (k, dist, homographies, poses)
+    } else {
+        auto_fields.push("intrinsics");
+
+        let bootstrap = match bootstrap_planar_intrinsics(input, init_opts) {
+            Ok(b) => b,
+            Err(e) => {
+                session.log_failure("init", e.to_string());
+                return Err(Error::from(e));
+            }
+        };
+
+        let dist = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                bootstrap.camera.dist
+            }
+        };
+
+        let poses = match manual.poses {
+            Some(p) => {
+                manual_fields.push("poses");
+                if p.len() != input.num_views() {
+                    let msg = format!(
+                        "manual poses count ({}) does not match view count ({})",
+                        p.len(),
+                        input.num_views()
+                    );
+                    session.log_failure("init", msg.clone());
+                    return Err(Error::invalid_input(msg));
+                }
+                p
+            }
+            None => {
+                auto_fields.push("poses");
+                bootstrap.poses
+            }
+        };
+
+        (bootstrap.camera.k, dist, bootstrap.homographies, poses)
+    };
+
+    session.state.homographies = Some(homographies);
+    session.state.initial_intrinsics = Some(intrinsics);
+    session.state.initial_distortion = Some(distortion);
+    session.state.initial_poses = Some(poses);
+    session.state.clear_optimization();
+
+    let source = format_init_source(&manual_fields, &auto_fields);
+    session.log_success_with_notes(
+        "init",
+        format!(
+            "fx={:.1}, fy={:.1}, cx={:.1}, cy={:.1} {}",
+            intrinsics.fx, intrinsics.fy, intrinsics.cx, intrinsics.cy, source
+        ),
+    );
+
+    Ok(())
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
+}
+
+/// Initialize intrinsics and poses from observations using full auto-init.
+///
+/// Convenience wrapper around [`step_set_init`] with `PlanarManualInit::default()`
+/// (all-`None`). Auto-fits intrinsics + distortion via Zhang's method with iterative
+/// distortion, then recovers poses from homographies.
 ///
 /// Updates `session.state` with intermediate results (homographies, initial estimates).
 ///
@@ -111,54 +313,12 @@ impl Default for FilterOptions {
 ///
 /// # Errors
 ///
-/// - Input not set
-/// - Fewer than 3 views
-/// - Homography computation fails
-/// - Intrinsics estimation fails
+/// See [`step_set_init`].
 pub fn step_init(
     session: &mut CalibrationSession<PlanarIntrinsicsProblem>,
     opts: Option<IntrinsicsInitOptions>,
 ) -> Result<(), Error> {
-    // Validate preconditions
-    session.validate()?;
-    let input = session.require_input()?;
-
-    // Get effective options
-    let opts = opts.unwrap_or_default();
-    let mut init_opts = session.config.init_opts();
-    if let Some(iters) = opts.iterations {
-        init_opts.iterations = iters;
-    }
-
-    let bootstrap = match bootstrap_planar_intrinsics(input, init_opts) {
-        Ok(c) => c,
-        Err(e) => {
-            session.log_failure("init", e.to_string());
-            return Err(Error::from(e));
-        }
-    };
-
-    let camera = bootstrap.camera;
-
-    // Update state
-    session.state.homographies = Some(bootstrap.homographies);
-    session.state.initial_intrinsics = Some(camera.k);
-    session.state.initial_distortion = Some(camera.dist);
-    session.state.initial_poses = Some(bootstrap.poses);
-
-    // Clear any previous optimization results (since we have new init)
-    session.state.clear_optimization();
-
-    // Log success
-    session.log_success_with_notes(
-        "init",
-        format!(
-            "fx={:.1}, fy={:.1}, cx={:.1}, cy={:.1}",
-            camera.k.fx, camera.k.fy, camera.k.cx, camera.k.cy
-        ),
-    );
-
-    Ok(())
+    step_set_init(session, PlanarManualInit::default(), opts)
 }
 
 /// Optimize camera parameters using non-linear least squares.
@@ -573,5 +733,137 @@ mod tests {
         assert!(session.log.iter().any(|e| e.operation == "init"));
         assert!(session.log.iter().any(|e| e.operation == "optimize"));
         assert!(session.log.iter().all(|e| e.success));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Manual init (ADR 0011) tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn step_set_init_default_matches_step_init() {
+        let mut session_a = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session_a.set_input(make_test_dataset()).unwrap();
+        step_init(&mut session_a, None).unwrap();
+
+        let mut session_b = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session_b.set_input(make_test_dataset()).unwrap();
+        step_set_init(&mut session_b, PlanarManualInit::default(), None).unwrap();
+
+        // Both paths should produce identical state — step_init delegates to
+        // step_set_init with default fields.
+        let k_a = session_a.state.initial_intrinsics.unwrap();
+        let k_b = session_b.state.initial_intrinsics.unwrap();
+        assert!((k_a.fx - k_b.fx).abs() < 1e-9);
+        assert!((k_a.fy - k_b.fy).abs() < 1e-9);
+        assert!((k_a.cx - k_b.cx).abs() < 1e-9);
+        assert!((k_a.cy - k_b.cy).abs() < 1e-9);
+    }
+
+    #[test]
+    fn step_set_init_with_intrinsics_seed_converges() {
+        let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session.set_input(make_test_dataset()).unwrap();
+
+        let manual = PlanarManualInit {
+            intrinsics: Some(FxFyCxCySkew {
+                fx: 800.0,
+                fy: 780.0,
+                cx: 640.0,
+                cy: 360.0,
+                skew: 0.0,
+            }),
+            ..Default::default()
+        };
+        step_set_init(&mut session, manual, None).unwrap();
+        step_optimize(&mut session, None).unwrap();
+
+        let output = session.output().unwrap();
+        // Synthetic data with GT-matching intrinsics seed should converge tightly.
+        assert!(
+            output.mean_reproj_error < 1.0,
+            "got {:.4}",
+            output.mean_reproj_error
+        );
+    }
+
+    #[test]
+    fn step_set_init_with_full_seeds_converges_tightly() {
+        // Run auto-init first to harvest a plausible pose set.
+        let mut session_auto = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session_auto.set_input(make_test_dataset()).unwrap();
+        step_init(&mut session_auto, None).unwrap();
+        let auto_poses = session_auto.state.initial_poses.clone().unwrap();
+
+        let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session.set_input(make_test_dataset()).unwrap();
+
+        let manual = PlanarManualInit {
+            intrinsics: Some(FxFyCxCySkew {
+                fx: 800.0,
+                fy: 780.0,
+                cx: 640.0,
+                cy: 360.0,
+                skew: 0.0,
+            }),
+            distortion: Some(BrownConrady5::default()),
+            poses: Some(auto_poses),
+        };
+        step_set_init(&mut session, manual, None).unwrap();
+        step_optimize(&mut session, None).unwrap();
+
+        let output = session.output().unwrap();
+        assert!(
+            output.mean_reproj_error < 1.0,
+            "got {:.4}",
+            output.mean_reproj_error
+        );
+    }
+
+    #[test]
+    fn step_set_init_rejects_wrong_pose_count() {
+        use vision_calibration_core::Iso3;
+
+        let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session.set_input(make_test_dataset()).unwrap();
+
+        // Test dataset has 4 views; supply only 1 pose.
+        let manual = PlanarManualInit {
+            poses: Some(vec![Iso3::identity()]),
+            ..Default::default()
+        };
+        let err = step_set_init(&mut session, manual, None).unwrap_err();
+        assert!(
+            err.to_string().contains("manual poses count"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn step_set_init_logs_manual_and_auto_sources() {
+        let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+        session.set_input(make_test_dataset()).unwrap();
+
+        let manual = PlanarManualInit {
+            intrinsics: Some(FxFyCxCySkew {
+                fx: 800.0,
+                fy: 780.0,
+                cx: 640.0,
+                cy: 360.0,
+                skew: 0.0,
+            }),
+            ..Default::default()
+        };
+        step_set_init(&mut session, manual, None).unwrap();
+
+        let init_entry = session
+            .log
+            .iter()
+            .find(|e| e.operation == "init")
+            .expect("init log entry");
+        let notes = init_entry.notes.as_deref().unwrap_or("");
+        assert!(notes.contains("manual: intrinsics"), "notes: {}", notes);
+        assert!(notes.contains("auto: distortion"), "notes: {}", notes);
+        assert!(notes.contains("poses"), "notes: {}", notes);
     }
 }

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/mod.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/mod.rs
@@ -65,6 +65,8 @@ pub use problem::{
 };
 pub use state::RigExtrinsicsState;
 pub use steps::{
-    IntrinsicsInitOptions, IntrinsicsOptimizeOptions, RigOptimizeOptions, run_calibration,
-    step_intrinsics_init_all, step_intrinsics_optimize_all, step_rig_init, step_rig_optimize,
+    IntrinsicsInitOptions, IntrinsicsOptimizeOptions, RigExtrinsicsManualInit,
+    RigIntrinsicsManualInit, RigOptimizeOptions, run_calibration, step_intrinsics_init_all,
+    step_intrinsics_optimize_all, step_rig_init, step_rig_optimize, step_set_intrinsics_init_all,
+    step_set_rig_init,
 };

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
@@ -240,13 +240,12 @@ pub fn step_set_intrinsics_init_all(
                 .unwrap_or_default();
             make_pinhole_camera(k, dist)
         } else {
-            let bootstrap = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(
-                |e| {
+            let bootstrap =
+                estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(|e| {
                     Error::numerical(format!(
                         "intrinsics estimation failed for camera {cam_idx}: {e}"
                     ))
-                },
-            )?;
+                })?;
             let dist = manual
                 .per_cam_distortion
                 .as_ref()
@@ -304,11 +303,7 @@ pub fn step_intrinsics_init_all(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),
@@ -460,8 +455,7 @@ pub fn step_set_rig_init(
     // Coupling rule: both-or-neither.
     match (&manual.cam_se3_rig, &manual.rig_se3_target) {
         (Some(_), None) | (None, Some(_)) => {
-            let msg =
-                "RigExtrinsicsManualInit: cam_se3_rig and rig_se3_target must both be Some or \
+            let msg = "RigExtrinsicsManualInit: cam_se3_rig and rig_se3_target must both be Some or \
                  both be None (geometrically coupled per ADR 0011)";
             session.log_failure("rig_init", msg);
             return Err(Error::invalid_input(msg));
@@ -509,9 +503,7 @@ pub fn step_set_rig_init(
                 &per_cam_target_poses,
                 reference_camera_idx,
             )
-            .map_err(|e| {
-                Error::numerical(format!("rig extrinsics initialization failed: {e}"))
-            })?;
+            .map_err(|e| Error::numerical(format!("rig extrinsics initialization failed: {e}")))?;
             let cam_se3_rig: Vec<Iso3> = extrinsic_result
                 .cam_to_rig
                 .iter()

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
@@ -4,9 +4,10 @@
 //! `CalibrationSession<RigExtrinsicsProblem>` to perform calibration.
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraFixMask, Iso3, NoMeta, PlanarDataset, View, compute_rig_reprojection_stats_per_camera,
-    make_pinhole_camera,
+    BrownConrady5, CameraFixMask, FxFyCxCySkew, Iso3, NoMeta, PlanarDataset, Real, View,
+    compute_rig_reprojection_stats_per_camera, make_pinhole_camera,
 };
 use vision_calibration_linear::estimate_extrinsics_from_cam_target_poses;
 use vision_calibration_linear::prelude::*;
@@ -37,6 +38,41 @@ pub struct IntrinsicsOptimizeOptions {
     pub max_iters: Option<usize>,
     /// Override verbosity level.
     pub verbosity: Option<usize>,
+}
+
+/// Manual seeds for the **per-camera intrinsics stage** of rig extrinsics
+/// calibration.
+///
+/// All fields are `Option<T>`. When `per_cam_intrinsics` is `Some`, the bootstrap
+/// Zhang's auto-fit is skipped for *every* camera; per-camera target poses are
+/// then recovered from per-camera homographies using the seeded intrinsics. When
+/// `None`, the existing per-camera auto-init runs.
+///
+/// `per_cam_distortion` follows the same convention as `PlanarManualInit`: when
+/// intrinsics are seeded but distortion is not, distortion defaults to zeros. When
+/// intrinsics are auto-init'd, the bootstrap fitted distortion is used unless
+/// distortion is seeded explicitly.
+///
+/// Per-camera vectors must have length equal to `input.num_cameras`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigIntrinsicsManualInit {
+    /// Per-camera intrinsics seeds. `None` runs Zhang's per camera.
+    pub per_cam_intrinsics: Option<Vec<FxFyCxCySkew<Real>>>,
+    /// Per-camera distortion seeds.
+    pub per_cam_distortion: Option<Vec<BrownConrady5<Real>>>,
+}
+
+/// Manual seeds for the **rig extrinsics stage**.
+///
+/// `cam_se3_rig` and `rig_se3_target` are geometrically coupled — providing one
+/// without the other is ambiguous. Per ADR 0011, both must be `Some` or both must
+/// be `None`. A mismatched configuration returns `Error::InvalidInput`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigExtrinsicsManualInit {
+    /// Per-camera `T_C_R` (camera-from-rig). `None` runs the linear extrinsics fit.
+    pub cam_se3_rig: Option<Vec<Iso3>>,
+    /// Per-view `T_R_T` (rig-from-target). Must be paired with `cam_se3_rig`.
+    pub rig_se3_target: Option<Vec<Iso3>>,
 }
 
 /// Options for rig BA optimization.
@@ -114,16 +150,24 @@ fn estimate_target_pose(
 // Step Functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Initialize intrinsics for all cameras.
+/// Initialize intrinsics for all cameras from any combination of manual seeds
+/// and auto-estimation (Zhang's method per camera).
 ///
-/// Runs Zhang's method with iterative distortion estimation on each camera independently.
+/// This is the load-bearing intrinsics-stage init. [`step_intrinsics_init_all`]
+/// is a thin delegate with `RigIntrinsicsManualInit::default()`.
+///
+/// See [`RigIntrinsicsManualInit`] for partial-seed semantics. Per-camera target
+/// poses are *always* recovered from per-camera homographies — using the seeded
+/// intrinsics if provided, otherwise the auto-fit intrinsics.
 ///
 /// # Errors
 ///
-/// - Input not set
-/// - Any camera has fewer than 3 views with observations
-pub fn step_intrinsics_init_all(
+/// - Input not set, or any camera has fewer than 3 views with observations.
+/// - `manual.per_cam_intrinsics` (or `per_cam_distortion`) length mismatches
+///   `input.num_cameras`.
+pub fn step_set_intrinsics_init_all(
     session: &mut CalibrationSession<RigExtrinsicsProblem>,
+    manual: RigIntrinsicsManualInit,
     opts: Option<IntrinsicsInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
@@ -131,6 +175,28 @@ pub fn step_intrinsics_init_all(
 
     let opts = opts.unwrap_or_default();
     let config = &session.config;
+
+    let num_cameras = input.num_cameras;
+    let num_views = input.num_views();
+
+    if let Some(seeds) = &manual.per_cam_intrinsics
+        && seeds.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "manual.per_cam_intrinsics length ({}) does not match num_cameras ({})",
+            seeds.len(),
+            num_cameras
+        )));
+    }
+    if let Some(seeds) = &manual.per_cam_distortion
+        && seeds.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "manual.per_cam_distortion length ({}) does not match num_cameras ({})",
+            seeds.len(),
+            num_cameras
+        )));
+    }
 
     let init_opts = IterativeIntrinsicsOptions {
         iterations: opts.iterations.unwrap_or(config.intrinsics_init_iterations),
@@ -142,29 +208,53 @@ pub fn step_intrinsics_init_all(
         zero_skew: config.zero_skew,
     };
 
-    // Copy values we need to avoid borrow conflicts
-    let num_cameras = input.num_cameras;
-    let num_views = input.num_views();
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+    if manual.per_cam_intrinsics.is_some() {
+        manual_fields.push("per_cam_intrinsics");
+    } else {
+        auto_fields.push("per_cam_intrinsics");
+    }
+    if manual.per_cam_distortion.is_some() {
+        manual_fields.push("per_cam_distortion");
+    } else {
+        auto_fields.push("per_cam_distortion");
+    }
 
     let mut per_cam_intrinsics = Vec::with_capacity(num_cameras);
     let mut per_cam_target_poses: Vec<Vec<Option<Iso3>>> = vec![vec![None; num_cameras]; num_views];
 
     #[allow(clippy::needless_range_loop)]
-    // cam_idx used for both extract_camera_views and 2D array indexing
     for cam_idx in 0..num_cameras {
         let cam_views = extract_camera_views(input, cam_idx);
         let (planar_dataset, valid_indices) = views_to_planar_dataset(&cam_views).map_err(|e| {
             Error::numerical(format!("camera {cam_idx} has insufficient views: {e}"))
         })?;
 
-        // Estimate intrinsics
-        let camera = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(|e| {
-            Error::numerical(format!(
-                "intrinsics estimation failed for camera {cam_idx}: {e}"
-            ))
-        })?;
+        let camera = if let Some(seeds) = manual.per_cam_intrinsics.as_ref() {
+            let k = seeds[cam_idx];
+            let dist = manual
+                .per_cam_distortion
+                .as_ref()
+                .map(|d| d[cam_idx])
+                .unwrap_or_default();
+            make_pinhole_camera(k, dist)
+        } else {
+            let bootstrap = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(
+                |e| {
+                    Error::numerical(format!(
+                        "intrinsics estimation failed for camera {cam_idx}: {e}"
+                    ))
+                },
+            )?;
+            let dist = manual
+                .per_cam_distortion
+                .as_ref()
+                .map(|d| d[cam_idx])
+                .unwrap_or(bootstrap.dist);
+            make_pinhole_camera(bootstrap.k, dist)
+        };
 
-        // Compute K matrix for pose estimation
         let k_matrix = vision_calibration_core::Mat3::new(
             camera.k.fx,
             camera.k.skew,
@@ -177,7 +267,6 @@ pub fn step_intrinsics_init_all(
             1.0,
         );
 
-        // Estimate target poses for valid views
         for (local_idx, &global_idx) in valid_indices.iter().enumerate() {
             let view = &planar_dataset.views[local_idx];
             let pose = estimate_target_pose(&k_matrix, &view.obs).map_err(|e| {
@@ -188,19 +277,42 @@ pub fn step_intrinsics_init_all(
             per_cam_target_poses[global_idx][cam_idx] = Some(pose);
         }
 
-        per_cam_intrinsics.push(make_pinhole_camera(camera.k, camera.dist));
+        per_cam_intrinsics.push(camera);
     }
 
-    // Update state
     session.state.per_cam_intrinsics = Some(per_cam_intrinsics);
     session.state.per_cam_target_poses = Some(per_cam_target_poses);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "intrinsics_init_all",
-        format!("initialized {} cameras", num_cameras),
+        format!("initialized {} cameras {}", num_cameras, source),
     );
 
     Ok(())
+}
+
+/// Initialize intrinsics for all cameras using full auto-init (Zhang's per camera).
+///
+/// Convenience wrapper around [`step_set_intrinsics_init_all`] with default seeds.
+pub fn step_intrinsics_init_all(
+    session: &mut CalibrationSession<RigExtrinsicsProblem>,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    step_set_intrinsics_init_all(session, RigIntrinsicsManualInit::default(), opts)
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
 }
 
 /// Optimize intrinsics for all cameras.
@@ -310,58 +422,125 @@ pub fn step_intrinsics_optimize_all(
     Ok(())
 }
 
-/// Initialize rig extrinsics from per-camera target poses.
+/// Initialize rig extrinsics from any combination of manual seeds and auto-
+/// estimation (linear extrinsics fit).
 ///
-/// Uses linear initialization to estimate rig-to-camera transforms.
+/// This is the load-bearing rig-stage init. [`step_rig_init`] is a thin delegate
+/// with `RigExtrinsicsManualInit::default()`.
 ///
-/// Requires [`step_intrinsics_optimize_all`] to be run first.
+/// **Coupling rule** (ADR 0011): `cam_se3_rig` and `rig_se3_target` are
+/// geometrically coupled. Both must be `Some` or both `None`. Mismatched
+/// configurations return `Error::InvalidInput`.
 ///
 /// # Errors
 ///
-/// - Input not set
-/// - Per-camera intrinsics not computed
-/// - Insufficient overlapping views between cameras
-pub fn step_rig_init(session: &mut CalibrationSession<RigExtrinsicsProblem>) -> Result<(), Error> {
+/// - Input not set, or per-camera intrinsics not computed.
+/// - Coupling rule violated (one of `cam_se3_rig` / `rig_se3_target` seeded
+///   without the other).
+/// - Vector length mismatches: `cam_se3_rig.len() != input.num_cameras`, or
+///   `rig_se3_target.len() != input.num_views()`.
+/// - Auto-init linear estimation fails.
+pub fn step_set_rig_init(
+    session: &mut CalibrationSession<RigExtrinsicsProblem>,
+    manual: RigExtrinsicsManualInit,
+) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
 
     if !session.state.has_per_cam_intrinsics() {
         return Err(Error::not_available(
-            "per-camera intrinsics (call step_intrinsics_optimize_all first)",
+            "per-camera intrinsics (call step_intrinsics_init_all first)",
         ));
     }
 
-    // Copy values we need
     let num_views = input.num_views();
+    let num_cameras = input.num_cameras;
     let reference_camera_idx = session.config.reference_camera_idx;
 
-    // TODO: use ref instead of clone?
-    let per_cam_target_poses = session
-        .state
-        .per_cam_target_poses
-        .clone()
-        .ok_or_else(|| Error::not_available("per-camera target poses"))?;
+    // Coupling rule: both-or-neither.
+    match (&manual.cam_se3_rig, &manual.rig_se3_target) {
+        (Some(_), None) | (None, Some(_)) => {
+            let msg =
+                "RigExtrinsicsManualInit: cam_se3_rig and rig_se3_target must both be Some or \
+                 both be None (geometrically coupled per ADR 0011)";
+            session.log_failure("rig_init", msg);
+            return Err(Error::invalid_input(msg));
+        }
+        _ => {}
+    }
 
-    // Use vision_calibration_linear's rig extrinsics initialization
-    let extrinsic_result =
-        estimate_extrinsics_from_cam_target_poses(&per_cam_target_poses, reference_camera_idx)
-            .map_err(|e| Error::numerical(format!("rig extrinsics initialization failed: {e}")))?;
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
 
-    // Update state
-    let cam_se3_rig: Vec<Iso3> = extrinsic_result
-        .cam_to_rig
-        .iter()
-        .map(|t| t.inverse())
-        .collect();
+    let (cam_se3_rig, rig_se3_target) = match (manual.cam_se3_rig, manual.rig_se3_target) {
+        (Some(cam_se3_rig), Some(rig_se3_target)) => {
+            if cam_se3_rig.len() != num_cameras {
+                let msg = format!(
+                    "manual cam_se3_rig length ({}) does not match num_cameras ({})",
+                    cam_se3_rig.len(),
+                    num_cameras
+                );
+                session.log_failure("rig_init", msg.clone());
+                return Err(Error::invalid_input(msg));
+            }
+            if rig_se3_target.len() != num_views {
+                let msg = format!(
+                    "manual rig_se3_target length ({}) does not match num_views ({})",
+                    rig_se3_target.len(),
+                    num_views
+                );
+                session.log_failure("rig_init", msg.clone());
+                return Err(Error::invalid_input(msg));
+            }
+            manual_fields.push("cam_se3_rig");
+            manual_fields.push("rig_se3_target");
+            (cam_se3_rig, rig_se3_target)
+        }
+        _ => {
+            auto_fields.push("cam_se3_rig");
+            auto_fields.push("rig_se3_target");
+            let per_cam_target_poses = session
+                .state
+                .per_cam_target_poses
+                .clone()
+                .ok_or_else(|| Error::not_available("per-camera target poses"))?;
+
+            let extrinsic_result = estimate_extrinsics_from_cam_target_poses(
+                &per_cam_target_poses,
+                reference_camera_idx,
+            )
+            .map_err(|e| {
+                Error::numerical(format!("rig extrinsics initialization failed: {e}"))
+            })?;
+            let cam_se3_rig: Vec<Iso3> = extrinsic_result
+                .cam_to_rig
+                .iter()
+                .map(|t| t.inverse())
+                .collect();
+            (cam_se3_rig, extrinsic_result.rig_from_target)
+        }
+    };
+
     session.state.initial_cam_se3_rig = Some(cam_se3_rig);
-    session.state.initial_rig_se3_target = Some(extrinsic_result.rig_from_target);
+    session.state.initial_rig_se3_target = Some(rig_se3_target);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "rig_init",
-        format!("ref_cam={}, {} views", reference_camera_idx, num_views),
+        format!(
+            "ref_cam={}, {} views {}",
+            reference_camera_idx, num_views, source
+        ),
     );
 
     Ok(())
+}
+
+/// Initialize rig extrinsics using full auto-init (linear extrinsics fit).
+///
+/// Convenience wrapper around [`step_set_rig_init`] with default seeds.
+pub fn step_rig_init(session: &mut CalibrationSession<RigExtrinsicsProblem>) -> Result<(), Error> {
+    step_set_rig_init(session, RigExtrinsicsManualInit::default())
 }
 
 /// Optimize rig extrinsics using bundle adjustment.

--- a/crates/vision-calibration-pipeline/src/rig_handeye/mod.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/mod.rs
@@ -78,6 +78,8 @@ pub use problem::{
 pub use state::RigHandeyeState;
 pub use steps::{
     HandeyeInitOptions, HandeyeOptimizeOptions, IntrinsicsInitOptions, IntrinsicsOptimizeOptions,
+    RigHandeyeHandeyeManualInit, RigHandeyeIntrinsicsManualInit, RigHandeyeRigManualInit,
     RigOptimizeOptions, run_calibration, step_handeye_init, step_handeye_optimize,
     step_intrinsics_init_all, step_intrinsics_optimize_all, step_rig_init, step_rig_optimize,
+    step_set_handeye_init, step_set_intrinsics_init_all, step_set_rig_init,
 };

--- a/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
@@ -769,9 +769,9 @@ pub fn step_set_handeye_init(
             match handeye_mode {
                 HandEyeMode::EyeInHand => robot_poses[0] * handeye * rig_se3_target[0],
                 HandEyeMode::EyeToHand => {
-                    // gripper_se3_target derived from T_R_T = T_R_B * T_B_G * T_G_T.
-                    // T_G_T = (T_B_G)^-1 * (T_R_B)^-1 * T_R_T = (T_B_G)^-1 * handeye * T_R_T.
-                    robot_poses[0].inverse() * handeye * rig_se3_target[0]
+                    // handeye = T_R_B. Chain: T_R_T = T_R_B * T_B_G * T_G_T.
+                    // T_G_T = (T_B_G)^-1 * (T_R_B)^-1 * T_R_T = robot_poses[0]^-1 * handeye^-1 * T_R_T.
+                    robot_poses[0].inverse() * handeye.inverse() * rig_se3_target[0]
                 }
             }
         }
@@ -1132,6 +1132,62 @@ mod tests {
             .unwrap();
 
         assert!(session.has_output());
+    }
+
+    #[test]
+    fn step_set_handeye_init_eye_to_hand_recovers_target_on_gripper() {
+        // Regression test for Codex P1 on PR #32: in EyeToHand mode the
+        // auto-derive of `mode_target_pose` from a manual `handeye` seed must
+        // use `handeye.inverse()`, since `handeye = T_R_B` and the chain is
+        // T_R_T = T_R_B * T_B_G * T_G_T, so T_G_T = T_B_G^-1 * T_R_B^-1 * T_R_T.
+        let input = make_test_input();
+        let robot_poses: Vec<Iso3> = input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper)
+            .collect();
+
+        // Ground-truth EyeToHand: rig fixed in robot base, target on gripper.
+        let t_r_b = make_iso((0.4, -0.2, 0.1), (0.5, -0.3, 0.2));
+        let t_g_t = make_iso((0.15, 0.0, -0.1), (0.05, 0.04, 0.03));
+        let rig_se3_target: Vec<Iso3> = robot_poses.iter().map(|tbg| t_r_b * tbg * t_g_t).collect();
+
+        let mut session = CalibrationSession::<RigHandeyeProblem>::new();
+        session.set_input(input).unwrap();
+        session
+            .set_config(super::super::problem::RigHandeyeConfig {
+                handeye_init: super::super::problem::RigHandeyeInitConfig {
+                    handeye_mode: HandEyeMode::EyeToHand,
+                    min_motion_angle_deg: 5.0,
+                },
+                ..Default::default()
+            })
+            .unwrap();
+
+        // Simulate post-rig-BA state.
+        session.state.rig_ba_cam_se3_rig = Some(vec![
+            Iso3::identity();
+            session.require_input().unwrap().num_cameras
+        ]);
+        session.state.rig_ba_rig_se3_target = Some(rig_se3_target);
+
+        // Pin handeye to ground truth so the test isolates the
+        // mode_target_pose auto-derive arithmetic from DLT precision.
+        let manual = RigHandeyeHandeyeManualInit {
+            handeye: Some(t_r_b),
+            mode_target_pose: None,
+        };
+        step_set_handeye_init(&mut session, manual, None).unwrap();
+
+        let recovered = session.state.initial_mode_target_pose.unwrap();
+        let dt = (recovered.translation.vector - t_g_t.translation.vector).norm();
+        let dq = recovered
+            .rotation
+            .rotation_to(&t_g_t.rotation)
+            .angle()
+            .abs();
+        assert!(dt < 1e-9, "T_G_T translation mismatch: |Δt|={dt}");
+        assert!(dq < 1e-9, "T_G_T rotation mismatch: angle={dq}");
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
@@ -253,13 +253,12 @@ pub fn step_set_intrinsics_init_all(
                 .unwrap_or_default();
             make_pinhole_camera(k, dist)
         } else {
-            let bootstrap = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(
-                |e| {
+            let bootstrap =
+                estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(|e| {
                     Error::numerical(format!(
                         "intrinsics estimation failed for camera {cam_idx}: {e}"
                     ))
-                },
-            )?;
+                })?;
             let dist = manual
                 .per_cam_distortion
                 .as_ref()
@@ -314,11 +313,7 @@ pub fn step_intrinsics_init_all(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),
@@ -505,9 +500,7 @@ pub fn step_set_rig_init(
                 &per_cam_target_poses,
                 reference_camera_idx,
             )
-            .map_err(|e| {
-                Error::numerical(format!("rig extrinsics initialization failed: {e}"))
-            })?;
+            .map_err(|e| Error::numerical(format!("rig extrinsics initialization failed: {e}")))?;
             let cam_se3_rig: Vec<Iso3> = extrinsic_result
                 .cam_to_rig
                 .iter()

--- a/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
@@ -4,15 +4,16 @@
 //! `CalibrationSession<RigHandeyeProblem>` to perform calibration.
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraFixMask, Iso3, NoMeta, PlanarDataset, View, compute_rig_reprojection_stats_per_camera,
-    make_pinhole_camera,
+    BrownConrady5, CameraFixMask, FxFyCxCySkew, Iso3, NoMeta, PlanarDataset, Real, View,
+    compute_rig_reprojection_stats_per_camera, make_pinhole_camera,
 };
 use vision_calibration_linear::estimate_extrinsics_from_cam_target_poses;
 use vision_calibration_linear::prelude::*;
 use vision_calibration_linear::{estimate_gripper_se3_target_dlt, estimate_handeye_dlt};
 use vision_calibration_optim::{
-    BackendSolveOptions, HandEyeDataset, HandEyeParams, HandEyeSolveOptions,
+    BackendSolveOptions, HandEyeDataset, HandEyeMode, HandEyeParams, HandEyeSolveOptions,
     PlanarIntrinsicsParams, PlanarIntrinsicsSolveOptions, RigExtrinsicsParams,
     RigExtrinsicsSolveOptions, optimize_handeye, optimize_planar_intrinsics,
     optimize_rig_extrinsics,
@@ -56,6 +57,43 @@ pub struct RigOptimizeOptions {
 pub struct HandeyeInitOptions {
     /// Override minimum motion angle (degrees).
     pub min_motion_angle_deg: Option<f64>,
+}
+
+/// Manual seeds for the **per-camera intrinsics stage** of rig hand-eye
+/// calibration. See `rig_extrinsics::RigIntrinsicsManualInit` for semantics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigHandeyeIntrinsicsManualInit {
+    pub per_cam_intrinsics: Option<Vec<FxFyCxCySkew<Real>>>,
+    pub per_cam_distortion: Option<Vec<BrownConrady5<Real>>>,
+}
+
+/// Manual seeds for the **rig extrinsics stage** of rig hand-eye calibration.
+///
+/// `cam_se3_rig` and `rig_se3_target` are coupled per ADR 0011 — both must be
+/// `Some` or both `None`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigHandeyeRigManualInit {
+    pub cam_se3_rig: Option<Vec<Iso3>>,
+    pub rig_se3_target: Option<Vec<Iso3>>,
+}
+
+/// Manual seeds for the **hand-eye stage** of rig hand-eye calibration.
+///
+/// Mode-aware: the meaning of `handeye` and `mode_target_pose` depends on
+/// `session.config.handeye_init.handeye_mode`:
+/// - `EyeInHand`: `handeye = gripper_se3_rig` (T_G_R), `mode_target_pose =
+///   base_se3_target` (T_B_T).
+/// - `EyeToHand`: `handeye = rig_se3_base` (T_R_B), `mode_target_pose =
+///   gripper_se3_target` (T_G_T).
+///
+/// The state stores both as mode-agnostic `initial_handeye` and
+/// `initial_mode_target_pose`, so this struct mirrors that shape directly.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigHandeyeHandeyeManualInit {
+    /// Mode-dependent hand-eye transform.
+    pub handeye: Option<Iso3>,
+    /// Mode-dependent target pose.
+    pub mode_target_pose: Option<Iso3>,
 }
 
 /// Options for hand-eye optimization.
@@ -141,15 +179,37 @@ fn estimate_target_pose(
 ///
 /// - Input not set
 /// - Any camera has fewer than 3 views with observations
-pub fn step_intrinsics_init_all(
+pub fn step_set_intrinsics_init_all(
     session: &mut CalibrationSession<RigHandeyeProblem>,
+    manual: RigHandeyeIntrinsicsManualInit,
     opts: Option<IntrinsicsInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
-
     let opts = opts.unwrap_or_default();
     let config = &session.config;
+
+    let num_cameras = input.num_cameras;
+    let num_views = input.num_views();
+
+    if let Some(s) = &manual.per_cam_intrinsics
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_intrinsics length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
+    if let Some(s) = &manual.per_cam_distortion
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_distortion length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
 
     let init_opts = IterativeIntrinsicsOptions {
         iterations: opts.iterations.unwrap_or(config.intrinsics.init_iterations),
@@ -161,29 +221,53 @@ pub fn step_intrinsics_init_all(
         zero_skew: config.intrinsics.zero_skew,
     };
 
-    // Copy values we need to avoid borrow conflicts
-    let num_cameras = input.num_cameras;
-    let num_views = input.num_views();
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+    if manual.per_cam_intrinsics.is_some() {
+        manual_fields.push("per_cam_intrinsics");
+    } else {
+        auto_fields.push("per_cam_intrinsics");
+    }
+    if manual.per_cam_distortion.is_some() {
+        manual_fields.push("per_cam_distortion");
+    } else {
+        auto_fields.push("per_cam_distortion");
+    }
 
     let mut per_cam_intrinsics = Vec::with_capacity(num_cameras);
     let mut per_cam_target_poses: Vec<Vec<Option<Iso3>>> = vec![vec![None; num_cameras]; num_views];
 
     #[allow(clippy::needless_range_loop)]
-    // cam_idx used for both extract_camera_views and 2D array indexing
     for cam_idx in 0..num_cameras {
         let cam_views = extract_camera_views(input, cam_idx);
         let (planar_dataset, valid_indices) = views_to_planar_dataset(&cam_views).map_err(|e| {
             Error::numerical(format!("camera {cam_idx} has insufficient views: {e}"))
         })?;
 
-        // Estimate intrinsics
-        let camera = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(|e| {
-            Error::numerical(format!(
-                "intrinsics estimation failed for camera {cam_idx}: {e}"
-            ))
-        })?;
+        let camera = if let Some(seeds) = manual.per_cam_intrinsics.as_ref() {
+            let k = seeds[cam_idx];
+            let dist = manual
+                .per_cam_distortion
+                .as_ref()
+                .map(|d| d[cam_idx])
+                .unwrap_or_default();
+            make_pinhole_camera(k, dist)
+        } else {
+            let bootstrap = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(
+                |e| {
+                    Error::numerical(format!(
+                        "intrinsics estimation failed for camera {cam_idx}: {e}"
+                    ))
+                },
+            )?;
+            let dist = manual
+                .per_cam_distortion
+                .as_ref()
+                .map(|d| d[cam_idx])
+                .unwrap_or(bootstrap.dist);
+            make_pinhole_camera(bootstrap.k, dist)
+        };
 
-        // Compute K matrix for pose estimation
         let k_matrix = vision_calibration_core::Mat3::new(
             camera.k.fx,
             camera.k.skew,
@@ -196,7 +280,6 @@ pub fn step_intrinsics_init_all(
             1.0,
         );
 
-        // Estimate target poses for valid views
         for (local_idx, &global_idx) in valid_indices.iter().enumerate() {
             let view = &planar_dataset.views[local_idx];
             let pose = estimate_target_pose(&k_matrix, &view.obs).map_err(|e| {
@@ -207,19 +290,39 @@ pub fn step_intrinsics_init_all(
             per_cam_target_poses[global_idx][cam_idx] = Some(pose);
         }
 
-        per_cam_intrinsics.push(make_pinhole_camera(camera.k, camera.dist));
+        per_cam_intrinsics.push(camera);
     }
 
-    // Update state
     session.state.per_cam_intrinsics = Some(per_cam_intrinsics);
     session.state.per_cam_target_poses = Some(per_cam_target_poses);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "intrinsics_init_all",
-        format!("initialized {} cameras", num_cameras),
+        format!("initialized {} cameras {}", num_cameras, source),
     );
 
     Ok(())
+}
+
+pub fn step_intrinsics_init_all(
+    session: &mut CalibrationSession<RigHandeyeProblem>,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    step_set_intrinsics_init_all(session, RigHandeyeIntrinsicsManualInit::default(), opts)
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
 }
 
 /// Optimize intrinsics for all cameras.
@@ -340,7 +443,10 @@ pub fn step_intrinsics_optimize_all(
 /// - Input not set
 /// - Per-camera intrinsics not computed
 /// - Insufficient overlapping views between cameras
-pub fn step_rig_init(session: &mut CalibrationSession<RigHandeyeProblem>) -> Result<(), Error> {
+pub fn step_set_rig_init(
+    session: &mut CalibrationSession<RigHandeyeProblem>,
+    manual: RigHandeyeRigManualInit,
+) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
 
@@ -350,36 +456,84 @@ pub fn step_rig_init(session: &mut CalibrationSession<RigHandeyeProblem>) -> Res
         ));
     }
 
-    // Copy values we need before modifying state
     let num_views = input.num_views();
+    let num_cameras = input.num_cameras;
     let reference_camera_idx = session.config.rig.reference_camera_idx;
 
-    let per_cam_target_poses = session
-        .state
-        .per_cam_target_poses
-        .clone()
-        .ok_or_else(|| Error::not_available("per-camera target poses"))?;
+    match (&manual.cam_se3_rig, &manual.rig_se3_target) {
+        (Some(_), None) | (None, Some(_)) => {
+            let msg = "RigHandeyeRigManualInit: cam_se3_rig and rig_se3_target must both be Some \
+                       or both None (geometrically coupled per ADR 0011)";
+            session.log_failure("rig_init", msg);
+            return Err(Error::invalid_input(msg));
+        }
+        _ => {}
+    }
 
-    // Use vision_calibration_linear's rig extrinsics initialization
-    let extrinsic_result =
-        estimate_extrinsics_from_cam_target_poses(&per_cam_target_poses, reference_camera_idx)
-            .map_err(|e| Error::numerical(format!("rig extrinsics initialization failed: {e}")))?;
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
 
-    // Update state
-    let cam_se3_rig: Vec<Iso3> = extrinsic_result
-        .cam_to_rig
-        .iter()
-        .map(|t| t.inverse())
-        .collect();
+    let (cam_se3_rig, rig_se3_target) = match (manual.cam_se3_rig, manual.rig_se3_target) {
+        (Some(cam_se3_rig), Some(rig_se3_target)) => {
+            if cam_se3_rig.len() != num_cameras {
+                return Err(Error::invalid_input(format!(
+                    "cam_se3_rig length ({}) != num_cameras ({})",
+                    cam_se3_rig.len(),
+                    num_cameras
+                )));
+            }
+            if rig_se3_target.len() != num_views {
+                return Err(Error::invalid_input(format!(
+                    "rig_se3_target length ({}) != num_views ({})",
+                    rig_se3_target.len(),
+                    num_views
+                )));
+            }
+            manual_fields.push("cam_se3_rig");
+            manual_fields.push("rig_se3_target");
+            (cam_se3_rig, rig_se3_target)
+        }
+        _ => {
+            auto_fields.push("cam_se3_rig");
+            auto_fields.push("rig_se3_target");
+            let per_cam_target_poses = session
+                .state
+                .per_cam_target_poses
+                .clone()
+                .ok_or_else(|| Error::not_available("per-camera target poses"))?;
+            let extrinsic_result = estimate_extrinsics_from_cam_target_poses(
+                &per_cam_target_poses,
+                reference_camera_idx,
+            )
+            .map_err(|e| {
+                Error::numerical(format!("rig extrinsics initialization failed: {e}"))
+            })?;
+            let cam_se3_rig: Vec<Iso3> = extrinsic_result
+                .cam_to_rig
+                .iter()
+                .map(|t| t.inverse())
+                .collect();
+            (cam_se3_rig, extrinsic_result.rig_from_target)
+        }
+    };
+
     session.state.initial_cam_se3_rig = Some(cam_se3_rig);
-    session.state.initial_rig_se3_target = Some(extrinsic_result.rig_from_target);
+    session.state.initial_rig_se3_target = Some(rig_se3_target);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "rig_init",
-        format!("ref_cam={}, {} views", reference_camera_idx, num_views),
+        format!(
+            "ref_cam={}, {} views {}",
+            reference_camera_idx, num_views, source
+        ),
     );
 
     Ok(())
+}
+
+pub fn step_rig_init(session: &mut CalibrationSession<RigHandeyeProblem>) -> Result<(), Error> {
+    step_set_rig_init(session, RigHandeyeRigManualInit::default())
 }
 
 /// Optimize rig extrinsics using bundle adjustment.
@@ -546,8 +700,9 @@ pub fn step_rig_optimize(
 /// - Input not set
 /// - Rig optimization not run
 /// - Linear hand-eye estimation fails
-pub fn step_handeye_init(
+pub fn step_set_handeye_init(
     session: &mut CalibrationSession<RigHandeyeProblem>,
+    manual: RigHandeyeHandeyeManualInit,
     opts: Option<HandeyeInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
@@ -560,12 +715,11 @@ pub fn step_handeye_init(
     }
 
     let opts = opts.unwrap_or_default();
-    let config = &session.config;
     let min_angle = opts
         .min_motion_angle_deg
-        .unwrap_or(config.handeye_init.min_motion_angle_deg);
+        .unwrap_or(session.config.handeye_init.min_motion_angle_deg);
+    let handeye_mode = session.config.handeye_init.handeye_mode;
 
-    // Get robot poses and rig-to-target poses
     let robot_poses: Vec<Iso3> = input
         .views
         .iter()
@@ -577,49 +731,80 @@ pub fn step_handeye_init(
         .clone()
         .ok_or_else(|| Error::not_available("rig_se3_target from rig BA"))?;
 
-    let (handeye, mode_target_pose) = match config.handeye_init.handeye_mode {
-        vision_calibration_optim::HandEyeMode::EyeInHand => {
-            // vision-calibration-linear expects `target_se3_rig` (rig -> target), while the rig BA state
-            // stores `rig_se3_target` (target -> rig).
-            let target_se3_rig: Vec<Iso3> = rig_se3_target.iter().map(|t| t.inverse()).collect();
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
 
-            // Note: estimate_handeye_dlt expects `target_se3_camera`; here "camera" is the rig.
-            let gripper_se3_rig = estimate_handeye_dlt(&robot_poses, &target_se3_rig, min_angle)
-                .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
-                .map_err(|e| Error::numerical(format!("linear hand-eye estimation failed: {e}")))?;
-
-            // base_se3_target = base_se3_gripper * gripper_se3_rig * rig_se3_target
-            let base_se3_target = robot_poses[0] * gripper_se3_rig * rig_se3_target[0];
-
-            (gripper_se3_rig, base_se3_target)
+    let handeye = match manual.handeye {
+        Some(t) => {
+            manual_fields.push("handeye");
+            t
         }
-        vision_calibration_optim::HandEyeMode::EyeToHand => {
-            // For EyeToHand, the target is attached to the gripper. Solve for the fixed
-            // gripper_se3_target (T_G_T) using relative motions, then recover rig_se3_base.
-            let gripper_se3_target =
-                estimate_gripper_se3_target_dlt(&robot_poses, &rig_se3_target, min_angle)
-                    .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
-                    .map_err(|e| {
-                        Error::numerical(format!("linear gripper->target estimation failed: {e}"))
-                    })?;
+        None => {
+            auto_fields.push("handeye");
+            match handeye_mode {
+                HandEyeMode::EyeInHand => {
+                    let target_se3_rig: Vec<Iso3> =
+                        rig_se3_target.iter().map(|t| t.inverse()).collect();
+                    estimate_handeye_dlt(&robot_poses, &target_se3_rig, min_angle)
+                        .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
+                        .map_err(|e| {
+                            Error::numerical(format!("linear hand-eye estimation failed: {e}"))
+                        })?
+                }
+                HandEyeMode::EyeToHand => {
+                    let gripper_se3_target =
+                        estimate_gripper_se3_target_dlt(&robot_poses, &rig_se3_target, min_angle)
+                            .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
+                            .map_err(|e| {
+                                Error::numerical(format!(
+                                    "linear gripper->target estimation failed: {e}"
+                                ))
+                            })?;
+                    rig_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse()
+                }
+            }
+        }
+    };
 
-            // T_R_T = T_R_B * T_B_G * T_G_T  =>  T_R_B = T_R_T * (T_B_G * T_G_T)^-1
-            let rig_se3_base = rig_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse();
-
-            // In EyeToHand mode the mode-target pose is `gripper_se3_target` (T_G_T).
-            (rig_se3_base, gripper_se3_target)
+    let mode_target_pose = match manual.mode_target_pose {
+        Some(t) => {
+            manual_fields.push("mode_target_pose");
+            t
+        }
+        None => {
+            auto_fields.push("mode_target_pose");
+            match handeye_mode {
+                HandEyeMode::EyeInHand => robot_poses[0] * handeye * rig_se3_target[0],
+                HandEyeMode::EyeToHand => {
+                    // gripper_se3_target derived from T_R_T = T_R_B * T_B_G * T_G_T.
+                    // T_G_T = (T_B_G)^-1 * (T_R_B)^-1 * T_R_T = (T_B_G)^-1 * handeye * T_R_T.
+                    robot_poses[0].inverse() * handeye * rig_se3_target[0]
+                }
+            }
         }
     };
 
     session.state.initial_handeye = Some(handeye);
     session.state.initial_mode_target_pose = Some(mode_target_pose);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "handeye_init",
-        format!("translation_norm={:.4}m", handeye.translation.vector.norm()),
+        format!(
+            "translation_norm={:.4}m {}",
+            handeye.translation.vector.norm(),
+            source
+        ),
     );
 
     Ok(())
+}
+
+pub fn step_handeye_init(
+    session: &mut CalibrationSession<RigHandeyeProblem>,
+    opts: Option<HandeyeInitOptions>,
+) -> Result<(), Error> {
+    step_set_handeye_init(session, RigHandeyeHandeyeManualInit::default(), opts)
 }
 
 /// Optimize hand-eye calibration using bundle adjustment.

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/mod.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/mod.rs
@@ -13,4 +13,7 @@ pub use problem::{
     RigLaserlineDeviceProblem, RigUpstreamCalibration,
 };
 pub use state::RigLaserlineDeviceState;
-pub use steps::{StepOptions, run_calibration, step_init, step_optimize};
+pub use steps::{
+    RigLaserlineDeviceManualInit, StepOptions, run_calibration, step_init, step_optimize,
+    step_set_init,
+};

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/steps.rs
@@ -75,19 +75,20 @@ pub fn step_set_init(
         return Err(Error::invalid_input(msg));
     }
 
-    let (planes, source): (Vec<LaserPlane>, &'static str) = match (manual.planes_cam, &input.initial_planes_cam) {
-        (Some(p), _) => (p, "(manual: planes_cam)"),
-        (None, Some(p)) => (p.clone(), "(input: initial_planes_cam)"),
-        (None, None) => {
-            let mut planes = Vec::with_capacity(input.dataset.num_cameras);
-            for cam_idx in 0..input.dataset.num_cameras {
-                let default_plane = LaserPlane::new(Vector3::new(0.0, 0.0, 1.0), -0.2);
-                let plane = linear_plane_init(input, cam_idx).unwrap_or(default_plane);
-                planes.push(plane);
+    let (planes, source): (Vec<LaserPlane>, &'static str) =
+        match (manual.planes_cam, &input.initial_planes_cam) {
+            (Some(p), _) => (p, "(manual: planes_cam)"),
+            (None, Some(p)) => (p.clone(), "(input: initial_planes_cam)"),
+            (None, None) => {
+                let mut planes = Vec::with_capacity(input.dataset.num_cameras);
+                for cam_idx in 0..input.dataset.num_cameras {
+                    let default_plane = LaserPlane::new(Vector3::new(0.0, 0.0, 1.0), -0.2);
+                    let plane = linear_plane_init(input, cam_idx).unwrap_or(default_plane);
+                    planes.push(plane);
+                }
+                (planes, "(auto: linear fit with default fallback)")
             }
-            (planes, "(auto: linear fit with default fallback)")
-        }
-    };
+        };
 
     session.state.initial_planes_cam = Some(planes);
     session.log_success_with_notes("init", format!("initial planes set {source}"));

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/steps.rs
@@ -2,6 +2,7 @@
 
 use crate::Error;
 use nalgebra::Vector3;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{Camera, Pinhole};
 use vision_calibration_linear::laserline::{
     LaserlinePlaneSolver, LaserlineView as LinearLaserlineView,
@@ -24,38 +25,80 @@ pub struct StepOptions {
     pub verbosity: Option<usize>,
 }
 
-/// Initialize per-camera laser planes in camera frame.
+/// Manual seeds for rig laserline device calibration.
 ///
-/// If the input provides `initial_planes_cam`, they are stored as-is.
-/// Otherwise a closed-form plane fit is computed from the frozen upstream
-/// poses, with a generic default plane as a fallback for degenerate inputs.
+/// The upstream rig calibration (intrinsics, distortion, sensors, cam_se3_rig,
+/// rig_se3_target) is part of `input.upstream` and is *not* a manual-init concern
+/// — it's an input contract. Only the laser planes are seedable here.
+///
+/// When `planes_cam` is `Some`, it overrides any `input.initial_planes_cam` and
+/// the linear plane fit is skipped entirely. Length must equal
+/// `input.dataset.num_cameras`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigLaserlineDeviceManualInit {
+    /// Per-camera laser planes (camera frame). Overrides input-supplied seeds.
+    pub planes_cam: Option<Vec<LaserPlane>>,
+}
+
+/// Initialize per-camera laser planes from any combination of manual seeds and
+/// auto-estimation.
+///
+/// This is the load-bearing init function. [`step_init`] is a thin delegate with
+/// `RigLaserlineDeviceManualInit::default()`.
+///
+/// Resolution order for the laser planes:
+/// 1. `manual.planes_cam` if `Some` (highest priority).
+/// 2. `input.initial_planes_cam` if `Some`.
+/// 3. Closed-form linear fit per camera, with a generic fallback plane for
+///    degenerate cases.
 ///
 /// # Errors
 ///
-/// Returns [`Error`] if the session has no input.
-pub fn step_init(session: &mut CalibrationSession<RigLaserlineDeviceProblem>) -> Result<(), Error> {
+/// - Input not set.
+/// - `manual.planes_cam.len() != input.dataset.num_cameras`.
+pub fn step_set_init(
+    session: &mut CalibrationSession<RigLaserlineDeviceProblem>,
+    manual: RigLaserlineDeviceManualInit,
+) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
 
-    let planes: Vec<LaserPlane> = match &input.initial_planes_cam {
-        Some(p) => p.clone(),
-        None => {
+    if let Some(p) = &manual.planes_cam
+        && p.len() != input.dataset.num_cameras
+    {
+        let msg = format!(
+            "manual planes_cam length ({}) != num_cameras ({})",
+            p.len(),
+            input.dataset.num_cameras
+        );
+        session.log_failure("init", msg.clone());
+        return Err(Error::invalid_input(msg));
+    }
+
+    let (planes, source): (Vec<LaserPlane>, &'static str) = match (manual.planes_cam, &input.initial_planes_cam) {
+        (Some(p), _) => (p, "(manual: planes_cam)"),
+        (None, Some(p)) => (p.clone(), "(input: initial_planes_cam)"),
+        (None, None) => {
             let mut planes = Vec::with_capacity(input.dataset.num_cameras);
             for cam_idx in 0..input.dataset.num_cameras {
                 let default_plane = LaserPlane::new(Vector3::new(0.0, 0.0, 1.0), -0.2);
                 let plane = linear_plane_init(input, cam_idx).unwrap_or(default_plane);
                 planes.push(plane);
             }
-            planes
+            (planes, "(auto: linear fit with default fallback)")
         }
     };
 
     session.state.initial_planes_cam = Some(planes);
-    session.log_success_with_notes(
-        "init",
-        "initial planes set (linear fit with default fallback)".to_string(),
-    );
+    session.log_success_with_notes("init", format!("initial planes set {source}"));
     Ok(())
+}
+
+/// Initialize per-camera laser planes using the input-or-auto path.
+///
+/// Convenience wrapper around [`step_set_init`] with default seeds.
+pub fn step_init(session: &mut CalibrationSession<RigLaserlineDeviceProblem>) -> Result<(), Error> {
+    step_set_init(session, RigLaserlineDeviceManualInit::default())
 }
 
 fn linear_plane_init(

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/mod.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/mod.rs
@@ -18,6 +18,8 @@ pub use problem::{
 };
 pub use state::RigScheimpflugExtrinsicsState;
 pub use steps::{
-    IntrinsicsInitOptions, IntrinsicsOptimizeOptions, RigOptimizeOptions, run_calibration,
+    IntrinsicsInitOptions, IntrinsicsOptimizeOptions, RigOptimizeOptions,
+    RigScheimpflugExtrinsicsRigManualInit, RigScheimpflugIntrinsicsManualInit, run_calibration,
     step_intrinsics_init_all, step_intrinsics_optimize_all, step_rig_init, step_rig_optimize,
+    step_set_intrinsics_init_all, step_set_rig_init,
 };

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/steps.rs
@@ -212,13 +212,12 @@ pub fn step_set_intrinsics_init_all(
                 .unwrap_or_default();
             make_pinhole_camera(k, dist)
         } else {
-            let bootstrap = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(
-                |e| {
+            let bootstrap =
+                estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(|e| {
                     Error::numerical(format!(
                         "intrinsics estimation failed for camera {cam_idx}: {e}"
                     ))
-                },
-            )?;
+                })?;
             let dist = manual
                 .per_cam_distortion
                 .as_ref()
@@ -279,11 +278,7 @@ pub fn step_intrinsics_init_all(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),
@@ -475,9 +470,7 @@ pub fn step_set_rig_init(
                 &per_cam_target_poses,
                 reference_camera_idx,
             )
-            .map_err(|e| {
-                Error::numerical(format!("rig extrinsics initialization failed: {e}"))
-            })?;
+            .map_err(|e| Error::numerical(format!("rig extrinsics initialization failed: {e}")))?;
             let cam_se3_rig: Vec<Iso3> = extrinsic_result
                 .cam_to_rig
                 .iter()

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/steps.rs
@@ -1,9 +1,10 @@
 //! Step functions for Scheimpflug rig extrinsics calibration.
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraFixMask, DistortionFixMask, IntrinsicsFixMask, Iso3, NoMeta, PlanarDataset,
-    ScheimpflugParams, View, make_pinhole_camera,
+    BrownConrady5, CameraFixMask, DistortionFixMask, FxFyCxCySkew, IntrinsicsFixMask, Iso3, NoMeta,
+    PlanarDataset, Real, ScheimpflugParams, View, make_pinhole_camera,
 };
 use vision_calibration_linear::estimate_extrinsics_from_cam_target_poses;
 use vision_calibration_linear::prelude::*;
@@ -31,6 +32,27 @@ pub struct IntrinsicsOptimizeOptions {
     pub max_iters: Option<usize>,
     /// Override verbosity level.
     pub verbosity: Option<usize>,
+}
+
+/// Manual seeds for the **per-camera intrinsics stage** of Scheimpflug rig
+/// extrinsics calibration.
+///
+/// Mirrors `RigIntrinsicsManualInit` from rig_extrinsics with an additional
+/// `per_cam_sensors` field for Scheimpflug tilts. When `per_cam_sensors` is
+/// `None`, sensors default to `ScheimpflugParams { tilt_x: config.init_tilt_x,
+/// tilt_y: config.init_tilt_y }`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigScheimpflugIntrinsicsManualInit {
+    pub per_cam_intrinsics: Option<Vec<FxFyCxCySkew<Real>>>,
+    pub per_cam_distortion: Option<Vec<BrownConrady5<Real>>>,
+    pub per_cam_sensors: Option<Vec<ScheimpflugParams>>,
+}
+
+/// Manual seeds for the **rig extrinsics stage**. Coupled per ADR 0011.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigScheimpflugExtrinsicsRigManualInit {
+    pub cam_se3_rig: Option<Vec<Iso3>>,
+    pub rig_se3_target: Option<Vec<Iso3>>,
 }
 
 /// Options for rig BA optimization.
@@ -97,19 +119,46 @@ fn estimate_target_pose(
         .map_err(|e| Error::numerical(format!("failed to recover pose from homography: {e}")))
 }
 
-/// Initialize intrinsics for all cameras (Zhang + zero Scheimpflug tilts).
-///
-/// # Errors
-///
-/// Returns [`Error`] if the input is missing or any camera has insufficient views.
-pub fn step_intrinsics_init_all(
+pub fn step_set_intrinsics_init_all(
     session: &mut CalibrationSession<RigScheimpflugExtrinsicsProblem>,
+    manual: RigScheimpflugIntrinsicsManualInit,
     opts: Option<IntrinsicsInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
     let opts = opts.unwrap_or_default();
     let config = &session.config;
+
+    let num_cameras = input.num_cameras;
+    let num_views = input.num_views();
+
+    if let Some(s) = &manual.per_cam_intrinsics
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_intrinsics length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
+    if let Some(s) = &manual.per_cam_distortion
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_distortion length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
+    if let Some(s) = &manual.per_cam_sensors
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_sensors length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
 
     let init_opts = IterativeIntrinsicsOptions {
         iterations: opts.iterations.unwrap_or(config.intrinsics_init_iterations),
@@ -120,9 +169,28 @@ pub fn step_intrinsics_init_all(
         },
         zero_skew: config.zero_skew,
     };
+    let default_sensor = ScheimpflugParams {
+        tilt_x: config.init_tilt_x,
+        tilt_y: config.init_tilt_y,
+    };
 
-    let num_cameras = input.num_cameras;
-    let num_views = input.num_views();
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+    if manual.per_cam_intrinsics.is_some() {
+        manual_fields.push("per_cam_intrinsics");
+    } else {
+        auto_fields.push("per_cam_intrinsics");
+    }
+    if manual.per_cam_distortion.is_some() {
+        manual_fields.push("per_cam_distortion");
+    } else {
+        auto_fields.push("per_cam_distortion");
+    }
+    if manual.per_cam_sensors.is_some() {
+        manual_fields.push("per_cam_sensors");
+    } else {
+        auto_fields.push("per_cam_sensors");
+    }
 
     let mut per_cam_intrinsics = Vec::with_capacity(num_cameras);
     let mut per_cam_sensors = Vec::with_capacity(num_cameras);
@@ -135,11 +203,29 @@ pub fn step_intrinsics_init_all(
             Error::numerical(format!("camera {cam_idx} has insufficient views: {e}"))
         })?;
 
-        let camera = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(|e| {
-            Error::numerical(format!(
-                "intrinsics estimation failed for camera {cam_idx}: {e}"
-            ))
-        })?;
+        let camera = if let Some(seeds) = manual.per_cam_intrinsics.as_ref() {
+            let k = seeds[cam_idx];
+            let dist = manual
+                .per_cam_distortion
+                .as_ref()
+                .map(|d| d[cam_idx])
+                .unwrap_or_default();
+            make_pinhole_camera(k, dist)
+        } else {
+            let bootstrap = estimate_intrinsics_iterative(&planar_dataset, init_opts).map_err(
+                |e| {
+                    Error::numerical(format!(
+                        "intrinsics estimation failed for camera {cam_idx}: {e}"
+                    ))
+                },
+            )?;
+            let dist = manual
+                .per_cam_distortion
+                .as_ref()
+                .map(|d| d[cam_idx])
+                .unwrap_or(bootstrap.dist);
+            make_pinhole_camera(bootstrap.k, dist)
+        };
 
         let k_matrix = vision_calibration_core::Mat3::new(
             camera.k.fx,
@@ -162,22 +248,46 @@ pub fn step_intrinsics_init_all(
             per_cam_target_poses[global_idx][cam_idx] = Some(pose);
         }
 
-        per_cam_intrinsics.push(make_pinhole_camera(camera.k, camera.dist));
-        per_cam_sensors.push(ScheimpflugParams {
-            tilt_x: config.init_tilt_x,
-            tilt_y: config.init_tilt_y,
-        });
+        let sensor = manual
+            .per_cam_sensors
+            .as_ref()
+            .map(|s| s[cam_idx])
+            .unwrap_or(default_sensor);
+
+        per_cam_intrinsics.push(camera);
+        per_cam_sensors.push(sensor);
     }
 
     session.state.per_cam_intrinsics = Some(per_cam_intrinsics);
     session.state.per_cam_sensors = Some(per_cam_sensors);
     session.state.per_cam_target_poses = Some(per_cam_target_poses);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "intrinsics_init_all",
-        format!("initialized {num_cameras} cameras"),
+        format!("initialized {num_cameras} cameras {source}"),
     );
     Ok(())
+}
+
+pub fn step_intrinsics_init_all(
+    session: &mut CalibrationSession<RigScheimpflugExtrinsicsProblem>,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    step_set_intrinsics_init_all(session, RigScheimpflugIntrinsicsManualInit::default(), opts)
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
 }
 
 /// Optimize Scheimpflug intrinsics per camera.
@@ -303,14 +413,9 @@ pub fn step_intrinsics_optimize_all(
     Ok(())
 }
 
-/// Initialize rig extrinsics from per-camera target poses (linear).
-///
-/// # Errors
-///
-/// Returns [`Error`] if intrinsics have not been computed, or if rig
-/// initialization fails (e.g., insufficient overlap).
-pub fn step_rig_init(
+pub fn step_set_rig_init(
     session: &mut CalibrationSession<RigScheimpflugExtrinsicsProblem>,
+    manual: RigScheimpflugExtrinsicsRigManualInit,
 ) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
@@ -322,31 +427,81 @@ pub fn step_rig_init(
     }
 
     let num_views = input.num_views();
+    let num_cameras = input.num_cameras;
     let reference_camera_idx = session.config.reference_camera_idx;
 
-    let per_cam_target_poses = session
-        .state
-        .per_cam_target_poses
-        .clone()
-        .ok_or_else(|| Error::not_available("per-camera target poses"))?;
+    match (&manual.cam_se3_rig, &manual.rig_se3_target) {
+        (Some(_), None) | (None, Some(_)) => {
+            let msg = "RigScheimpflugExtrinsicsRigManualInit: cam_se3_rig and rig_se3_target must \
+                       both be Some or both None (geometrically coupled per ADR 0011)";
+            session.log_failure("rig_init", msg);
+            return Err(Error::invalid_input(msg));
+        }
+        _ => {}
+    }
 
-    let extrinsic_result =
-        estimate_extrinsics_from_cam_target_poses(&per_cam_target_poses, reference_camera_idx)
-            .map_err(|e| Error::numerical(format!("rig extrinsics initialization failed: {e}")))?;
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
 
-    let cam_se3_rig: Vec<Iso3> = extrinsic_result
-        .cam_to_rig
-        .iter()
-        .map(|t| t.inverse())
-        .collect();
+    let (cam_se3_rig, rig_se3_target) = match (manual.cam_se3_rig, manual.rig_se3_target) {
+        (Some(cam_se3_rig), Some(rig_se3_target)) => {
+            if cam_se3_rig.len() != num_cameras {
+                return Err(Error::invalid_input(format!(
+                    "cam_se3_rig length ({}) != num_cameras ({})",
+                    cam_se3_rig.len(),
+                    num_cameras
+                )));
+            }
+            if rig_se3_target.len() != num_views {
+                return Err(Error::invalid_input(format!(
+                    "rig_se3_target length ({}) != num_views ({})",
+                    rig_se3_target.len(),
+                    num_views
+                )));
+            }
+            manual_fields.push("cam_se3_rig");
+            manual_fields.push("rig_se3_target");
+            (cam_se3_rig, rig_se3_target)
+        }
+        _ => {
+            auto_fields.push("cam_se3_rig");
+            auto_fields.push("rig_se3_target");
+            let per_cam_target_poses = session
+                .state
+                .per_cam_target_poses
+                .clone()
+                .ok_or_else(|| Error::not_available("per-camera target poses"))?;
+            let extrinsic_result = estimate_extrinsics_from_cam_target_poses(
+                &per_cam_target_poses,
+                reference_camera_idx,
+            )
+            .map_err(|e| {
+                Error::numerical(format!("rig extrinsics initialization failed: {e}"))
+            })?;
+            let cam_se3_rig: Vec<Iso3> = extrinsic_result
+                .cam_to_rig
+                .iter()
+                .map(|t| t.inverse())
+                .collect();
+            (cam_se3_rig, extrinsic_result.rig_from_target)
+        }
+    };
+
     session.state.initial_cam_se3_rig = Some(cam_se3_rig);
-    session.state.initial_rig_se3_target = Some(extrinsic_result.rig_from_target);
+    session.state.initial_rig_se3_target = Some(rig_se3_target);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "rig_init",
-        format!("ref_cam={reference_camera_idx}, {num_views} views"),
+        format!("ref_cam={reference_camera_idx}, {num_views} views {source}"),
     );
     Ok(())
+}
+
+pub fn step_rig_init(
+    session: &mut CalibrationSession<RigScheimpflugExtrinsicsProblem>,
+) -> Result<(), Error> {
+    step_set_rig_init(session, RigScheimpflugExtrinsicsRigManualInit::default())
 }
 
 /// Optimize Scheimpflug rig extrinsics via bundle adjustment.

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/mod.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/mod.rs
@@ -16,6 +16,9 @@ pub use problem::{
 pub use state::RigScheimpflugHandeyeState;
 pub use steps::{
     HandeyeInitOptions, HandeyeOptimizeOptions, IntrinsicsInitOptions, IntrinsicsOptimizeOptions,
-    RigOptimizeOptions, run_calibration, step_handeye_init, step_handeye_optimize,
-    step_intrinsics_init_all, step_intrinsics_optimize_all, step_rig_init, step_rig_optimize,
+    RigOptimizeOptions, RigScheimpflugHandeyeHandeyeManualInit,
+    RigScheimpflugHandeyeIntrinsicsManualInit, RigScheimpflugHandeyeRigManualInit, run_calibration,
+    step_handeye_init, step_handeye_optimize, step_intrinsics_init_all,
+    step_intrinsics_optimize_all, step_rig_init, step_rig_optimize, step_set_handeye_init,
+    step_set_intrinsics_init_all, step_set_rig_init,
 };

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/steps.rs
@@ -963,8 +963,9 @@ pub fn step_set_handeye_init(
             match handeye_mode {
                 HandEyeMode::EyeInHand => robot_poses[0] * handeye * rig_se3_target[0],
                 HandEyeMode::EyeToHand => {
-                    // T_G_T = (T_B_G)^-1 * (T_R_B)^-1 * T_R_T = (T_B_G)^-1 * handeye * T_R_T
-                    robot_poses[0].inverse() * handeye * rig_se3_target[0]
+                    // handeye = T_R_B. T_G_T = (T_B_G)^-1 * (T_R_B)^-1 * T_R_T
+                    //                       = robot_poses[0]^-1 * handeye^-1 * T_R_T
+                    robot_poses[0].inverse() * handeye.inverse() * rig_se3_target[0]
                 }
             }
         }
@@ -1109,4 +1110,148 @@ pub fn run_calibration(
     step_handeye_init(session, None)?;
     step_handeye_optimize(session, None)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Rotation3, Translation3};
+    use vision_calibration_core::{
+        BrownConrady5, CorrespondenceView, FxFyCxCySkew, PinholeCamera, Pt2, Pt3, RigDataset,
+        RigView, RigViewObs, make_pinhole_camera,
+    };
+    use vision_calibration_optim::RobotPoseMeta;
+
+    fn make_iso(angles: (f64, f64, f64), t: (f64, f64, f64)) -> Iso3 {
+        let rot = Rotation3::from_euler_angles(angles.0, angles.1, angles.2);
+        let tr = Translation3::new(t.0, t.1, t.2);
+        Iso3::from_parts(tr, rot.into())
+    }
+
+    fn make_test_camera() -> PinholeCamera {
+        make_pinhole_camera(
+            FxFyCxCySkew {
+                fx: 800.0,
+                fy: 800.0,
+                cx: 640.0,
+                cy: 360.0,
+                skew: 0.0,
+            },
+            BrownConrady5::default(),
+        )
+    }
+
+    fn make_test_input() -> RigScheimpflugHandeyeInput {
+        let cam = make_test_camera();
+        let cam0_se3_rig = Iso3::identity();
+        let cam1_se3_rig = make_iso((0.0, 0.0, 0.1), (0.2, 0.0, 0.0));
+        let handeye_gt = make_iso((0.05, -0.03, 0.02), (0.03, -0.02, 0.08));
+        let target_in_base_gt = make_iso((0.0, 0.0, 0.0), (0.0, 0.0, 1.2));
+
+        let board_pts: Vec<Pt3> = (0..6)
+            .flat_map(|i| (0..5).map(move |j| Pt3::new(i as f64 * 0.05, j as f64 * 0.05, 0.0)))
+            .collect();
+
+        let robot_poses = [
+            make_iso((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
+            make_iso((0.1, 0.0, 0.0), (0.1, 0.0, 0.0)),
+            make_iso((0.0, 0.1, 0.0), (0.0, 0.1, 0.0)),
+            make_iso((0.05, 0.05, 0.0), (-0.1, 0.0, 0.0)),
+        ];
+
+        let views: Vec<RigView<RobotPoseMeta>> = robot_poses
+            .iter()
+            .map(|robot_pose| {
+                let rig_se3_target = (robot_pose * handeye_gt).inverse() * target_in_base_gt;
+                let cam0_se3_target = cam0_se3_rig * rig_se3_target;
+                let cam1_se3_target = cam1_se3_rig * rig_se3_target;
+                let project = |pose: &Iso3| -> Vec<Pt2> {
+                    board_pts
+                        .iter()
+                        .map(|p| {
+                            let p_cam = pose.transform_point(p);
+                            cam.project_point_c(&p_cam.coords).unwrap()
+                        })
+                        .collect()
+                };
+                RigView {
+                    meta: RobotPoseMeta {
+                        base_se3_gripper: *robot_pose,
+                    },
+                    obs: RigViewObs {
+                        cameras: vec![
+                            Some(
+                                CorrespondenceView::new(
+                                    board_pts.clone(),
+                                    project(&cam0_se3_target),
+                                )
+                                .unwrap(),
+                            ),
+                            Some(
+                                CorrespondenceView::new(
+                                    board_pts.clone(),
+                                    project(&cam1_se3_target),
+                                )
+                                .unwrap(),
+                            ),
+                        ],
+                    },
+                }
+            })
+            .collect();
+
+        RigDataset::new(views, 2).unwrap()
+    }
+
+    #[test]
+    fn step_set_handeye_init_eye_to_hand_recovers_target_on_gripper() {
+        // Regression test for Codex P1 on PR #32: in EyeToHand mode the
+        // auto-derive of `mode_target_pose` from a manual `handeye` seed must
+        // use `handeye.inverse()`, since `handeye = T_R_B` and the chain is
+        // T_R_T = T_R_B * T_B_G * T_G_T, so T_G_T = T_B_G^-1 * T_R_B^-1 * T_R_T.
+        let input = make_test_input();
+        let robot_poses: Vec<Iso3> = input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper)
+            .collect();
+
+        let t_r_b = make_iso((0.4, -0.2, 0.1), (0.5, -0.3, 0.2));
+        let t_g_t = make_iso((0.15, 0.0, -0.1), (0.05, 0.04, 0.03));
+        let rig_se3_target: Vec<Iso3> = robot_poses.iter().map(|tbg| t_r_b * tbg * t_g_t).collect();
+
+        let mut session = CalibrationSession::<RigScheimpflugHandeyeProblem>::new();
+        session.set_input(input).unwrap();
+        session
+            .set_config(super::super::problem::RigScheimpflugHandeyeConfig {
+                handeye_init: super::super::problem::RigScheimpflugHandeyeInitConfig {
+                    handeye_mode: HandEyeMode::EyeToHand,
+                    min_motion_angle_deg: 5.0,
+                },
+                ..Default::default()
+            })
+            .unwrap();
+
+        session.state.rig_ba_cam_se3_rig = Some(vec![
+            Iso3::identity();
+            session.require_input().unwrap().num_cameras
+        ]);
+        session.state.rig_ba_rig_se3_target = Some(rig_se3_target);
+
+        let manual = RigScheimpflugHandeyeHandeyeManualInit {
+            handeye: Some(t_r_b),
+            mode_target_pose: None,
+        };
+        step_set_handeye_init(&mut session, manual, None).unwrap();
+
+        let recovered = session.state.initial_mode_target_pose.unwrap();
+        let dt = (recovered.translation.vector - t_g_t.translation.vector).norm();
+        let dq = recovered
+            .rotation
+            .rotation_to(&t_g_t.rotation)
+            .angle()
+            .abs();
+        assert!(dt < 1e-9, "T_G_T translation mismatch: |Δt|={dt}");
+        assert!(dq < 1e-9, "T_G_T rotation mismatch: angle={dq}");
+    }
 }

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/steps.rs
@@ -773,11 +773,7 @@ pub fn step_rig_init(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),
@@ -938,10 +934,11 @@ pub fn step_set_handeye_init(
                     estimate_handeye_dlt(&robot_poses, &target_se3_rig, min_angle)
                 }
                 HandEyeMode::EyeToHand => {
-                    estimate_gripper_se3_target_dlt(&robot_poses, &rig_se3_target, min_angle)
-                        .map(|gripper_se3_target| {
+                    estimate_gripper_se3_target_dlt(&robot_poses, &rig_se3_target, min_angle).map(
+                        |gripper_se3_target| {
                             rig_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse()
-                        })
+                        },
+                    )
                 }
             };
             match estimated {
@@ -993,7 +990,11 @@ pub fn step_handeye_init(
     session: &mut CalibrationSession<RigScheimpflugHandeyeProblem>,
     opts: Option<HandeyeInitOptions>,
 ) -> Result<(), Error> {
-    step_set_handeye_init(session, RigScheimpflugHandeyeHandeyeManualInit::default(), opts)
+    step_set_handeye_init(
+        session,
+        RigScheimpflugHandeyeHandeyeManualInit::default(),
+        opts,
+    )
 }
 
 /// Optimize Scheimpflug hand-eye calibration.

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/steps.rs
@@ -4,9 +4,10 @@
 //! `RigScheimpflugHandeyeInitConfig::handeye_mode`.
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraFixMask, DistortionFixMask, IntrinsicsFixMask, Iso3, NoMeta, PlanarDataset,
-    ScheimpflugParams, View, make_pinhole_camera,
+    BrownConrady5, CameraFixMask, DistortionFixMask, FxFyCxCySkew, IntrinsicsFixMask, Iso3, NoMeta,
+    PlanarDataset, Real, ScheimpflugParams, View, make_pinhole_camera,
 };
 use vision_calibration_linear::{
     estimate_extrinsics_from_cam_target_poses, estimate_gripper_se3_target_dlt,
@@ -54,6 +55,35 @@ pub struct RigOptimizeOptions {
 pub struct HandeyeInitOptions {
     /// Minimum motion angle override (degrees).
     pub min_motion_angle_deg: Option<f64>,
+}
+
+/// Manual seeds for the **per-camera intrinsics stage**.
+///
+/// Note: this problem type also accepts intrinsics seeds via
+/// `config.intrinsics.initial_cameras` and `config.intrinsics.initial_sensors`,
+/// which is the legacy mechanism. When both are provided, this `ManualInit`
+/// takes precedence per-field. When neither is provided, Zhang's per-camera
+/// auto-fit runs (with a `fallback_to_shared_init` recovery path on failure).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigScheimpflugHandeyeIntrinsicsManualInit {
+    pub per_cam_intrinsics: Option<Vec<FxFyCxCySkew<Real>>>,
+    pub per_cam_distortion: Option<Vec<BrownConrady5<Real>>>,
+    pub per_cam_sensors: Option<Vec<ScheimpflugParams>>,
+}
+
+/// Manual seeds for the **rig extrinsics stage**. Coupled per ADR 0011.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigScheimpflugHandeyeRigManualInit {
+    pub cam_se3_rig: Option<Vec<Iso3>>,
+    pub rig_se3_target: Option<Vec<Iso3>>,
+}
+
+/// Manual seeds for the **hand-eye stage**. Mode-aware — see
+/// `rig_handeye::RigHandeyeHandeyeManualInit` for field semantics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RigScheimpflugHandeyeHandeyeManualInit {
+    pub handeye: Option<Iso3>,
+    pub mode_target_pose: Option<Iso3>,
 }
 
 /// Options for hand-eye optimization.
@@ -343,6 +373,85 @@ pub fn step_intrinsics_init_all(
     Ok(())
 }
 
+/// Initialize per-camera Scheimpflug intrinsics from any combination of manual
+/// seeds and auto-estimation.
+///
+/// This delegates to [`step_intrinsics_init_all`] after temporarily injecting the
+/// `manual` seeds into `session.config.intrinsics.initial_cameras` and
+/// `session.config.intrinsics.initial_sensors`. The original config values are
+/// restored afterwards. This preserves the existing Zhang+fallback logic while
+/// allowing seed-driven overrides at the API surface.
+///
+/// **Caveat:** `manual.per_cam_distortion` only takes effect when
+/// `manual.per_cam_intrinsics` is also seeded; the underlying override mechanism
+/// is `Vec<PinholeCamera>` (combined intrinsics + distortion).
+pub fn step_set_intrinsics_init_all(
+    session: &mut CalibrationSession<RigScheimpflugHandeyeProblem>,
+    manual: RigScheimpflugHandeyeIntrinsicsManualInit,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    session.validate()?;
+    let num_cameras = session.require_input()?.num_cameras;
+
+    if let Some(s) = &manual.per_cam_intrinsics
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_intrinsics length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
+    if let Some(s) = &manual.per_cam_distortion
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_distortion length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
+    if let Some(s) = &manual.per_cam_sensors
+        && s.len() != num_cameras
+    {
+        return Err(Error::invalid_input(format!(
+            "per_cam_sensors length ({}) != num_cameras ({})",
+            s.len(),
+            num_cameras
+        )));
+    }
+
+    let orig_cameras = session.config.intrinsics.initial_cameras.clone();
+    let orig_sensors = session.config.intrinsics.initial_sensors.clone();
+
+    if let Some(intrinsics) = &manual.per_cam_intrinsics {
+        let default_dist = BrownConrady5::default();
+        let cameras: Vec<vision_calibration_core::PinholeCamera> = intrinsics
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                let d = manual
+                    .per_cam_distortion
+                    .as_ref()
+                    .map(|v| v[i])
+                    .unwrap_or(default_dist);
+                make_pinhole_camera(*k, d)
+            })
+            .collect();
+        session.config.intrinsics.initial_cameras = Some(cameras);
+    }
+    if let Some(sensors) = &manual.per_cam_sensors {
+        session.config.intrinsics.initial_sensors = Some(sensors.clone());
+    }
+
+    let result = step_intrinsics_init_all(session, opts);
+
+    session.config.intrinsics.initial_cameras = orig_cameras;
+    session.config.intrinsics.initial_sensors = orig_sensors;
+
+    result
+}
+
 fn solve_per_view_poses(
     input: &RigScheimpflugHandeyeInput,
     cam_idx: usize,
@@ -583,13 +692,9 @@ pub fn step_intrinsics_optimize_all(
     Ok(())
 }
 
-/// Initialize rig extrinsics from per-camera target poses.
-///
-/// # Errors
-///
-/// Returns [`Error`] if intrinsics have not been computed, or if linear init fails.
-pub fn step_rig_init(
+pub fn step_set_rig_init(
     session: &mut CalibrationSession<RigScheimpflugHandeyeProblem>,
+    manual: RigScheimpflugHandeyeRigManualInit,
 ) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
@@ -599,21 +704,84 @@ pub fn step_rig_init(
         ));
     }
     let num_views = input.num_views();
+    let num_cameras = input.num_cameras;
     let reference_camera_idx = session.config.rig.reference_camera_idx;
-    let per_cam_target_poses = session.state.per_cam_target_poses.clone().unwrap();
 
-    let result =
-        estimate_extrinsics_from_cam_target_poses(&per_cam_target_poses, reference_camera_idx)
+    match (&manual.cam_se3_rig, &manual.rig_se3_target) {
+        (Some(_), None) | (None, Some(_)) => {
+            let msg = "RigScheimpflugHandeyeRigManualInit: cam_se3_rig and rig_se3_target must \
+                       both be Some or both None (geometrically coupled per ADR 0011)";
+            session.log_failure("rig_init", msg);
+            return Err(Error::invalid_input(msg));
+        }
+        _ => {}
+    }
+
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+
+    let (cam_se3_rig, rig_se3_target) = match (manual.cam_se3_rig, manual.rig_se3_target) {
+        (Some(cam_se3_rig), Some(rig_se3_target)) => {
+            if cam_se3_rig.len() != num_cameras {
+                return Err(Error::invalid_input(format!(
+                    "cam_se3_rig length ({}) != num_cameras ({})",
+                    cam_se3_rig.len(),
+                    num_cameras
+                )));
+            }
+            if rig_se3_target.len() != num_views {
+                return Err(Error::invalid_input(format!(
+                    "rig_se3_target length ({}) != num_views ({})",
+                    rig_se3_target.len(),
+                    num_views
+                )));
+            }
+            manual_fields.push("cam_se3_rig");
+            manual_fields.push("rig_se3_target");
+            (cam_se3_rig, rig_se3_target)
+        }
+        _ => {
+            auto_fields.push("cam_se3_rig");
+            auto_fields.push("rig_se3_target");
+            let per_cam_target_poses = session.state.per_cam_target_poses.clone().unwrap();
+            let result = estimate_extrinsics_from_cam_target_poses(
+                &per_cam_target_poses,
+                reference_camera_idx,
+            )
             .map_err(|e| Error::numerical(format!("rig init failed: {e}")))?;
+            let cam_se3_rig: Vec<Iso3> = result.cam_to_rig.iter().map(|t| t.inverse()).collect();
+            (cam_se3_rig, result.rig_from_target)
+        }
+    };
 
-    let cam_se3_rig: Vec<Iso3> = result.cam_to_rig.iter().map(|t| t.inverse()).collect();
     session.state.initial_cam_se3_rig = Some(cam_se3_rig);
-    session.state.initial_rig_se3_target = Some(result.rig_from_target);
+    session.state.initial_rig_se3_target = Some(rig_se3_target);
+
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "rig_init",
-        format!("ref_cam={reference_camera_idx}, {num_views} views"),
+        format!("ref_cam={reference_camera_idx}, {num_views} views {source}"),
     );
     Ok(())
+}
+
+pub fn step_rig_init(
+    session: &mut CalibrationSession<RigScheimpflugHandeyeProblem>,
+) -> Result<(), Error> {
+    step_set_rig_init(session, RigScheimpflugHandeyeRigManualInit::default())
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
 }
 
 /// Optimize rig extrinsics with Scheimpflug bundle adjustment.
@@ -728,21 +896,9 @@ pub fn step_rig_optimize(
     Ok(())
 }
 
-/// Initialize hand-eye transform via Tsai-Lenz.
-///
-/// Mode-dependent semantics:
-///
-/// - `EyeInHand`: solves for `gripper_se3_rig` (T_G_R) with a fixed target in
-///   the base; recovers `base_se3_target` (T_B_T) from the first view.
-/// - `EyeToHand`: solves for `gripper_se3_target` (T_G_T) with a target on the
-///   gripper and rig fixed in base; recovers `rig_se3_base` (T_R_B) from the
-///   first view.
-///
-/// # Errors
-///
-/// Returns [`Error`] if rig BA has not run or linear hand-eye estimation fails.
-pub fn step_handeye_init(
+pub fn step_set_handeye_init(
     session: &mut CalibrationSession<RigScheimpflugHandeyeProblem>,
+    manual: RigScheimpflugHandeyeHandeyeManualInit,
     opts: Option<HandeyeInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
@@ -765,50 +921,79 @@ pub fn step_handeye_init(
         .collect();
     let rig_se3_target = session.state.rig_ba_rig_se3_target.clone().unwrap();
 
-    let result = match handeye_mode {
-        HandEyeMode::EyeInHand => {
-            // estimate_handeye_dlt expects target_se3_rig = rig_se3_target.inverse().
-            let target_se3_rig: Vec<Iso3> = rig_se3_target.iter().map(|t| t.inverse()).collect();
-            estimate_handeye_dlt(&robot_poses, &target_se3_rig, min_angle).map(|gripper_se3_rig| {
-                // base_se3_target = base_se3_gripper * gripper_se3_rig * rig_se3_target
-                let base_se3_target = robot_poses[0] * gripper_se3_rig * rig_se3_target[0];
-                (gripper_se3_rig, base_se3_target)
-            })
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+
+    let handeye = match manual.handeye {
+        Some(t) => {
+            manual_fields.push("handeye");
+            t
         }
-        HandEyeMode::EyeToHand => {
-            // Target is on the gripper; solve for the fixed gripper_se3_target
-            // (T_G_T), then recover rig_se3_base (T_R_B) from the first view.
-            estimate_gripper_se3_target_dlt(&robot_poses, &rig_se3_target, min_angle).map(
-                |gripper_se3_target| {
-                    // T_R_T = T_R_B * T_B_G * T_G_T  =>  T_R_B = T_R_T * (T_B_G * T_G_T)^-1
-                    let rig_se3_base =
-                        rig_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse();
-                    (rig_se3_base, gripper_se3_target)
-                },
-            )
+        None => {
+            auto_fields.push("handeye");
+            let estimated = match handeye_mode {
+                HandEyeMode::EyeInHand => {
+                    let target_se3_rig: Vec<Iso3> =
+                        rig_se3_target.iter().map(|t| t.inverse()).collect();
+                    estimate_handeye_dlt(&robot_poses, &target_se3_rig, min_angle)
+                }
+                HandEyeMode::EyeToHand => {
+                    estimate_gripper_se3_target_dlt(&robot_poses, &rig_se3_target, min_angle)
+                        .map(|gripper_se3_target| {
+                            rig_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse()
+                        })
+                }
+            };
+            match estimated {
+                Ok(v) => v,
+                Err(e) => {
+                    session.log_failure("handeye_init", e.to_string());
+                    return Err(Error::numerical(format!(
+                        "linear hand-eye estimation failed: {e}"
+                    )));
+                }
+            }
         }
     };
-    let (handeye, mode_target_pose) = match result {
-        Ok(v) => v,
-        Err(e) => {
-            session.log_failure("handeye_init", e.to_string());
-            return Err(Error::numerical(format!(
-                "linear hand-eye estimation failed: {e}"
-            )));
+
+    let mode_target_pose = match manual.mode_target_pose {
+        Some(t) => {
+            manual_fields.push("mode_target_pose");
+            t
+        }
+        None => {
+            auto_fields.push("mode_target_pose");
+            match handeye_mode {
+                HandEyeMode::EyeInHand => robot_poses[0] * handeye * rig_se3_target[0],
+                HandEyeMode::EyeToHand => {
+                    // T_G_T = (T_B_G)^-1 * (T_R_B)^-1 * T_R_T = (T_B_G)^-1 * handeye * T_R_T
+                    robot_poses[0].inverse() * handeye * rig_se3_target[0]
+                }
+            }
         }
     };
 
     session.state.initial_handeye = Some(handeye);
     session.state.initial_mode_target_pose = Some(mode_target_pose);
+
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "handeye_init",
         format!(
-            "mode={:?} |t|={:.4}m",
+            "mode={:?} |t|={:.4}m {}",
             handeye_mode,
-            handeye.translation.vector.norm()
+            handeye.translation.vector.norm(),
+            source
         ),
     );
     Ok(())
+}
+
+pub fn step_handeye_init(
+    session: &mut CalibrationSession<RigScheimpflugHandeyeProblem>,
+    opts: Option<HandeyeInitOptions>,
+) -> Result<(), Error> {
+    step_set_handeye_init(session, RigScheimpflugHandeyeHandeyeManualInit::default(), opts)
 }
 
 /// Optimize Scheimpflug hand-eye calibration.

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/mod.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/mod.rs
@@ -14,5 +14,6 @@ pub use problem::{
 };
 pub use state::ScheimpflugIntrinsicsState;
 pub use steps::{
-    IntrinsicsInitOptions, IntrinsicsOptimizeOptions, run_calibration, step_init, step_optimize,
+    IntrinsicsInitOptions, IntrinsicsOptimizeOptions, ScheimpflugManualInit, run_calibration,
+    step_init, step_optimize, step_set_init,
 };

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
@@ -15,8 +15,7 @@ use vision_calibration_optim::{
 };
 
 use crate::planar_family::{
-    bootstrap_planar_intrinsics, estimate_view_homographies,
-    recover_planar_poses_from_homographies,
+    bootstrap_planar_intrinsics, estimate_view_homographies, recover_planar_poses_from_homographies,
 };
 use crate::session::CalibrationSession;
 
@@ -150,9 +149,7 @@ pub fn step_set_init(
                     ))
                 })?;
                 recover_planar_poses_from_homographies(&homographies, &k).map_err(|e| {
-                    Error::numerical(format!(
-                        "scheimpflug intrinsics pose recovery failed: {e}"
-                    ))
+                    Error::numerical(format!("scheimpflug intrinsics pose recovery failed: {e}"))
                 })?
             }
         };
@@ -252,11 +249,7 @@ pub fn step_set_init(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
@@ -1,9 +1,10 @@
 //! Step functions for Scheimpflug intrinsics calibration.
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams,
-    ProjectionParams, ScheimpflugParams, SensorParams,
+    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams, Iso3,
+    ProjectionParams, Real, ScheimpflugParams, SensorParams,
 };
 use vision_calibration_linear::{DistortionFitOptions, IterativeIntrinsicsOptions};
 use vision_calibration_optim::{
@@ -13,7 +14,10 @@ use vision_calibration_optim::{
     optimize_scheimpflug_intrinsics,
 };
 
-use crate::planar_family::bootstrap_planar_intrinsics;
+use crate::planar_family::{
+    bootstrap_planar_intrinsics, estimate_view_homographies,
+    recover_planar_poses_from_homographies,
+};
 use crate::session::CalibrationSession;
 
 use super::problem::{
@@ -28,6 +32,37 @@ pub struct IntrinsicsInitOptions {
     pub iterations: Option<usize>,
 }
 
+/// Manual initialization seeds for Scheimpflug intrinsics calibration.
+///
+/// All fields are `Option<T>`:
+/// - `None` means *auto-initialize this group* (same path as plain `step_init`).
+/// - `Some(value)` means *use this value*; do not auto-initialize.
+///
+/// Partial-seed semantics mirror `PlanarManualInit`:
+/// - `intrinsics: Some` skips the planar bootstrap; distortion defaults to zeros and
+///   sensor to identity tilt unless also seeded; poses recover from homographies using
+///   the manual intrinsics.
+/// - `intrinsics: None` runs the bootstrap; any seeded field overrides the
+///   corresponding bootstrap output. The auto path's tangential-distortion zeroing
+///   (workflow invariant — Scheimpflug pipelines fix tangential) is **not** applied
+///   when the user supplies a manual `distortion` — they get exactly what they pass.
+///
+/// See ADR 0011 for the design rationale.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScheimpflugManualInit {
+    /// Manual intrinsics seed. `None` means auto-init via Zhang's method.
+    pub intrinsics: Option<FxFyCxCySkew<Real>>,
+    /// Manual distortion seed. `None` means auto-init (or zeros when intrinsics are
+    /// seeded).
+    pub distortion: Option<BrownConrady5<Real>>,
+    /// Manual Scheimpflug sensor tilts. `None` means start at identity tilt
+    /// (`ScheimpflugParams::default()`); the optimizer refines from there.
+    pub sensor: Option<ScheimpflugParams>,
+    /// Manual per-view poses (`camera_se3_target`). `None` means recover from
+    /// homographies using whichever intrinsics are in effect.
+    pub poses: Option<Vec<Iso3>>,
+}
+
 /// Options for the optimization step.
 #[derive(Debug, Clone, Default)]
 pub struct IntrinsicsOptimizeOptions {
@@ -37,9 +72,23 @@ pub struct IntrinsicsOptimizeOptions {
     pub verbosity: Option<usize>,
 }
 
-/// Initialize intrinsics and poses for Scheimpflug refinement.
-pub fn step_init(
+/// Initialize Scheimpflug intrinsics, distortion, sensor tilt, and per-view poses
+/// from any combination of manual seeds and auto-estimation.
+///
+/// This is the load-bearing init function. [`step_init`] is a thin delegate that
+/// passes `ScheimpflugManualInit::default()` (all-`None`, full auto path).
+///
+/// See [`ScheimpflugManualInit`] for partial-seed semantics.
+///
+/// # Errors
+///
+/// - Input not set, or fewer than 3 views.
+/// - `init_iterations == 0` when running the bootstrap auto-fit.
+/// - Homography or auto-init computation fails.
+/// - `manual.poses` is `Some` but its length does not match the view count.
+pub fn step_set_init(
     session: &mut CalibrationSession<ScheimpflugIntrinsicsProblem>,
+    manual: ScheimpflugManualInit,
     opts: Option<IntrinsicsInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
@@ -50,49 +99,179 @@ pub fn step_init(
     if let Some(iterations) = opts.iterations {
         init_iterations = iterations;
     }
-    if init_iterations == 0 {
-        return Err(Error::invalid_input("init_iterations must be positive"));
-    }
 
-    // Shared planar-family initialization helper (homographies + intrinsics + poses).
-    let bootstrap = bootstrap_planar_intrinsics(
-        &dataset,
-        IterativeIntrinsicsOptions {
-            iterations: init_iterations,
-            distortion_opts: DistortionFitOptions {
-                fix_k3: session.config.fix_k3_in_init,
-                fix_tangential: true,
-                iters: 8,
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+
+    let (intrinsics, distortion, sensor, poses) = if let Some(k) = manual.intrinsics {
+        manual_fields.push("intrinsics");
+
+        let dist = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                BrownConrady5::default()
+            }
+        };
+
+        let sensor = match manual.sensor {
+            Some(s) => {
+                manual_fields.push("sensor");
+                s
+            }
+            None => {
+                auto_fields.push("sensor");
+                ScheimpflugParams::default()
+            }
+        };
+
+        let poses = match manual.poses {
+            Some(p) => {
+                manual_fields.push("poses");
+                if p.len() != dataset.num_views() {
+                    let msg = format!(
+                        "manual poses count ({}) does not match view count ({})",
+                        p.len(),
+                        dataset.num_views()
+                    );
+                    session.log_failure("init", msg.clone());
+                    return Err(Error::invalid_input(msg));
+                }
+                p
+            }
+            None => {
+                auto_fields.push("poses");
+                let homographies = estimate_view_homographies(&dataset).map_err(|e| {
+                    Error::numerical(format!(
+                        "scheimpflug intrinsics homography estimation failed: {e}"
+                    ))
+                })?;
+                recover_planar_poses_from_homographies(&homographies, &k).map_err(|e| {
+                    Error::numerical(format!(
+                        "scheimpflug intrinsics pose recovery failed: {e}"
+                    ))
+                })?
+            }
+        };
+
+        (k, dist, sensor, poses)
+    } else {
+        if init_iterations == 0 {
+            return Err(Error::invalid_input("init_iterations must be positive"));
+        }
+        auto_fields.push("intrinsics");
+
+        let bootstrap = bootstrap_planar_intrinsics(
+            &dataset,
+            IterativeIntrinsicsOptions {
+                iterations: init_iterations,
+                distortion_opts: DistortionFitOptions {
+                    fix_k3: session.config.fix_k3_in_init,
+                    fix_tangential: true,
+                    iters: 8,
+                },
+                zero_skew: session.config.zero_skew,
             },
-            zero_skew: session.config.zero_skew,
-        },
-    )
-    .map_err(|e| Error::numerical(format!("scheimpflug intrinsics initialization failed: {e}")))?;
-    let mut initial_camera = bootstrap.camera;
+        )
+        .map_err(|e| {
+            Error::numerical(format!("scheimpflug intrinsics initialization failed: {e}"))
+        })?;
 
-    // Tangential terms are intentionally fixed for this workflow.
-    initial_camera.dist.p1 = 0.0;
-    initial_camera.dist.p2 = 0.0;
+        let dist = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                // Workflow invariant: Scheimpflug pipelines fix tangential distortion.
+                let mut d = bootstrap.camera.dist;
+                d.p1 = 0.0;
+                d.p2 = 0.0;
+                d
+            }
+        };
 
-    let poses = bootstrap.poses;
+        let sensor = match manual.sensor {
+            Some(s) => {
+                manual_fields.push("sensor");
+                s
+            }
+            None => {
+                auto_fields.push("sensor");
+                ScheimpflugParams::default()
+            }
+        };
 
-    session.state.initial_intrinsics = Some(initial_camera.k);
-    session.state.initial_distortion = Some(initial_camera.dist);
-    session.state.initial_sensor = Some(ScheimpflugParams::default());
+        let poses = match manual.poses {
+            Some(p) => {
+                manual_fields.push("poses");
+                if p.len() != dataset.num_views() {
+                    let msg = format!(
+                        "manual poses count ({}) does not match view count ({})",
+                        p.len(),
+                        dataset.num_views()
+                    );
+                    session.log_failure("init", msg.clone());
+                    return Err(Error::invalid_input(msg));
+                }
+                p
+            }
+            None => {
+                auto_fields.push("poses");
+                bootstrap.poses
+            }
+        };
+
+        (bootstrap.camera.k, dist, sensor, poses)
+    };
+
+    session.state.initial_intrinsics = Some(intrinsics);
+    session.state.initial_distortion = Some(distortion);
+    session.state.initial_sensor = Some(sensor);
     session.state.initial_poses = Some(poses);
     session.state.clear_optimization();
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "init",
         format!(
-            "fx={:.1}, fy={:.1}, views={}",
-            initial_camera.k.fx,
-            initial_camera.k.fy,
-            dataset.num_views()
+            "fx={:.1}, fy={:.1}, views={} {}",
+            intrinsics.fx,
+            intrinsics.fy,
+            dataset.num_views(),
+            source
         ),
     );
 
     Ok(())
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
+}
+
+/// Initialize intrinsics, distortion, sensor tilt, and poses from observations
+/// using full auto-init.
+///
+/// Convenience wrapper around [`step_set_init`] with `ScheimpflugManualInit::default()`.
+pub fn step_init(
+    session: &mut CalibrationSession<ScheimpflugIntrinsicsProblem>,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    step_set_init(session, ScheimpflugManualInit::default(), opts)
 }
 
 /// Optimize Scheimpflug intrinsics, distortion, sensor tilt, and target poses.
@@ -270,5 +449,81 @@ mod tests {
         assert!(output.mean_reproj_error.is_finite());
         assert!(output.mean_reproj_error < 1.0);
         assert_eq!(output.params.camera_se3_target.len(), 5);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Manual init (ADR 0011) tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn step_set_init_default_matches_step_init() {
+        let sensor_gt = ScheimpflugParams::default();
+        let mut session_a = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+        session_a.set_input(make_dataset(sensor_gt)).expect("input");
+        step_init(&mut session_a, None).expect("step_init");
+
+        let mut session_b = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+        session_b.set_input(make_dataset(sensor_gt)).expect("input");
+        step_set_init(&mut session_b, ScheimpflugManualInit::default(), None)
+            .expect("step_set_init");
+
+        let k_a = session_a.state.initial_intrinsics.unwrap();
+        let k_b = session_b.state.initial_intrinsics.unwrap();
+        assert!((k_a.fx - k_b.fx).abs() < 1e-9);
+        assert!((k_a.fy - k_b.fy).abs() < 1e-9);
+    }
+
+    #[test]
+    fn step_set_init_with_intrinsics_and_sensor_seed_converges() {
+        let sensor_gt = ScheimpflugParams {
+            tilt_x: 0.01,
+            tilt_y: -0.008,
+        };
+        let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+        session.set_input(make_dataset(sensor_gt)).expect("input");
+
+        let manual = ScheimpflugManualInit {
+            intrinsics: Some(FxFyCxCySkew {
+                fx: 800.0,
+                fy: 780.0,
+                cx: 640.0,
+                cy: 360.0,
+                skew: 0.0,
+            }),
+            distortion: Some(BrownConrady5::default()),
+            sensor: Some(sensor_gt),
+            poses: None,
+        };
+        step_set_init(&mut session, manual, None).expect("step_set_init");
+        step_optimize(&mut session, None).expect("step_optimize");
+
+        let output = session.output().expect("output");
+        assert!(
+            output.mean_reproj_error < 1.0,
+            "got {:.4}",
+            output.mean_reproj_error
+        );
+    }
+
+    #[test]
+    fn step_set_init_rejects_wrong_pose_count() {
+        use vision_calibration_core::Iso3;
+
+        let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+        session
+            .set_input(make_dataset(ScheimpflugParams::default()))
+            .expect("input");
+
+        // Test dataset has 5 views; supply only 1 pose.
+        let manual = ScheimpflugManualInit {
+            poses: Some(vec![Iso3::identity()]),
+            ..Default::default()
+        };
+        let err = step_set_init(&mut session, manual, None).unwrap_err();
+        assert!(
+            err.to_string().contains("manual poses count"),
+            "unexpected error: {}",
+            err
+        );
     }
 }

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/mod.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/mod.rs
@@ -74,6 +74,7 @@ pub use problem::{
 pub use state::SingleCamHandeyeState;
 pub use steps::{
     HandeyeInitOptions, HandeyeOptimizeOptions, IntrinsicsInitOptions, IntrinsicsOptimizeOptions,
-    run_calibration, step_handeye_init, step_handeye_optimize, step_intrinsics_init,
-    step_intrinsics_optimize,
+    SingleCamHandeyeManualInit, SingleCamIntrinsicsManualInit, run_calibration, step_handeye_init,
+    step_handeye_optimize, step_intrinsics_init, step_intrinsics_optimize, step_set_handeye_init,
+    step_set_intrinsics_init,
 };

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/steps.rs
@@ -28,13 +28,15 @@
 //! ```
 
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraFixMask, CorrespondenceView, Iso3, NoMeta, PlanarDataset, RigView, RigViewObs, View,
+    BrownConrady5, CameraFixMask, CorrespondenceView, FxFyCxCySkew, Iso3, NoMeta, PlanarDataset,
+    Real, RigView, RigViewObs, View, make_pinhole_camera,
 };
 use vision_calibration_linear::prelude::*;
 use vision_calibration_linear::{estimate_gripper_se3_target_dlt, estimate_handeye_dlt};
 use vision_calibration_optim::{
-    BackendSolveOptions, HandEyeDataset, HandEyeParams, HandEyeSolveOptions,
+    BackendSolveOptions, HandEyeDataset, HandEyeMode, HandEyeParams, HandEyeSolveOptions,
     PlanarIntrinsicsParams, PlanarIntrinsicsSolveOptions, RobotPoseMeta, optimize_handeye,
     optimize_planar_intrinsics,
 };
@@ -61,6 +63,46 @@ pub struct IntrinsicsOptimizeOptions {
     pub max_iters: Option<usize>,
     /// Override verbosity level.
     pub verbosity: Option<usize>,
+}
+
+/// Manual initialization seeds for the **intrinsics stage** of single-camera
+/// hand-eye calibration.
+///
+/// All fields are `Option<T>`. `None` means auto-init via Zhang's method (same path
+/// as plain `step_intrinsics_init`); `Some` means use the provided value.
+///
+/// Partial-seed semantics mirror `PlanarManualInit`: when `intrinsics` is seeded
+/// but `target_poses` is `None`, poses are recovered from per-view homographies
+/// using the manual intrinsics. When intrinsics are seeded and distortion is not,
+/// distortion defaults to `BrownConrady5::default()`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SingleCamIntrinsicsManualInit {
+    /// Manual intrinsics seed.
+    pub intrinsics: Option<FxFyCxCySkew<Real>>,
+    /// Manual distortion seed.
+    pub distortion: Option<BrownConrady5<Real>>,
+    /// Manual per-view target poses (`camera_se3_target`).
+    pub target_poses: Option<Vec<Iso3>>,
+}
+
+/// Manual initialization seeds for the **hand-eye stage** of single-camera
+/// hand-eye calibration.
+///
+/// Fields are mode-dependent — see `session.config.handeye_mode`:
+/// - `HandEyeMode::EyeInHand` consumes `gripper_se3_camera` and `base_se3_target`.
+/// - `HandEyeMode::EyeToHand` consumes `camera_se3_base` and `gripper_se3_target`.
+///
+/// Fields irrelevant to the active mode are ignored.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SingleCamHandeyeManualInit {
+    /// (EyeInHand) Camera mounted on gripper: `T_G_C`.
+    pub gripper_se3_camera: Option<Iso3>,
+    /// (EyeInHand) Target attached in base frame: `T_B_T`.
+    pub base_se3_target: Option<Iso3>,
+    /// (EyeToHand) Camera fixed in scene observing gripper-mounted target: `T_C_B`.
+    pub camera_se3_base: Option<Iso3>,
+    /// (EyeToHand) Target attached to gripper: `T_G_T`.
+    pub gripper_se3_target: Option<Iso3>,
 }
 
 /// Options for hand-eye initialization step.
@@ -122,90 +164,148 @@ fn estimate_target_pose(
 // Step Functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Initialize intrinsics from observations.
+/// Initialize intrinsics, distortion, and per-view target poses from any
+/// combination of manual seeds and auto-estimation.
 ///
-/// This step computes:
-/// 1. Initial intrinsics using Zhang's method with iterative distortion estimation
-/// 2. Initial target poses from homographies and estimated intrinsics
+/// This is the load-bearing intrinsics-stage init. [`step_intrinsics_init`] is a
+/// thin delegate with `SingleCamIntrinsicsManualInit::default()`.
 ///
-/// Updates `session.state` with intermediate results.
-///
-/// # Errors
-///
-/// - Input not set
-/// - Fewer than 3 views
-/// - Intrinsics estimation fails
-pub fn step_intrinsics_init(
+/// See [`SingleCamIntrinsicsManualInit`] for partial-seed semantics.
+pub fn step_set_intrinsics_init(
     session: &mut CalibrationSession<SingleCamHandeyeProblem>,
+    manual: SingleCamIntrinsicsManualInit,
     opts: Option<IntrinsicsInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
     let input = session.require_input()?;
-
+    let view_count = input.views.len();
     let opts = opts.unwrap_or_default();
     let config = &session.config;
 
-    // Build init options
-    let init_opts = IterativeIntrinsicsOptions {
-        iterations: opts.iterations.unwrap_or(config.intrinsics_init_iterations),
-        distortion_opts: DistortionFitOptions {
-            fix_k3: config.fix_k3,
-            fix_tangential: config.fix_tangential,
-            iters: 8,
-        },
-        zero_skew: config.zero_skew,
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+
+    let camera = if let Some(k) = manual.intrinsics {
+        manual_fields.push("intrinsics");
+        let dist = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                BrownConrady5::default()
+            }
+        };
+        make_pinhole_camera(k, dist)
+    } else {
+        auto_fields.push("intrinsics");
+        let init_opts = IterativeIntrinsicsOptions {
+            iterations: opts.iterations.unwrap_or(config.intrinsics_init_iterations),
+            distortion_opts: DistortionFitOptions {
+                fix_k3: config.fix_k3,
+                fix_tangential: config.fix_tangential,
+                iters: 8,
+            },
+            zero_skew: config.zero_skew,
+        };
+        let planar_dataset = input_to_planar_dataset(input)?;
+        let bootstrap_camera = match estimate_intrinsics_iterative(&planar_dataset, init_opts) {
+            Ok(c) => c,
+            Err(e) => {
+                session.log_failure("intrinsics_init", e.to_string());
+                return Err(Error::from(e));
+            }
+        };
+        let dist = match manual.distortion {
+            Some(d) => {
+                manual_fields.push("distortion");
+                d
+            }
+            None => {
+                auto_fields.push("distortion");
+                bootstrap_camera.dist
+            }
+        };
+        make_pinhole_camera(bootstrap_camera.k, dist)
     };
 
-    // Convert to PlanarDataset
-    let planar_dataset = input_to_planar_dataset(input)?;
-
-    // Estimate intrinsics
-    let camera = match estimate_intrinsics_iterative(&planar_dataset, init_opts) {
-        Ok(c) => c,
-        Err(e) => {
-            session.log_failure("intrinsics_init", e.to_string());
-            return Err(Error::from(e));
+    let initial_poses = match manual.target_poses {
+        Some(p) => {
+            manual_fields.push("target_poses");
+            if p.len() != view_count {
+                let msg = format!(
+                    "manual target_poses count ({}) does not match view count ({})",
+                    p.len(),
+                    view_count
+                );
+                session.log_failure("intrinsics_init", msg.clone());
+                return Err(Error::invalid_input(msg));
+            }
+            p
+        }
+        None => {
+            auto_fields.push("target_poses");
+            let k_matrix = vision_calibration_core::Mat3::new(
+                camera.k.fx,
+                camera.k.skew,
+                camera.k.cx,
+                0.0,
+                camera.k.fy,
+                camera.k.cy,
+                0.0,
+                0.0,
+                1.0,
+            );
+            input
+                .views
+                .iter()
+                .enumerate()
+                .map(|(idx, view)| {
+                    estimate_target_pose(&k_matrix, &view.obs).map_err(|e| {
+                        Error::numerical(format!("failed to estimate pose for view {idx}: {e}"))
+                    })
+                })
+                .collect::<Result<Vec<_>, Error>>()?
         }
     };
 
-    // Compute K matrix for pose estimation
-    let k_matrix = vision_calibration_core::Mat3::new(
-        camera.k.fx,
-        camera.k.skew,
-        camera.k.cx,
-        0.0,
-        camera.k.fy,
-        camera.k.cy,
-        0.0,
-        0.0,
-        1.0,
-    );
-
-    // Estimate initial target poses
-    let initial_poses: Vec<Iso3> = input
-        .views
-        .iter()
-        .enumerate()
-        .map(|(idx, view)| {
-            estimate_target_pose(&k_matrix, &view.obs).map_err(|e| {
-                Error::numerical(format!("failed to estimate pose for view {idx}: {e}"))
-            })
-        })
-        .collect::<Result<Vec<_>, Error>>()?;
-
-    // Update state
     session.state.initial_camera = Some(camera.clone());
     session.state.initial_target_poses = Some(initial_poses);
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "intrinsics_init",
         format!(
-            "fx={:.1}, fy={:.1}, cx={:.1}, cy={:.1}",
-            camera.k.fx, camera.k.fy, camera.k.cx, camera.k.cy
+            "fx={:.1}, fy={:.1}, cx={:.1}, cy={:.1} {}",
+            camera.k.fx, camera.k.fy, camera.k.cx, camera.k.cy, source
         ),
     );
 
     Ok(())
+}
+
+/// Initialize intrinsics from observations using full auto-init.
+///
+/// Convenience wrapper around [`step_set_intrinsics_init`] with default seeds.
+pub fn step_intrinsics_init(
+    session: &mut CalibrationSession<SingleCamHandeyeProblem>,
+    opts: Option<IntrinsicsInitOptions>,
+) -> Result<(), Error> {
+    step_set_intrinsics_init(session, SingleCamIntrinsicsManualInit::default(), opts)
+}
+
+fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
+    match (manual.is_empty(), auto.is_empty()) {
+        (false, false) => format!(
+            "(manual: {}; auto: {})",
+            manual.join(", "),
+            auto.join(", ")
+        ),
+        (false, true) => format!("(manual: {})", manual.join(", ")),
+        (true, false) => format!("(auto: {})", auto.join(", ")),
+        (true, true) => "(empty)".to_string(),
+    }
 }
 
 /// Optimize intrinsics using non-linear least squares.
@@ -298,19 +398,28 @@ pub fn step_intrinsics_optimize(
     Ok(())
 }
 
-/// Initialize hand-eye transform from robot poses and camera-target poses.
+/// Initialize the hand-eye stage from any combination of manual seeds and
+/// auto-estimation (Tsai-Lenz DLT).
 ///
-/// Uses Tsai-Lenz linear initialization.
+/// This is the load-bearing handeye-stage init. [`step_handeye_init`] is a thin
+/// delegate with `SingleCamHandeyeManualInit::default()`.
 ///
-/// Requires [`step_intrinsics_optimize`] to be run first.
+/// Mode-aware behavior — `session.config.handeye_mode` selects which seed fields
+/// are consumed:
+/// - `EyeInHand`: `gripper_se3_camera` (auto: Tsai-Lenz DLT) and `base_se3_target`
+///   (auto: derived from `gripper_se3_camera × target_pose[0] × robot_pose[0]`).
+/// - `EyeToHand`: `gripper_se3_target` (auto: DLT) and `camera_se3_base` (auto:
+///   derived from the seed/DLT result and the first observation).
+///
+/// Fields irrelevant to the active mode are ignored.
 ///
 /// # Errors
 ///
-/// - Input not set
-/// - Intrinsics optimization not run
-/// - Linear hand-eye estimation fails
-pub fn step_handeye_init(
+/// - Input not set, intrinsics optimization not run.
+/// - DLT auto-init fails (when not seeded).
+pub fn step_set_handeye_init(
     session: &mut CalibrationSession<SingleCamHandeyeProblem>,
+    manual: SingleCamHandeyeManualInit,
     opts: Option<HandeyeInitOptions>,
 ) -> Result<(), Error> {
     session.validate()?;
@@ -328,7 +437,6 @@ pub fn step_handeye_init(
         .min_motion_angle_deg
         .unwrap_or(config.min_motion_angle_deg);
 
-    // Get robot poses and camera-target poses
     let robot_poses: Vec<Iso3> = input
         .views
         .iter()
@@ -340,45 +448,79 @@ pub fn step_handeye_init(
         .clone()
         .ok_or_else(|| Error::not_available("optimized target poses"))?;
 
-    // Clear previous init results (allows re-running with a different mode)
+    // Clear previous init results (allows re-running with a different mode).
     session.state.initial_gripper_se3_camera = None;
     session.state.initial_camera_se3_base = None;
     session.state.initial_base_se3_target = None;
     session.state.initial_gripper_se3_target = None;
 
+    let mut manual_fields: Vec<&'static str> = Vec::new();
+    let mut auto_fields: Vec<&'static str> = Vec::new();
+
     let (log_pose, log_label) = match config.handeye_mode {
-        vision_calibration_optim::HandEyeMode::EyeInHand => {
-            // vision-calibration-linear expects `target_se3_camera` (camera -> target), while planar intrinsics
-            // produces `cam_se3_target` (target -> camera).
-            let target_se3_camera: Vec<Iso3> = cam_se3_target.iter().map(|t| t.inverse()).collect();
+        HandEyeMode::EyeInHand => {
+            let gripper_se3_camera = match manual.gripper_se3_camera {
+                Some(t) => {
+                    manual_fields.push("gripper_se3_camera");
+                    t
+                }
+                None => {
+                    auto_fields.push("gripper_se3_camera");
+                    let target_se3_camera: Vec<Iso3> =
+                        cam_se3_target.iter().map(|t| t.inverse()).collect();
+                    estimate_handeye_dlt(&robot_poses, &target_se3_camera, min_angle)
+                        .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
+                        .map_err(|e| {
+                            Error::numerical(format!("linear hand-eye estimation failed: {e}"))
+                        })?
+                }
+            };
 
-            let gripper_se3_camera =
-                estimate_handeye_dlt(&robot_poses, &target_se3_camera, min_angle)
-                    .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
-                    .map_err(|e| {
-                        Error::numerical(format!("linear hand-eye estimation failed: {e}"))
-                    })?;
-
-            let base_se3_target = robot_poses[0] * gripper_se3_camera * cam_se3_target[0];
+            let base_se3_target = match manual.base_se3_target {
+                Some(t) => {
+                    manual_fields.push("base_se3_target");
+                    t
+                }
+                None => {
+                    auto_fields.push("base_se3_target");
+                    robot_poses[0] * gripper_se3_camera * cam_se3_target[0]
+                }
+            };
 
             session.state.initial_gripper_se3_camera = Some(gripper_se3_camera);
             session.state.initial_base_se3_target = Some(base_se3_target);
 
             (gripper_se3_camera, "gripper_se3_camera")
         }
-        vision_calibration_optim::HandEyeMode::EyeToHand => {
-            // For EyeToHand, the target is attached to the gripper. Solve for the fixed
-            // gripper_se3_target (T_G_T) using relative motions, then recover camera_se3_base.
-            let gripper_se3_target =
-                estimate_gripper_se3_target_dlt(&robot_poses, &cam_se3_target, min_angle)
-                    .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
-                    .map_err(|e| {
-                        Error::numerical(format!("linear gripper->target estimation failed: {e}"))
-                    })?;
+        HandEyeMode::EyeToHand => {
+            let gripper_se3_target = match manual.gripper_se3_target {
+                Some(t) => {
+                    manual_fields.push("gripper_se3_target");
+                    t
+                }
+                None => {
+                    auto_fields.push("gripper_se3_target");
+                    estimate_gripper_se3_target_dlt(&robot_poses, &cam_se3_target, min_angle)
+                        .inspect_err(|e| session.log_failure("handeye_init", e.to_string()))
+                        .map_err(|e| {
+                            Error::numerical(format!(
+                                "linear gripper->target estimation failed: {e}"
+                            ))
+                        })?
+                }
+            };
 
-            // T_C_T = T_C_B * T_B_G * T_G_T  =>  T_C_B = T_C_T * (T_B_G * T_G_T)^-1
-            let camera_se3_base =
-                cam_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse();
+            let camera_se3_base = match manual.camera_se3_base {
+                Some(t) => {
+                    manual_fields.push("camera_se3_base");
+                    t
+                }
+                None => {
+                    auto_fields.push("camera_se3_base");
+                    // T_C_T = T_C_B * T_B_G * T_G_T  =>  T_C_B = T_C_T * (T_B_G * T_G_T)^-1
+                    cam_se3_target[0] * (robot_poses[0] * gripper_se3_target).inverse()
+                }
+            };
 
             session.state.initial_camera_se3_base = Some(camera_se3_base);
             session.state.initial_gripper_se3_target = Some(gripper_se3_target);
@@ -387,16 +529,28 @@ pub fn step_handeye_init(
         }
     };
 
+    let source = format_init_source(&manual_fields, &auto_fields);
     session.log_success_with_notes(
         "handeye_init",
         format!(
-            "{} |t|={:.4}m",
+            "{} |t|={:.4}m {}",
             log_label,
-            log_pose.translation.vector.norm()
+            log_pose.translation.vector.norm(),
+            source
         ),
     );
 
     Ok(())
+}
+
+/// Initialize the hand-eye transform using full auto-init (Tsai-Lenz DLT).
+///
+/// Convenience wrapper around [`step_set_handeye_init`] with default seeds.
+pub fn step_handeye_init(
+    session: &mut CalibrationSession<SingleCamHandeyeProblem>,
+    opts: Option<HandeyeInitOptions>,
+) -> Result<(), Error> {
+    step_set_handeye_init(session, SingleCamHandeyeManualInit::default(), opts)
 }
 
 /// Optimize hand-eye calibration using bundle adjustment.

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/steps.rs
@@ -297,11 +297,7 @@ pub fn step_intrinsics_init(
 
 fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
     match (manual.is_empty(), auto.is_empty()) {
-        (false, false) => format!(
-            "(manual: {}; auto: {})",
-            manual.join(", "),
-            auto.join(", ")
-        ),
+        (false, false) => format!("(manual: {}; auto: {})", manual.join(", "), auto.join(", ")),
         (false, true) => format!("(manual: {})", manual.join(", ")),
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),

--- a/crates/vision-calibration/examples/manual_init_proof.rs
+++ b/crates/vision-calibration/examples/manual_init_proof.rs
@@ -1,0 +1,340 @@
+//! End-to-end proof that ADR 0011 manual init (PR #32) works on real data.
+//!
+//! Loads `data/stereo_charuco/`, then runs the rig-extrinsics pipeline three
+//! ways and compares results:
+//!
+//! 1. **Run A — full auto-init**: today's behaviour. Captures per-cam intrinsics
+//!    + cam-to-rig extrinsics + mean reprojection error.
+//! 2. **Run B — replay manual seed**: seeds Run A's per-cam intrinsics +
+//!    distortion via [`RigIntrinsicsManualInit`] AND seeds Run A's rig
+//!    initialization via [`RigExtrinsicsManualInit`], then skips per-camera
+//!    intrinsics re-optimization (since the seeds are already optimized) and
+//!    runs only `step_rig_optimize`. Expectation: identical final
+//!    reprojection error (Zhang + DLT bypassed entirely).
+//! 3. **Run C — perturbed manual seed**: seeds intrinsics with a noticeable
+//!    error (10 % focal-length perturbation, principal point offset by 50 px).
+//!    Expectation: BA recovers a final reprojection error close to Run A.
+//!
+//! Each run also prints the stage-init log lines so the `(manual: …)` /
+//! `(auto: …)` markers show the seed source.
+//!
+//! Run with: `cargo run -p vision-calibration --example manual_init_proof --release`
+
+#[path = "support/stereo_charuco_io.rs"]
+mod stereo_charuco_io;
+
+use anyhow::{Result, ensure};
+use chess_corners::ChessConfig;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use stereo_charuco_io::{
+    BOARD_CELL_SIZE_MM, BOARD_COLS, BOARD_DICTIONARY_NAME, BOARD_MARKER_SIZE_REL, BOARD_ROWS,
+    load_stereo_charuco_input_with_progress, make_charuco_detector_params,
+};
+use vision_calibration::core::{BrownConrady5, FxFyCxCySkew, Iso3, PinholeCamera};
+use vision_calibration::prelude::*;
+use vision_calibration::rig_extrinsics::{
+    RigExtrinsicsInput, RigExtrinsicsManualInit, RigExtrinsicsProblem, RigIntrinsicsManualInit,
+    step_intrinsics_optimize_all, step_rig_optimize, step_set_intrinsics_init_all,
+    step_set_rig_init,
+};
+use vision_calibration::session::LogEntry;
+
+fn main() -> Result<()> {
+    let max_views = parse_max_views();
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let data_dir = repo_root.join("data/stereo_charuco");
+    ensure!(
+        data_dir.exists(),
+        "stereo ChArUco dataset not found at {}",
+        data_dir.display()
+    );
+
+    println!("=== Manual init proof on data/stereo_charuco ===\n");
+    println!("Dataset: {}", data_dir.display());
+    println!(
+        "Board: {}x{}, cell {:.4}mm, marker scale {:.2}, dict {}",
+        BOARD_ROWS, BOARD_COLS, BOARD_CELL_SIZE_MM, BOARD_MARKER_SIZE_REL, BOARD_DICTIONARY_NAME
+    );
+    println!("Max views: {max_views}\n");
+
+    let chess_config = ChessConfig::default();
+    let charuco_params = make_charuco_detector_params();
+
+    let load = || -> Result<RigExtrinsicsInput> {
+        let (input, summary) = load_stereo_charuco_input_with_progress(
+            &data_dir,
+            &chess_config,
+            &charuco_params,
+            Some(max_views),
+            |idx, total, suffix| {
+                print!("\r  Detect pair {idx}/{total} ({suffix})");
+                let _ = io::stdout().flush();
+            },
+        )?;
+        println!(
+            "\n  Loaded {} views from {} pairs ({} skipped, left={} right={})",
+            summary.used_views,
+            summary.total_pairs,
+            summary.skipped_views,
+            summary.usable_left,
+            summary.usable_right
+        );
+        Ok(input)
+    };
+
+    // ─── Run A: full auto pipeline ────────────────────────────────────────
+    println!("--- Run A: full auto-init pipeline ---");
+    let mut session_a = CalibrationSession::<RigExtrinsicsProblem>::new();
+    session_a.set_input(load()?)?;
+    step_set_intrinsics_init_all(&mut session_a, RigIntrinsicsManualInit::default(), None)?;
+    step_intrinsics_optimize_all(&mut session_a, None)?;
+    step_set_rig_init(&mut session_a, RigExtrinsicsManualInit::default())?;
+    step_rig_optimize(&mut session_a, None)?;
+    let a_summary = summarize(&session_a, "Run A")?;
+    print_init_logs(&session_a.log, "Run A");
+    println!();
+
+    let cameras_a = session_a
+        .state
+        .per_cam_intrinsics
+        .clone()
+        .expect("Run A: per-cam intrinsics");
+    let cam_se3_rig_a = session_a
+        .state
+        .initial_cam_se3_rig
+        .clone()
+        .expect("Run A: initial cam_se3_rig");
+    let rig_se3_target_a = session_a
+        .state
+        .initial_rig_se3_target
+        .clone()
+        .expect("Run A: initial rig_se3_target");
+
+    let per_cam_k: Vec<FxFyCxCySkew<f64>> = cameras_a.iter().map(|c| c.k).collect();
+    let per_cam_dist: Vec<BrownConrady5<f64>> = cameras_a.iter().map(|c| c.dist).collect();
+
+    // ─── Run B: replay Run A's intermediates as manual seeds ──────────────
+    println!("--- Run B: replay Run A's seeds via ManualInit ---");
+    let mut session_b = CalibrationSession::<RigExtrinsicsProblem>::new();
+    session_b.set_input(load()?)?;
+    step_set_intrinsics_init_all(
+        &mut session_b,
+        RigIntrinsicsManualInit {
+            per_cam_intrinsics: Some(per_cam_k.clone()),
+            per_cam_distortion: Some(per_cam_dist.clone()),
+        },
+        None,
+    )?;
+    // Skip step_intrinsics_optimize_all: the seed is Run A's already-optimized
+    // intrinsics, so re-running the per-camera optimizer would just shift them
+    // by solver-noise levels and is not what a "load saved calibration" caller
+    // would do. We still need state.per_cam_reproj_errors populated for the
+    // rig stage, but rig_optimize does not depend on it directly — it only
+    // needs per_cam_intrinsics + per_cam_target_poses, both already set by
+    // step_set_intrinsics_init_all.
+    step_set_rig_init(
+        &mut session_b,
+        RigExtrinsicsManualInit {
+            cam_se3_rig: Some(cam_se3_rig_a.clone()),
+            rig_se3_target: Some(rig_se3_target_a.clone()),
+        },
+    )?;
+    step_rig_optimize(&mut session_b, None)?;
+    let b_summary = summarize(&session_b, "Run B")?;
+    print_init_logs(&session_b.log, "Run B");
+    println!();
+
+    // ─── Run C: rough perturbed seed (intrinsics only) ────────────────────
+    println!("--- Run C: perturbed intrinsics seed (10% fx, 50px cx) ---");
+    let perturbed_k: Vec<FxFyCxCySkew<f64>> = per_cam_k
+        .iter()
+        .enumerate()
+        .map(|(i, k)| {
+            let sign = if i.is_multiple_of(2) { 1.0 } else { -1.0 };
+            FxFyCxCySkew {
+                fx: k.fx * (1.0 + sign * 0.10),
+                fy: k.fy * (1.0 + sign * 0.10),
+                cx: k.cx + sign * 50.0,
+                cy: k.cy - sign * 50.0,
+                skew: k.skew,
+            }
+        })
+        .collect();
+    let mut session_c = CalibrationSession::<RigExtrinsicsProblem>::new();
+    session_c.set_input(load()?)?;
+    step_set_intrinsics_init_all(
+        &mut session_c,
+        RigIntrinsicsManualInit {
+            per_cam_intrinsics: Some(perturbed_k),
+            per_cam_distortion: None, // let auto-fit it
+        },
+        None,
+    )?;
+    step_intrinsics_optimize_all(&mut session_c, None)?;
+    step_set_rig_init(&mut session_c, RigExtrinsicsManualInit::default())?;
+    step_rig_optimize(&mut session_c, None)?;
+    let c_summary = summarize(&session_c, "Run C")?;
+    print_init_logs(&session_c.log, "Run C");
+    println!();
+
+    // ─── Verdict ──────────────────────────────────────────────────────────
+    println!("=== Verdict ===");
+    print_compare("auto vs replay (B vs A)", &a_summary, &b_summary);
+    print_compare("auto vs perturbed (C vs A)", &a_summary, &c_summary);
+
+    let replay_diff = (b_summary.mean_reproj - a_summary.mean_reproj).abs();
+    let recover_diff = (c_summary.mean_reproj - a_summary.mean_reproj).abs();
+
+    let replay_ok = replay_diff < 1.0e-4;
+    let recover_ok = recover_diff < 0.05;
+
+    println!(
+        "\n  replay agrees with auto: {} (|Δ reproj| = {:.2e} px, threshold 1e-4)",
+        if replay_ok { "PASS" } else { "FAIL" },
+        replay_diff
+    );
+    println!(
+        "  perturbed BA recovers : {} (|Δ reproj| = {:.4} px, threshold 0.05)",
+        if recover_ok { "PASS" } else { "FAIL" },
+        recover_diff
+    );
+
+    ensure!(
+        replay_ok && recover_ok,
+        "manual init proof failed: replay_ok={replay_ok}, recover_ok={recover_ok}"
+    );
+    println!("\nAll checks passed.");
+    Ok(())
+}
+
+struct RunSummary {
+    label: String,
+    mean_reproj: f64,
+    per_cam_reproj: Vec<f64>,
+    cameras: Vec<PinholeCamera>,
+    cam_se3_rig: Vec<Iso3>,
+}
+
+fn summarize(
+    session: &CalibrationSession<RigExtrinsicsProblem>,
+    label: &str,
+) -> Result<RunSummary> {
+    let mean_reproj = session
+        .state
+        .rig_ba_reproj_error
+        .ok_or_else(|| anyhow::anyhow!("{label}: rig BA reproj missing"))?;
+    let per_cam_reproj = session
+        .state
+        .rig_ba_per_cam_reproj_errors
+        .clone()
+        .unwrap_or_default();
+    let cameras = session.state.per_cam_intrinsics.clone().unwrap_or_default();
+    let output = session
+        .require_output()
+        .map_err(|e| anyhow::anyhow!("{label}: no output: {e}"))?;
+    let cam_se3_rig: Vec<Iso3> = output
+        .params
+        .cam_to_rig
+        .iter()
+        .map(|t| t.inverse())
+        .collect();
+
+    println!("  {label}: mean reproj = {:.4} px", mean_reproj);
+    for (i, err) in per_cam_reproj.iter().enumerate() {
+        println!("    cam {i}: reproj = {:.4} px", err);
+    }
+    if cam_se3_rig.len() >= 2 {
+        let baseline =
+            (cam_se3_rig[1].translation.vector - cam_se3_rig[0].translation.vector).norm();
+        println!(
+            "    baseline |t(cam0->cam1)| = {:.4} m ({:.2} mm)",
+            baseline,
+            baseline * 1000.0
+        );
+    }
+    for (i, cam) in cameras.iter().enumerate() {
+        let k = &cam.k;
+        println!(
+            "    cam {i}: fx={:.2}, fy={:.2}, cx={:.2}, cy={:.2}",
+            k.fx, k.fy, k.cx, k.cy
+        );
+    }
+
+    Ok(RunSummary {
+        label: label.to_string(),
+        mean_reproj,
+        per_cam_reproj,
+        cameras,
+        cam_se3_rig,
+    })
+}
+
+fn print_compare(title: &str, a: &RunSummary, b: &RunSummary) {
+    println!("\n  {title}:");
+    println!(
+        "    mean reproj: {:.4} → {:.4} px (Δ = {:+.2e})",
+        a.mean_reproj,
+        b.mean_reproj,
+        b.mean_reproj - a.mean_reproj
+    );
+    for (i, (ea, eb)) in a
+        .per_cam_reproj
+        .iter()
+        .zip(b.per_cam_reproj.iter())
+        .enumerate()
+    {
+        println!(
+            "    cam {i}: {:.4} → {:.4} px (Δ = {:+.2e})",
+            ea,
+            eb,
+            eb - ea
+        );
+    }
+    if a.cam_se3_rig.len() >= 2 && b.cam_se3_rig.len() >= 2 {
+        let ba = (a.cam_se3_rig[1].translation.vector - a.cam_se3_rig[0].translation.vector).norm();
+        let bb = (b.cam_se3_rig[1].translation.vector - b.cam_se3_rig[0].translation.vector).norm();
+        println!(
+            "    baseline: {:.2} → {:.2} mm (Δ = {:+.4} mm)",
+            ba * 1000.0,
+            bb * 1000.0,
+            (bb - ba) * 1000.0
+        );
+    }
+    for (i, (ka, kb)) in a.cameras.iter().zip(b.cameras.iter()).enumerate() {
+        println!(
+            "    cam {i}: fx Δ = {:+.4}, fy Δ = {:+.4}, cx Δ = {:+.4}, cy Δ = {:+.4}",
+            kb.k.fx - ka.k.fx,
+            kb.k.fy - ka.k.fy,
+            kb.k.cx - ka.k.cx,
+            kb.k.cy - ka.k.cy,
+        );
+    }
+    let _ = b.label.as_str();
+}
+
+fn print_init_logs(log: &[LogEntry], label: &str) {
+    let init_ops = ["intrinsics_init_all", "rig_init"];
+    println!("  {label} init log:");
+    for entry in log {
+        if init_ops.contains(&entry.operation.as_str()) {
+            let notes = entry.notes.as_deref().unwrap_or("");
+            println!("    [{}] {}", entry.operation, notes);
+        }
+    }
+}
+
+fn parse_max_views() -> usize {
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        if let Some(raw) = arg.strip_prefix("--max-views=") {
+            return raw.parse().expect("invalid --max-views");
+        }
+        if arg == "--max-views"
+            && let Some(raw) = iter.next()
+        {
+            return raw.parse().expect("invalid --max-views");
+        }
+    }
+    8
+}

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -89,7 +89,8 @@ pub mod scheimpflug_intrinsics {
         IntrinsicsInitOptions, IntrinsicsOptimizeOptions, ScheimpflugFixMask,
         ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsExport, ScheimpflugIntrinsicsInput,
         ScheimpflugIntrinsicsParams, ScheimpflugIntrinsicsProblem, ScheimpflugIntrinsicsResult,
-        ScheimpflugIntrinsicsState, run_calibration, step_init, step_optimize,
+        ScheimpflugIntrinsicsState, ScheimpflugManualInit, run_calibration, step_init,
+        step_optimize, step_set_init,
     };
 }
 
@@ -146,6 +147,8 @@ pub mod planar_intrinsics {
         PlanarIntrinsicsParams,
         PlanarIntrinsicsProblem,
         PlanarIntrinsicsSolveOptions,
+        // Manual init seed (ADR 0011)
+        PlanarManualInit,
         PlanarState,
         // Step functions
         run_calibration,
@@ -153,6 +156,7 @@ pub mod planar_intrinsics {
         step_filter,
         step_init,
         step_optimize,
+        step_set_init,
     };
 }
 
@@ -194,15 +198,20 @@ pub mod single_cam_handeye {
         SingleCamHandeyeConfig,
         SingleCamHandeyeExport,
         SingleCamHandeyeInput,
+        // Manual init seeds (ADR 0011)
+        SingleCamHandeyeManualInit,
         SingleCamHandeyeProblem,
         SingleCamHandeyeState,
         SingleCamHandeyeView,
+        SingleCamIntrinsicsManualInit,
         // Step functions
         run_calibration,
         step_handeye_init,
         step_handeye_optimize,
         step_intrinsics_init,
         step_intrinsics_optimize,
+        step_set_handeye_init,
+        step_set_intrinsics_init,
     };
 }
 
@@ -231,9 +240,10 @@ pub mod single_cam_handeye {
 pub mod laserline_device {
     pub use vision_calibration_pipeline::laserline_device::{
         DeviceInitOptions, DeviceOptimizeOptions, LaserlineDeviceConfig, LaserlineDeviceExport,
-        LaserlineDeviceInitConfig, LaserlineDeviceInput, LaserlineDeviceOptimizeConfig,
-        LaserlineDeviceOutput, LaserlineDeviceProblem, LaserlineDeviceSolverConfig,
-        LaserlineDeviceState, run_calibration, step_init, step_optimize,
+        LaserlineDeviceInitConfig, LaserlineDeviceInput, LaserlineDeviceManualInit,
+        LaserlineDeviceOptimizeConfig, LaserlineDeviceOutput, LaserlineDeviceProblem,
+        LaserlineDeviceSolverConfig, LaserlineDeviceState, run_calibration, step_init,
+        step_optimize, step_set_init,
     };
 }
 
@@ -273,8 +283,11 @@ pub mod rig_extrinsics {
         RigExtrinsicsConfig,
         RigExtrinsicsExport,
         RigExtrinsicsInput,
+        // Manual init seeds (ADR 0011)
+        RigExtrinsicsManualInit,
         RigExtrinsicsProblem,
         RigExtrinsicsState,
+        RigIntrinsicsManualInit,
         RigOptimizeOptions,
         // Step functions
         run_calibration,
@@ -282,6 +295,8 @@ pub mod rig_extrinsics {
         step_intrinsics_optimize_all,
         step_rig_init,
         step_rig_optimize,
+        step_set_intrinsics_init_all,
+        step_set_rig_init,
     };
 }
 
@@ -323,11 +338,15 @@ pub mod rig_handeye {
         RigHandeyeBaConfig,
         RigHandeyeConfig,
         RigHandeyeExport,
+        // Manual init seeds (ADR 0011)
+        RigHandeyeHandeyeManualInit,
         RigHandeyeInitConfig,
         RigHandeyeInput,
         RigHandeyeIntrinsicsConfig,
+        RigHandeyeIntrinsicsManualInit,
         RigHandeyeProblem,
         RigHandeyeRigConfig,
+        RigHandeyeRigManualInit,
         RigHandeyeSolverConfig,
         RigHandeyeState,
         RigOptimizeOptions,
@@ -339,6 +358,9 @@ pub mod rig_handeye {
         step_intrinsics_optimize_all,
         step_rig_init,
         step_rig_optimize,
+        step_set_handeye_init,
+        step_set_intrinsics_init_all,
+        step_set_rig_init,
     };
 }
 
@@ -350,8 +372,10 @@ pub mod rig_scheimpflug_extrinsics {
         IntrinsicsInitOptions, IntrinsicsOptimizeOptions, RigOptimizeOptions,
         RigScheimpflugExtrinsicsConfig, RigScheimpflugExtrinsicsExport,
         RigScheimpflugExtrinsicsInput, RigScheimpflugExtrinsicsProblem,
-        RigScheimpflugExtrinsicsState, run_calibration, step_intrinsics_init_all,
+        RigScheimpflugExtrinsicsRigManualInit, RigScheimpflugExtrinsicsState,
+        RigScheimpflugIntrinsicsManualInit, run_calibration, step_intrinsics_init_all,
         step_intrinsics_optimize_all, step_rig_init, step_rig_optimize,
+        step_set_intrinsics_init_all, step_set_rig_init,
     };
 }
 
@@ -363,12 +387,15 @@ pub mod rig_scheimpflug_handeye {
     pub use vision_calibration_pipeline::rig_scheimpflug_handeye::{
         HandeyeInitOptions, HandeyeOptimizeOptions, IntrinsicsInitOptions,
         IntrinsicsOptimizeOptions, RigOptimizeOptions, RigScheimpflugHandeyeBaConfig,
-        RigScheimpflugHandeyeConfig, RigScheimpflugHandeyeExport, RigScheimpflugHandeyeInitConfig,
+        RigScheimpflugHandeyeConfig, RigScheimpflugHandeyeExport,
+        RigScheimpflugHandeyeHandeyeManualInit, RigScheimpflugHandeyeInitConfig,
         RigScheimpflugHandeyeInput, RigScheimpflugHandeyeIntrinsicsConfig,
-        RigScheimpflugHandeyeProblem, RigScheimpflugHandeyeRigConfig,
+        RigScheimpflugHandeyeIntrinsicsManualInit, RigScheimpflugHandeyeProblem,
+        RigScheimpflugHandeyeRigConfig, RigScheimpflugHandeyeRigManualInit,
         RigScheimpflugHandeyeSolverConfig, RigScheimpflugHandeyeState, run_calibration,
         step_handeye_init, step_handeye_optimize, step_intrinsics_init_all,
-        step_intrinsics_optimize_all, step_rig_init, step_rig_optimize,
+        step_intrinsics_optimize_all, step_rig_init, step_rig_optimize, step_set_handeye_init,
+        step_set_intrinsics_init_all, step_set_rig_init,
     };
 }
 
@@ -379,8 +406,9 @@ pub mod rig_scheimpflug_handeye {
 pub mod rig_laserline_device {
     pub use vision_calibration_pipeline::rig_laserline_device::{
         RigLaserlineDeviceConfig, RigLaserlineDeviceExport, RigLaserlineDeviceInput,
-        RigLaserlineDeviceProblem, RigLaserlineDeviceState, RigUpstreamCalibration, StepOptions,
-        run_calibration, step_init, step_optimize,
+        RigLaserlineDeviceManualInit, RigLaserlineDeviceProblem, RigLaserlineDeviceState,
+        RigUpstreamCalibration, StepOptions, run_calibration, step_init, step_optimize,
+        step_set_init,
     };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,115 @@
+# calibration-rs Roadmap
+
+Canonical short-form summary of the multi-quarter direction. Detailed reasoning per track
+lives in ADRs (`docs/adrs/`); work-in-flight lives in open PRs.
+
+## Status (as of 2026-04-29)
+
+- **Version line:** 0.x. v1.0 (= stable public API) is deferred until the API has been
+  stable across two minor releases without breaking changes. Pre-1.0 means breaking changes
+  are acceptable.
+- **Active branch:** `main`.
+- **In-flight PRs:**
+  [#27 Manual init](https://github.com/VitalyVorobyev/calibration-rs/pull/27) — calibration
+  warm-start across all problem types.
+  [#28 mvg](https://github.com/VitalyVorobyev/calibration-rs/pull/28) — multiple-view
+  geometry crate split.
+
+## Four tracks
+
+### Track A — Calibration core
+
+Anchored to the **puzzle 130x130 rig** — the workspace's primary internal use case. The rig
+is structurally complete; its only blocker is Zhang's intrinsics init failing on a specific
+real-data camera ("invalid sign for lambda"). PR #27 is the literal unblocker.
+
+- **A1** Land PR #27 — manual init / warm-start across all nine problem types. See
+  [ADR 0011](adrs/0011-manual-initialization-workflow.md).
+- **A2** Per-feature residuals on every `*Export` type (gates the diagnose UI). New
+  ADR 0012 pending.
+- **A3** Zhang's init robustness: detect the lambda-sign failure and fall back to a
+  constant-K estimate.
+- **A4** EyeToHand mode for the Scheimpflug hand-eye family (currently EyeInHand only).
+- **A5** Python bindings parity for `RigScheimpflugExtrinsics`, `RigScheimpflugHandeye`,
+  `RigLaserlineDevice`.
+- **A6** `rig_family` shared-helpers refactor (defer until a third sibling problem type
+  exists).
+
+### Track B — Tauri 2 + React + TypeScript desktop app
+
+A production-grade internal tool wrapping the calibration library. ~4–6 months end-to-end
+at one-engineer cadence. ADR 0013 pending — records the choice over `rerun.io` and `egui`
+(rejected: `rerun`'s developer-tool aesthetic + gRPC clashes with this project's zenoh-Rust
+stack; `egui` has less ecosystem leverage for production polish).
+
+- **B0** Scaffolding — new `app/` directory with conventional Tauri 2 layout
+  (`app/src-tauri/` Rust + `app/src/` React + TS).
+- **B1** Project model + file loading (images + calibration config in).
+- **B2** Feature detection pipeline wrapping `chess-corners` and `calib-targets`.
+- **B3** Calibration runner with live progress streaming via Tauri events.
+- **B4** 3D rig viewer (Three.js / React Three Fiber: camera frustums, target poses,
+  laser plane).
+- **B5** **Diagnose mode — the MVP.** Per-feature reprojection arrows, per-image residual
+  heatmaps, drill-down, coordinated highlighting between 2D image, 3D scene, and sidebar.
+  Depends on A2.
+- **B6** Production polish — wizard, settings persistence, signed installers per OS.
+
+### Track C — MVG (postponed; depends on B5 done)
+
+PR #28 splits two-view geometry into `vision-geometry` (deterministic solvers) and
+`vision-mvg` (pipelines, robust estimation). Post-merge the track extends to multi-view
+geometry over already-calibrated rigs. ADR 0014 will cap the ceiling explicitly: no
+in-house dense matcher, no full SfM.
+
+- **C1** Land PR #28.
+- **C2** N-view triangulation + nonlinear refinement.
+- **C3** Bundle adjustment with frozen intrinsics, free poses, free structure.
+- **C4** Stereo rectification — including **Scheimpflug-aware rectification** (genuinely
+  novel for this project).
+- **C5** Dense matcher integration behind a `dense-opencv` feature flag, wrapping
+  `opencv-rust` SGBM.
+- **C-UI** MVG visualizations layered into the Tauri app (point clouds, depth maps,
+  rectified pairs).
+
+### Track D — Earn v1.0 (continuous ratchet)
+
+- **D1** Typed errors only — no `String`-typed escape hatches in public APIs.
+- **D2** Doc-warning-free, MSRV 1.88 frozen.
+- **D3** Python binding parity audited at every minor version bump.
+- **D4** v1.0 release once all puzzle rig phases run green via the Tauri app, PRs #27 and
+  #28 + A2 + B5 + C4 have all landed, and the API has been stable across two minor releases.
+
+## Sequencing
+
+```
+Weeks 1–2:    A1 (PR #27 rebase + land)   +  B0 (Tauri scaffolding)
+Weeks 3–6:    A2, A3                      +  B1 (file load) → B2 (detection)
+Weeks 7–12:   A4, A5, A6 cleanup          +  B3 (runner) → B4 (3D viewer)
+Weeks 13–24:  (A done)                    +  B5 — the MVP
+Weeks 25+:                                   B6 polish + C1 (PR #28 land)
+Weeks 28–40:                                                C2 → C3 → C4 → C5
+Weeks 40+:                                                                   D-ratchets, v1.0
+```
+
+Load-bearing path: **A1 → A2 → B5**. A1 unblocks the rig immediately. A2 is the small
+schema extension that gates the diagnose UI. Everything else is parallelizable cleanup or
+future ambition.
+
+## Out of scope (explicit)
+
+- New camera models (fisheye / Kannala-Brandt, omnidirectional, double-sphere, telecentric,
+  spline). Defer until a concrete project demands one.
+- In-house dense stereo matching. External (`opencv-rust` SGBM) only.
+- Full structure-from-motion (incremental SfM, pose graph, loop closure).
+- `rerun.io` / `egui` as the UI.
+- OSS-grade community surface and multi-platform install docs (internal-first; defer until
+  the tool earns it).
+- What-if interactive re-optimize (B6 stretch at earliest).
+
+## See also
+
+- [ADR index](adrs/README.md) — design records.
+- [MSRV notes](MSRV.md) — why the lockfile is frozen below latest releases.
+- Per-track ADRs: `0011-manual-initialization-workflow.md` (A1, ships with PR #27);
+  `0012-per-feature-residuals.md` (A2, pending); `0013-tauri-desktop-app.md` (B0, pending);
+  `0014-mvg-ceiling.md` (C1, pending).

--- a/docs/adrs/0011-manual-initialization-workflow.md
+++ b/docs/adrs/0011-manual-initialization-workflow.md
@@ -1,0 +1,137 @@
+# ADR 0011: Manual Parameter Initialization Workflow
+
+- Status: Accepted
+- Date: 2026-03-15 (revised 2026-04-29)
+
+## Context
+
+In industrial calibration environments, users often have prior knowledge of camera parameters —
+focal lengths from datasheets, sensor tilt angles from factory measurements, laser plane geometry
+from mechanical drawings. The default pipeline always runs automatic linear initialization (Zhang's
+method, Tsai-Lenz DLT), which may produce poor starting points for non-linear optimization when
+the auto-init quality is limited (e.g., narrow baseline, few views, large tilt angles, real-data
+homography conditioning issues).
+
+A concrete failure mode this ADR unblocks: the puzzle 130x130 rig sees Zhang's method fail on a
+specific camera with "invalid sign for lambda; check homographies" — the user has no way to seed
+that camera's intrinsics from datasheet values without rewriting the pipeline.
+
+## Decision
+
+Add a `step_set_init()` function (and per-stage variants for multi-stage problem types) alongside
+the existing `step_init()`:
+
+```rust
+// Automatic path (unchanged):
+step_init(&mut session, None)?;
+step_optimize(&mut session, None)?;
+
+// Manual path:
+step_set_init(&mut session, PlanarManualInit {
+    intrinsics: Some(nominal_camera_k),
+    distortion: None,  // auto-initialized (or zeros when intrinsics seeded)
+    poses: None,       // auto-recovered from homographies using manual intrinsics
+}, None)?;
+step_optimize(&mut session, None)?;
+```
+
+**Behavioral contract**:
+
+1. `step_set_init(session, manual, opts)` seeds any provided fields into the session state, then
+   auto-initializes all remaining fields using the same routines as `step_init`.
+2. After `step_set_init` returns, the session state is fully initialized — same postcondition as
+   `step_init`. `step_optimize` requires no changes.
+3. `step_init(session, opts)` is refactored to call
+   `step_set_init(session, ManualInit::default(), opts)`, preserving its existing signature and
+   behavior.
+4. For problem types with multiple init stages (SingleCamHandeye, RigExtrinsics, RigHandeye, the
+   Scheimpflug rig variants), each stage gets its own `step_set_*` function with a corresponding
+   typed `ManualInit` struct.
+
+**ManualInit struct rules**:
+
+- All fields are `Option<T>`. `None` means "auto-initialize this group"; `Some(value)` means "use
+  this value verbatim, do not auto-initialize".
+- Derive `Debug`, `Clone`, `Default`, `serde::Serialize`, `serde::Deserialize`. Serde is required
+  for Python binding deserialization via `pythonize` and for JSON config files.
+- Do NOT apply `#[non_exhaustive]` — users construct these with `..Default::default()` and
+  `#[non_exhaustive]` breaks that pattern across crate boundaries.
+- Placed in `steps.rs` alongside the step functions; re-exported from `mod.rs`.
+
+**Partial initialization semantics**:
+
+- When `intrinsics` is provided manually but `poses` is `None`, poses are auto-recovered from
+  per-view homographies using the **manually provided intrinsics** (not auto-estimated ones). This
+  keeps the geometric chain consistent with the seed.
+- When `intrinsics` is seeded and `distortion` is `None`, distortion defaults to
+  `BrownConrady5::default()` (zeros) — the auto distortion fit is coupled with iterative
+  intrinsics estimation and does not run when intrinsics are seeded.
+- Workflow-specific zeroing (e.g., Scheimpflug pipelines fix tangential distortion `p1=p2=0`) only
+  applies on the auto path. When the user supplies a manual `distortion`, they get exactly what
+  they pass.
+- The init log entry records which fields were manual vs auto, e.g.:
+  `"init: fx=800.0, fy=780.0 ... (manual: intrinsics; auto: distortion, poses)"`.
+
+**RigExtrinsics coupling rule**:
+
+`cam_se3_rig` and `rig_se3_target` are geometrically coupled; providing one without the other is
+ambiguous. The corresponding `ManualInit` for the rig stage requires both or neither, enforced at
+runtime with a clear `Error::InvalidInput` message and a `log_failure` entry. This rule applies to
+`RigExtrinsicsManualInit`, `RigHandeyeRigManualInit`, `RigScheimpflugExtrinsicsRigManualInit`, and
+`RigScheimpflugHandeyeRigManualInit`.
+
+**Sensor model exception (LaserlineDevice)**:
+
+For `LaserlineDevice`, the sensor model is a hardware property (not a calibrated parameter) and is
+always taken from `session.config.init.sensor_init` regardless of manual init. The corresponding
+`LaserlineDeviceManualInit` struct intentionally omits a `sensor` field.
+
+## Implementation status (2026-04-29)
+
+All nine problem types support manual init. Per-problem types and their step_set_* functions:
+
+| Problem type                  | ManualInit type(s)                                                 |
+|-------------------------------|---------------------------------------------------------------------|
+| `PlanarIntrinsics`            | `PlanarManualInit`                                                  |
+| `ScheimpflugIntrinsics`       | `ScheimpflugManualInit`                                             |
+| `LaserlineDevice`             | `LaserlineDeviceManualInit` (sensor excluded)                       |
+| `SingleCamHandeye`            | `SingleCamIntrinsicsManualInit` + `SingleCamHandeyeManualInit`      |
+| `RigExtrinsics`               | `RigIntrinsicsManualInit` + `RigExtrinsicsManualInit`               |
+| `RigHandeye`                  | `RigHandeyeIntrinsicsManualInit` + `RigHandeyeRigManualInit` + `RigHandeyeHandeyeManualInit` |
+| `RigScheimpflugExtrinsics`    | `RigScheimpflugIntrinsicsManualInit` + `RigScheimpflugExtrinsicsRigManualInit` |
+| `RigScheimpflugHandeye`       | `RigScheimpflugHandeyeIntrinsicsManualInit` + `RigScheimpflugHandeyeRigManualInit` + `RigScheimpflugHandeyeHandeyeManualInit` |
+| `RigLaserlineDevice`          | `RigLaserlineDeviceManualInit` (planes only)                        |
+
+The `RigScheimpflugHandeye` intrinsics stage internally delegates to the existing
+`step_intrinsics_init_all` with `manual` seeds temporarily injected into
+`config.intrinsics.initial_cameras` / `initial_sensors` (preserving Zhang+fallback logic).
+`per_cam_distortion` only takes effect when `per_cam_intrinsics` is also seeded for that problem
+type.
+
+## Consequences
+
+Positive:
+
+- Expert users can bypass unreliable auto-init for specific parameter groups.
+- `step_init` backward compatibility is maintained (same signature, same behavior).
+- `step_optimize` requires no changes.
+- Typing is per-problem and discoverable via rustdoc and IDE completion.
+- Init source recorded in session log (auditable, human-readable).
+- Unblocks the puzzle 130x130 rig's stuck Zhang's-init failure on real data.
+
+Negative:
+
+- Each problem module grows by one or more structs and step_set_* functions.
+- Users who provide incorrect manual seeds may get worse results — no automatic validation of
+  physical plausibility beyond cardinality checks (length matches num_cameras / num_views) and the
+  RigExtrinsics coupling rule.
+
+## Required follow-up
+
+- Python bindings for the `ManualInit` types across all problem types (matching the typed
+  warm-start pattern landed in commit `8351680` for `LaserlinePlane` in `RigLaserlineDeviceInput`).
+- Add a regression test using the puzzle rig real-data dataset that confirms manual intrinsics
+  seeding for the failing camera produces a successful end-to-end calibration.
+- Promote `RigScheimpflugHandeye`'s intrinsics-stage manual init from the temp-config-mutation
+  delegate pattern to a direct seed-driven path once the Zhang fallback logic is factored out into
+  a shared helper.


### PR DESCRIPTION
## Summary

Rewrites PR #27's manual init / warm-start work fresh on top of current `main`.
The original PR was authored 2026-03-15 against the retired M-numbered milestone
workflow with `anyhow::Result` and 6 problem types — both incompatible with
current `main` (typed `crate::Error`, 9 problem types, intentional deletion of
`docs/backlog.md`). 13 conflicting files made a mechanical rebase too risky;
this branch reimplements ADR 0011's design directly on current main.

**Scope**: every problem type now supports manual parameter initialization for
each of its init stages, per ADR 0011's per-stage rule.

| Problem type                  | ManualInit struct(s) added                                          |
|-------------------------------|---------------------------------------------------------------------|
| `PlanarIntrinsics`            | `PlanarManualInit`                                                  |
| `ScheimpflugIntrinsics`       | `ScheimpflugManualInit`                                             |
| `LaserlineDevice`             | `LaserlineDeviceManualInit` (sensor excluded)                       |
| `SingleCamHandeye`            | `SingleCamIntrinsicsManualInit`, `SingleCamHandeyeManualInit`       |
| `RigExtrinsics`               | `RigIntrinsicsManualInit`, `RigExtrinsicsManualInit`                |
| `RigHandeye`                  | `RigHandeyeIntrinsicsManualInit`, `RigHandeyeRigManualInit`, `RigHandeyeHandeyeManualInit` |
| `RigScheimpflugExtrinsics`    | `RigScheimpflugIntrinsicsManualInit`, `RigScheimpflugExtrinsicsRigManualInit` |
| `RigScheimpflugHandeye`       | three `RigScheimpflugHandeye*ManualInit` structs                    |
| `RigLaserlineDevice`          | `RigLaserlineDeviceManualInit` (planes only)                        |

For each stage, a new `step_set_*` function holds the load-bearing logic; the
existing `step_*` is refactored to a thin delegate with `ManualInit::default()`
so existing callers keep working unchanged.

Also includes:
- Updated `docs/adrs/0011-manual-initialization-workflow.md` (salvaged from #27,
  revised for current state).
- New `docs/ROADMAP.md` — canonical short-form roadmap (4 tracks: calibration,
  Tauri+React+TS desktop app, MVG, earn-v1.0).

## Why this matters

The puzzle 130x130 rig project is structurally complete (Phases A–E landed) but
blocked on Zhang's intrinsics init failing on a specific real-data camera with
"invalid sign for lambda; check homographies." This PR is the literal unblocker:
the user can now seed that camera's intrinsics from datasheet values via
`RigScheimpflugIntrinsicsManualInit::per_cam_intrinsics`, bypass Zhang for that
camera, and let the rest auto-init normally.

## Notable design choices

- **All-`Option<T>` ManualInit fields**, no `#[non_exhaustive]` (breaks
  `..Default::default()` ergonomics across crate boundaries).
- **Serde derives required** on every `ManualInit` for Python binding
  deserialization via `pythonize`.
- **Partial-seed semantics**: when intrinsics are seeded but poses are not,
  poses recover from per-view homographies using the *manual* intrinsics —
  geometric consistency. When intrinsics are seeded and distortion is not,
  distortion defaults to `BrownConrady5::default()`.
- **RigExtrinsics coupling rule** (ADR 0011): `cam_se3_rig` and
  `rig_se3_target` are geometrically coupled; both-or-neither, enforced at
  runtime.
- **Sensor exception** for `LaserlineDevice`: sensor is a hardware property
  read from `session.config.init.sensor_init`, not a `ManualInit` field.
- **Init source is recorded in the session log** —
  `"(manual: intrinsics; auto: distortion, poses)"`.
- **`RigScheimpflugHandeye` intrinsics-stage caveat**: that problem type
  already had a manual-init mechanism via `config.intrinsics.initial_cameras`
  with Zhang+fallback logic. The new `step_set_intrinsics_init_all` injects
  manual seeds into those config fields temporarily and delegates, preserving
  the existing fallback behavior. Promoting this to a direct seed-driven path
  is documented as future work in ADR 0011.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` clean — all existing tests pass through the
  delegation; new manual-init tests added for `planar_intrinsics` and
  `scheimpflug_intrinsics`
- [x] `cargo doc --workspace --no-deps` clean
- [ ] Real-data integration test on the puzzle rig dataset (deferred — needs
      Python bindings parity in a follow-up PR)

## Follow-up (separate PRs)

- Python bindings for the new `*ManualInit` types (matching the typed
  warm-start pattern in commit `8351680`).
- Real-data regression test using the puzzle rig's failing-camera dataset.
- Promote `RigScheimpflugHandeye` intrinsics-stage manual init from delegate to
  direct seed-driven path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)