### PR TITLE
Per-feature residuals follow-ups: 6 remaining exports + tutorials

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -109,7 +109,10 @@ be re-pinned manually after any update.
 
 ## Planning
 
-- 10 ADRs (0001–0010) in `docs/adrs/` — design decisions (see README there)
+- ADRs in `docs/adrs/` — design decisions (see README there). 0011 covers
+  manual init (PR #32), 0012 covers per-feature residuals (PR #33 + follow-ups).
+- Tutorials in `docs/tutorials/` — hands-on onboarding for new users. New
+  features should ship with a tutorial entry.
 - Automated workflow skills: `/orchestrate`, `/architect`, `/implement`, `/review`, `/gate-check`
 
 ## Strategic Roadmap (>40 weeks)

--- a/crates/vision-calibration-core/src/lib.rs
+++ b/crates/vision-calibration-core/src/lib.rs
@@ -346,8 +346,8 @@ pub fn compute_rig_reprojection_stats_per_camera<Meta>(
 /// # Errors
 ///
 /// Returns [`Error::InvalidInput`] if `camera_se3_target.len() != dataset.num_views()`.
-pub fn compute_planar_target_residuals(
-    camera: &PinholeCamera,
+pub fn compute_planar_target_residuals<C: CameraProject>(
+    camera: &C,
     dataset: &PlanarDataset,
     camera_se3_target: &[Iso3],
 ) -> Result<Vec<TargetFeatureResidual>, Error> {
@@ -358,11 +358,15 @@ pub fn compute_planar_target_residuals(
 /// `&[View<Meta>]` slice. Useful when the input dataset carries metadata
 /// (e.g., laser pixels) that the planar dataset wrapper does not preserve.
 ///
+/// `camera` is anything that implements [`CameraProject`] — the standard
+/// `PinholeCamera` and the Scheimpflug-tilted [`Camera`] variants both
+/// qualify.
+///
 /// # Errors
 ///
 /// Returns [`Error::InvalidInput`] if `camera_se3_target.len() != views.len()`.
-pub fn compute_planar_target_residuals_views<Meta>(
-    camera: &PinholeCamera,
+pub fn compute_planar_target_residuals_views<C: CameraProject, Meta>(
+    camera: &C,
     views: &[View<Meta>],
     camera_se3_target: &[Iso3],
 ) -> Result<Vec<TargetFeatureResidual>, Error> {
@@ -385,7 +389,7 @@ pub fn compute_planar_target_residuals_views<Meta>(
             .enumerate()
         {
             let p_cam = pose * p3d;
-            let (projected_px, error_px) = match camera.project_point_c(&p_cam.coords) {
+            let (projected_px, error_px) = match camera.project_camera_point(&p_cam.coords) {
                 Some(proj) => {
                     let err = (proj - *p2d).norm();
                     (Some([proj.x, proj.y]), Some(err))
@@ -415,18 +419,25 @@ pub fn compute_planar_target_residuals_views<Meta>(
 /// `points_3d`. Failed projections become records with `projected_px` and
 /// `error_px` set to `None`.
 ///
+/// `cameras` may be a slice of any concrete camera type implementing
+/// [`CameraProject`] — the standard `PinholeCamera` and Scheimpflug-tilted
+/// `Camera` variants both qualify.
+///
 /// # Errors
 ///
 /// Returns [`Error::InvalidInput`] if any of:
 /// - `cameras.len() != dataset.num_cameras`
 /// - `cam_se3_rig.len() != dataset.num_cameras`
 /// - `rig_se3_target.len() != dataset.num_views()`.
-pub fn compute_rig_target_residuals<Meta>(
-    cameras: &[PinholeCamera],
+pub fn compute_rig_target_residuals<C, Meta>(
+    cameras: &[C],
     dataset: &RigDataset<Meta>,
     cam_se3_rig: &[Iso3],
     rig_se3_target: &[Iso3],
-) -> Result<Vec<TargetFeatureResidual>, Error> {
+) -> Result<Vec<TargetFeatureResidual>, Error>
+where
+    C: CameraProject,
+{
     if cameras.len() != dataset.num_cameras {
         return Err(Error::invalid_input(format!(
             "camera count {} != num_cameras {}",
@@ -462,7 +473,7 @@ pub fn compute_rig_target_residuals<Meta>(
                 obs.points_3d.iter().zip(obs.points_2d.iter()).enumerate()
             {
                 let p_cam = cam_se3_target * p3d;
-                let (projected_px, error_px) = match cam.project_point_c(&p_cam.coords) {
+                let (projected_px, error_px) = match cam.project_camera_point(&p_cam.coords) {
                     Some(proj) => {
                         let err = (proj - *p2d).norm();
                         (Some([proj.x, proj.y]), Some(err))

--- a/crates/vision-calibration-core/src/models/camera.rs
+++ b/crates/vision-calibration-core/src/models/camera.rs
@@ -3,6 +3,32 @@ use serde::{Deserialize, Serialize};
 
 use super::{DistortionModel, IntrinsicsModel, ProjectionModel, SensorModel};
 
+/// Tiny abstraction over "anything that can project a 3D point in camera
+/// frame to a 2D pixel".
+///
+/// Implemented by [`Camera<f64, _, _, _, _>`] (and therefore by
+/// [`crate::PinholeCamera`] and the Scheimpflug variants used elsewhere in
+/// the workspace), this trait lets per-feature residual helpers in
+/// `vision_calibration_core` operate on any pinhole-style camera regardless
+/// of distortion or sensor configuration.
+pub trait CameraProject {
+    /// Project a 3D point in camera coordinates into pixel coordinates.
+    /// Returns `None` if the point is behind the camera or projection fails.
+    fn project_camera_point(&self, p_c: &Vector3<f64>) -> Option<Point2<f64>>;
+}
+
+impl<P, D, Sm, K> CameraProject for Camera<f64, P, D, Sm, K>
+where
+    P: ProjectionModel<f64>,
+    D: DistortionModel<f64>,
+    Sm: SensorModel<f64>,
+    K: IntrinsicsModel<f64>,
+{
+    fn project_camera_point(&self, p_c: &Vector3<f64>) -> Option<Point2<f64>> {
+        self.project_point_c(p_c)
+    }
+}
+
 /// A camera ray represented by its intersection with the z = 1 plane.
 #[derive(Clone, Copy, Debug)]
 pub struct Ray<S: RealField + Copy> {

--- a/crates/vision-calibration-optim/src/lib.rs
+++ b/crates/vision-calibration-optim/src/lib.rs
@@ -176,7 +176,7 @@ pub use crate::problems::scheimpflug_intrinsics::{
 
 pub use crate::problems::handeye::{
     HandEyeDataset, HandEyeEstimate, HandEyeParams, HandEyeSolveOptions, RobotPoseMeta,
-    handeye_observer_se3_target, optimize_handeye,
+    apply_robot_delta, handeye_observer_se3_target, optimize_handeye,
 };
 
 pub use crate::problems::handeye_scheimpflug::{

--- a/crates/vision-calibration-optim/src/lib.rs
+++ b/crates/vision-calibration-optim/src/lib.rs
@@ -176,7 +176,7 @@ pub use crate::problems::scheimpflug_intrinsics::{
 
 pub use crate::problems::handeye::{
     HandEyeDataset, HandEyeEstimate, HandEyeParams, HandEyeSolveOptions, RobotPoseMeta,
-    optimize_handeye,
+    handeye_observer_se3_target, optimize_handeye,
 };
 
 pub use crate::problems::handeye_scheimpflug::{

--- a/crates/vision-calibration-optim/src/lib.rs
+++ b/crates/vision-calibration-optim/src/lib.rs
@@ -197,7 +197,7 @@ pub use crate::problems::rig_extrinsics_scheimpflug::{
 
 pub use crate::problems::laserline_rig_bundle::{
     RigLaserlineDataset, RigLaserlineEstimate, RigLaserlineSolveOptions, RigLaserlineUpstream,
-    RigLaserlineView, optimize_rig_laserline,
+    RigLaserlineView, compute_rig_laserline_feature_residuals, optimize_rig_laserline,
 };
 
 pub use crate::problems::laserline_bundle::{

--- a/crates/vision-calibration-optim/src/problems/handeye.rs
+++ b/crates/vision-calibration-optim/src/problems/handeye.rs
@@ -169,6 +169,29 @@ pub struct HandEyeEstimate {
     pub per_cam_reproj_errors: Vec<f64>,
 }
 
+/// Apply a per-view se(3) robot pose correction `[rx, ry, rz, tx, ty, tz]` to
+/// a base-to-gripper pose, mirroring the convention the hand-eye optimizer
+/// uses internally:
+///
+/// `T_B_G_corr = exp(delta) * T_B_G`  (left-multiply; matches
+/// `crates/vision-calibration-optim/src/factors/reprojection_model.rs`).
+///
+/// A delta of all zeros returns `base_se3_gripper` unchanged.
+pub fn apply_robot_delta(base_se3_gripper: &Iso3, delta: &[Real; 6]) -> Iso3 {
+    use nalgebra::{Translation3, Unit, UnitQuaternion, Vector3};
+
+    let rot_vec = Vector3::new(delta[0], delta[1], delta[2]);
+    let trans_vec = Vector3::new(delta[3], delta[4], delta[5]);
+    let angle = rot_vec.norm();
+    let delta_rot = if angle > 1e-12 {
+        UnitQuaternion::from_axis_angle(&Unit::new_normalize(rot_vec), angle)
+    } else {
+        UnitQuaternion::identity()
+    };
+    let delta_iso = Iso3::from_parts(Translation3::from(trans_vec), delta_rot);
+    delta_iso * base_se3_gripper
+}
+
 /// Derive per-view "observer-to-target" poses from a hand-eye chain.
 ///
 /// The returned slice parallels `base_se3_gripper`: index `i` gives the
@@ -181,6 +204,12 @@ pub struct HandEyeEstimate {
 /// - `EyeToHand`: `handeye = T_R_B` (or `T_C_B` for single-camera) and
 ///   `mode_target_pose = T_G_T`. Result: `T_R_T_i = handeye * T_B_G_i * T_G_T`.
 ///
+/// When `robot_deltas` is `Some`, each `T_B_G_i` is first corrected via
+/// [`apply_robot_delta`] before being plugged into the chain. This matches
+/// the pose corrections the hand-eye optimizer applies internally when
+/// `refine_robot_poses = true`. Pass `None` to use the raw input poses
+/// unchanged.
+///
 /// For single-camera workflows the observer frame *is* the camera, so the
 /// returned poses are `T_C_T` directly. For multi-camera rigs the caller
 /// must compose with `cam_se3_rig` to project per camera.
@@ -189,12 +218,20 @@ pub fn handeye_observer_se3_target(
     handeye: &Iso3,
     mode_target_pose: &Iso3,
     base_se3_gripper: &[Iso3],
+    robot_deltas: Option<&[[Real; 6]]>,
 ) -> Vec<Iso3> {
     base_se3_gripper
         .iter()
-        .map(|tbg| match mode {
-            HandEyeMode::EyeInHand => handeye.inverse() * tbg.inverse() * mode_target_pose,
-            HandEyeMode::EyeToHand => handeye * tbg * mode_target_pose,
+        .enumerate()
+        .map(|(i, tbg)| {
+            let tbg_corr = match robot_deltas {
+                Some(deltas) if i < deltas.len() => apply_robot_delta(tbg, &deltas[i]),
+                _ => *tbg,
+            };
+            match mode {
+                HandEyeMode::EyeInHand => handeye.inverse() * tbg_corr.inverse() * mode_target_pose,
+                HandEyeMode::EyeToHand => handeye * tbg_corr * mode_target_pose,
+            }
         })
         .collect()
 }

--- a/crates/vision-calibration-optim/src/problems/handeye.rs
+++ b/crates/vision-calibration-optim/src/problems/handeye.rs
@@ -169,6 +169,36 @@ pub struct HandEyeEstimate {
     pub per_cam_reproj_errors: Vec<f64>,
 }
 
+/// Derive per-view "observer-to-target" poses from a hand-eye chain.
+///
+/// The returned slice parallels `base_se3_gripper`: index `i` gives the
+/// target pose in the observer frame (camera for single-cam, rig for
+/// rig-based problems) for view `i`.
+///
+/// Mode-dependent semantics:
+/// - `EyeInHand`: `handeye = T_G_R` (or `T_G_C` for single-camera) and
+///   `mode_target_pose = T_B_T`. Result: `T_R_T_i = handeye^-1 * T_G_B_i * T_B_T`.
+/// - `EyeToHand`: `handeye = T_R_B` (or `T_C_B` for single-camera) and
+///   `mode_target_pose = T_G_T`. Result: `T_R_T_i = handeye * T_B_G_i * T_G_T`.
+///
+/// For single-camera workflows the observer frame *is* the camera, so the
+/// returned poses are `T_C_T` directly. For multi-camera rigs the caller
+/// must compose with `cam_se3_rig` to project per camera.
+pub fn handeye_observer_se3_target(
+    mode: HandEyeMode,
+    handeye: &Iso3,
+    mode_target_pose: &Iso3,
+    base_se3_gripper: &[Iso3],
+) -> Vec<Iso3> {
+    base_se3_gripper
+        .iter()
+        .map(|tbg| match mode {
+            HandEyeMode::EyeInHand => handeye.inverse() * tbg.inverse() * mode_target_pose,
+            HandEyeMode::EyeToHand => handeye * tbg * mode_target_pose,
+        })
+        .collect()
+}
+
 /// Optimize hand-eye calibration using specified backend.
 ///
 /// # Errors

--- a/crates/vision-calibration-optim/src/problems/laserline_rig_bundle.rs
+++ b/crates/vision-calibration-optim/src/problems/laserline_rig_bundle.rs
@@ -31,11 +31,13 @@ use crate::backend::BackendSolveOptions;
 use crate::params::laser_plane::LaserPlane;
 use crate::problems::laserline_bundle::{
     LaserlineMeta, LaserlineParams, LaserlineResidualType, LaserlineSolveOptions, LaserlineStats,
-    LaserlineView, compute_laserline_stats, optimize_laserline,
+    LaserlineView, compute_laserline_stats, laser_line_endpoints_px,
+    laser_point_to_plane_residual_m, optimize_laserline, point_line_distance,
 };
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, Pt2, Real, ScheimpflugParams, View,
+    BrownConrady5, Camera, CorrespondenceView, FxFyCxCySkew, Iso3, LaserFeatureResidual, Pinhole,
+    Pt2, Real, ScheimpflugParams, View,
 };
 
 /// Per-view observations for a rig-level laserline calibration.
@@ -174,6 +176,85 @@ impl Default for RigLaserlineSolveOptions {
             laser_residual_type: LaserlineResidualType::default(),
         }
     }
+}
+
+/// Compute per-pixel laser residual records for every laser observation in a
+/// rig dataset, indexed pose-major then by camera then by pixel.
+///
+/// Like [`super::laserline_bundle::compute_laserline_feature_residuals`] but
+/// fans out across all cameras of a rig: each (view, cam_idx, pixel_idx)
+/// triple becomes one [`LaserFeatureResidual`] tagged with its triple. None
+/// slots in `dataset.views[v].laser_pixels[c]` produce no records.
+///
+/// `cam_se3_target_per_view_cam[v][c]` is the camera-frame target pose for
+/// view `v`, camera `c`, derived by composing `cam_se3_rig[c] *
+/// rig_se3_target[v]`. Cameras are reconstructed from `intrinsics`,
+/// `distortion`, and `sensors`.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidInput`] if the per-camera or per-view slice
+/// lengths are inconsistent with the dataset shape.
+pub fn compute_rig_laserline_feature_residuals(
+    dataset: &RigLaserlineDataset,
+    intrinsics: &[FxFyCxCySkew<Real>],
+    distortion: &[BrownConrady5<Real>],
+    sensors: &[ScheimpflugParams],
+    cam_se3_rig: &[Iso3],
+    rig_se3_target: &[Iso3],
+    laser_planes_cam: &[LaserPlane],
+) -> Result<Vec<LaserFeatureResidual>, Error> {
+    let n = dataset.num_cameras;
+    if intrinsics.len() != n
+        || distortion.len() != n
+        || sensors.len() != n
+        || cam_se3_rig.len() != n
+        || laser_planes_cam.len() != n
+    {
+        return Err(Error::invalid_input(format!(
+            "per-camera slice length mismatch (expected {n})"
+        )));
+    }
+    if rig_se3_target.len() != dataset.num_views() {
+        return Err(Error::invalid_input(format!(
+            "rig_se3_target has {} entries, expected {}",
+            rig_se3_target.len(),
+            dataset.num_views()
+        )));
+    }
+
+    let cameras: Vec<_> = (0..n)
+        .map(|c| Camera::new(Pinhole, distortion[c], sensors[c].compile(), intrinsics[c]))
+        .collect();
+
+    let mut out = Vec::new();
+    for (view_idx, view) in dataset.views.iter().enumerate() {
+        for cam_idx in 0..n {
+            let Some(pixels) = view.laser_pixels.get(cam_idx).and_then(|p| p.as_ref()) else {
+                continue;
+            };
+            let cam_se3_target = cam_se3_rig[cam_idx] * rig_se3_target[view_idx];
+            let camera = &cameras[cam_idx];
+            let plane = &laser_planes_cam[cam_idx];
+            let line_endpoints = laser_line_endpoints_px(camera, &cam_se3_target, plane);
+            for (feature_idx, px) in pixels.iter().enumerate() {
+                let residual_m =
+                    laser_point_to_plane_residual_m(camera, &cam_se3_target, plane, px);
+                let residual_px =
+                    line_endpoints.map(|line| point_line_distance([px.x, px.y], line));
+                out.push(LaserFeatureResidual {
+                    pose: view_idx,
+                    camera: cam_idx,
+                    feature: feature_idx,
+                    observed_px: [px.x, px.y],
+                    residual_m,
+                    residual_px,
+                    projected_line_px: line_endpoints,
+                });
+            }
+        }
+    }
+    Ok(out)
 }
 
 /// Result of rig-level laserline calibration.

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -394,8 +394,13 @@ impl ProblemType for RigHandeyeProblem {
             .iter()
             .map(|v| v.meta.base_se3_gripper)
             .collect();
-        let rig_se3_target =
-            handeye_observer_se3_target(mode, &output.params.handeye, &target_pose, &robot_poses);
+        let rig_se3_target = handeye_observer_se3_target(
+            mode,
+            &output.params.handeye,
+            &target_pose,
+            &robot_poses,
+            output.robot_deltas.as_deref(),
+        );
         let target = compute_rig_target_residuals(
             &output.params.cameras,
             input,

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -5,9 +5,13 @@
 
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{Iso3, PinholeCamera};
+use vision_calibration_core::{
+    FeatureResidualHistogram, Iso3, PerFeatureResiduals, PinholeCamera, build_feature_histogram,
+    compute_rig_target_residuals,
+};
 use vision_calibration_optim::{
     HandEyeEstimate, HandEyeMode, RigDataset, RobotPoseMeta, RobustLoss,
+    handeye_observer_se3_target,
 };
 #[cfg(test)]
 use vision_calibration_optim::{HandEyeParams, SolveReport};
@@ -207,6 +211,13 @@ pub struct RigHandeyeExport {
 
     /// Per-camera reprojection errors (pixels).
     pub per_cam_reproj_errors: Vec<f64>,
+
+    /// Per-feature reprojection residuals (ADR 0012). Per-view
+    /// `rig_se3_target` is derived from the handeye chain
+    /// (see [`handeye_observer_se3_target`](vision_calibration_optim::handeye_observer_se3_target)),
+    /// then composed with `cam_se3_rig` for projection.
+    #[serde(default)]
+    pub per_feature_residuals: PerFeatureResiduals,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -352,7 +363,7 @@ impl ProblemType for RigHandeyeProblem {
     }
 
     fn export(
-        _input: &Self::Input,
+        input: &Self::Input,
         output: &Self::Output,
         config: &Self::Config,
     ) -> Result<Self::Export, Error> {
@@ -370,18 +381,42 @@ impl ProblemType for RigHandeyeProblem {
             .copied()
             .ok_or_else(|| Error::invalid_input("no target pose in output"))?;
 
-        let (gripper_se3_rig, rig_se3_base, base_se3_target, gripper_se3_target) = match config
-            .handeye_init
-            .handeye_mode
-        {
+        let mode = config.handeye_init.handeye_mode;
+        let (gripper_se3_rig, rig_se3_base, base_se3_target, gripper_se3_target) = match mode {
             HandEyeMode::EyeInHand => (Some(output.params.handeye), None, Some(target_pose), None),
             HandEyeMode::EyeToHand => (None, Some(output.params.handeye), None, Some(target_pose)),
         };
 
+        // Per-feature residuals: derive rig_se3_target per view from the
+        // handeye chain, then project via the per-camera transform.
+        let robot_poses: Vec<Iso3> = input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper)
+            .collect();
+        let rig_se3_target =
+            handeye_observer_se3_target(mode, &output.params.handeye, &target_pose, &robot_poses);
+        let target = compute_rig_target_residuals(
+            &output.params.cameras,
+            input,
+            &cam_se3_rig,
+            &rig_se3_target,
+        )?;
+        let target_hist_per_camera: Vec<FeatureResidualHistogram> = (0..input.num_cameras)
+            .map(|cam_idx| {
+                build_feature_histogram(
+                    target
+                        .iter()
+                        .filter(|r| r.camera == cam_idx)
+                        .filter_map(|r| r.error_px),
+                )
+            })
+            .collect();
+
         Ok(RigHandeyeExport {
             cameras: output.params.cameras.clone(),
             cam_se3_rig,
-            handeye_mode: config.handeye_init.handeye_mode,
+            handeye_mode: mode,
             gripper_se3_rig,
             rig_se3_base,
             base_se3_target,
@@ -389,6 +424,12 @@ impl ProblemType for RigHandeyeProblem {
             robot_deltas: output.robot_deltas.clone(),
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: output.per_cam_reproj_errors.clone(),
+            per_feature_residuals: PerFeatureResiduals {
+                target,
+                laser: Vec::new(),
+                target_hist_per_camera: Some(target_hist_per_camera),
+                laser_hist_per_camera: None,
+            },
         })
     }
 }

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
@@ -3,9 +3,14 @@
 use crate::Error;
 use crate::rig_scheimpflug_handeye::RigScheimpflugHandeyeExport;
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{BrownConrady5, FxFyCxCySkew, Iso3, Real, ScheimpflugParams};
+use vision_calibration_core::{
+    BrownConrady5, Camera, FeatureResidualHistogram, FxFyCxCySkew, Iso3, NoMeta,
+    PerFeatureResiduals, Pinhole, Real, RigDataset, RigView, RigViewObs, ScheimpflugParams,
+    build_feature_histogram, compute_rig_target_residuals,
+};
 use vision_calibration_optim::{
     LaserPlane, LaserlineResidualType, LaserlineStats, RigLaserlineDataset, RigLaserlineEstimate,
+    compute_rig_laserline_feature_residuals,
 };
 
 use crate::session::{InvalidationPolicy, ProblemType};
@@ -97,6 +102,12 @@ pub struct RigLaserlineDeviceExport {
     pub laser_planes_cam: Vec<LaserPlane>,
     /// Per-camera stats (reprojection + laser residuals).
     pub per_camera_stats: Vec<LaserlineStats>,
+    /// Per-feature reprojection + laser residuals (ADR 0012). Multi-camera
+    /// rig: `target` covers per-corner reprojection (when present) and
+    /// `laser` covers per-pixel laser distances. Both per-camera histograms
+    /// are populated.
+    #[serde(default)]
+    pub per_feature_residuals: PerFeatureResiduals,
 }
 
 /// Rig laserline calibration problem.
@@ -164,14 +175,86 @@ impl ProblemType for RigLaserlineDeviceProblem {
     }
 
     fn export(
-        _input: &Self::Input,
+        input: &Self::Input,
         output: &Self::Output,
         _config: &Self::Config,
     ) -> Result<Self::Export, Error> {
+        let n = input.dataset.num_cameras;
+        let upstream = &input.upstream;
+
+        // Build a RigDataset<NoMeta> from the laser dataset's target slot for
+        // target residual computation.
+        let target_dataset = RigDataset::<NoMeta> {
+            num_cameras: n,
+            views: input
+                .dataset
+                .views
+                .iter()
+                .map(|v| RigView {
+                    meta: NoMeta,
+                    obs: RigViewObs {
+                        cameras: v.cameras.clone(),
+                    },
+                })
+                .collect(),
+        };
+        let scheimpflug_cameras: Vec<_> = (0..n)
+            .map(|c| {
+                Camera::new(
+                    Pinhole,
+                    upstream.distortion[c],
+                    upstream.sensors[c].compile(),
+                    upstream.intrinsics[c],
+                )
+            })
+            .collect();
+        let target = compute_rig_target_residuals(
+            &scheimpflug_cameras,
+            &target_dataset,
+            &upstream.cam_se3_rig,
+            &upstream.rig_se3_target,
+        )?;
+        let target_hist_per_camera: Vec<FeatureResidualHistogram> = (0..n)
+            .map(|cam_idx| {
+                build_feature_histogram(
+                    target
+                        .iter()
+                        .filter(|r| r.camera == cam_idx)
+                        .filter_map(|r| r.error_px),
+                )
+            })
+            .collect();
+
+        let laser = compute_rig_laserline_feature_residuals(
+            &input.dataset,
+            &upstream.intrinsics,
+            &upstream.distortion,
+            &upstream.sensors,
+            &upstream.cam_se3_rig,
+            &upstream.rig_se3_target,
+            &output.laser_planes_cam,
+        )?;
+        let laser_hist_per_camera: Vec<FeatureResidualHistogram> = (0..n)
+            .map(|cam_idx| {
+                build_feature_histogram(
+                    laser
+                        .iter()
+                        .filter(|r| r.camera == cam_idx)
+                        .filter_map(|r| r.residual_px),
+                )
+            })
+            .collect();
+
         Ok(RigLaserlineDeviceExport {
             laser_planes_rig: output.laser_planes_rig.clone(),
             laser_planes_cam: output.laser_planes_cam.clone(),
             per_camera_stats: output.per_camera_stats.clone(),
+            per_feature_residuals: PerFeatureResiduals {
+                target,
+                laser,
+                target_hist_per_camera: Some(target_hist_per_camera),
+                laser_hist_per_camera: Some(laser_hist_per_camera),
+            },
         })
     }
 }

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_extrinsics/problem.rs
@@ -2,7 +2,10 @@
 
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{Iso3, NoMeta, PinholeCamera, RigDataset, ScheimpflugParams};
+use vision_calibration_core::{
+    Camera, FeatureResidualHistogram, Iso3, NoMeta, PerFeatureResiduals, Pinhole, PinholeCamera,
+    RigDataset, ScheimpflugParams, build_feature_histogram, compute_rig_target_residuals,
+};
 use vision_calibration_optim::{RigExtrinsicsScheimpflugEstimate, RobustLoss, ScheimpflugFixMask};
 
 use crate::session::{InvalidationPolicy, ProblemType};
@@ -90,6 +93,12 @@ pub struct RigScheimpflugExtrinsicsExport {
     pub mean_reproj_error: f64,
     /// Per-camera reprojection errors (pixels).
     pub per_cam_reproj_errors: Vec<f64>,
+    /// Per-feature reprojection residuals (ADR 0012). Multi-camera Scheimpflug
+    /// rig: `target` is populated, `laser` is empty, `target_hist_per_camera`
+    /// has one entry per camera. Projection uses the full
+    /// pinhole + Brown-Conrady + Scheimpflug chain.
+    #[serde(default)]
+    pub per_feature_residuals: PerFeatureResiduals,
 }
 
 /// Multi-camera Scheimpflug rig extrinsics calibration problem.
@@ -172,7 +181,7 @@ impl ProblemType for RigScheimpflugExtrinsicsProblem {
     }
 
     fn export(
-        _input: &Self::Input,
+        input: &Self::Input,
         output: &Self::Output,
         _config: &Self::Config,
     ) -> Result<Self::Export, Error> {
@@ -182,6 +191,33 @@ impl ProblemType for RigScheimpflugExtrinsicsProblem {
             .iter()
             .map(|t| t.inverse())
             .collect();
+
+        // Build full Scheimpflug-tilted cameras for projection: combine each
+        // pinhole core with the corresponding compiled Scheimpflug sensor.
+        let scheimpflug_cameras: Vec<_> = output
+            .params
+            .cameras
+            .iter()
+            .zip(output.params.sensors.iter())
+            .map(|(cam, sensor)| Camera::new(Pinhole, cam.dist, sensor.compile(), cam.k))
+            .collect();
+        let target = compute_rig_target_residuals(
+            &scheimpflug_cameras,
+            input,
+            &cam_se3_rig,
+            &output.params.rig_from_target,
+        )?;
+        let target_hist_per_camera: Vec<FeatureResidualHistogram> = (0..input.num_cameras)
+            .map(|cam_idx| {
+                build_feature_histogram(
+                    target
+                        .iter()
+                        .filter(|r| r.camera == cam_idx)
+                        .filter_map(|r| r.error_px),
+                )
+            })
+            .collect();
+
         Ok(RigScheimpflugExtrinsicsExport {
             cameras: output.params.cameras.clone(),
             sensors: output.params.sensors.clone(),
@@ -189,6 +225,12 @@ impl ProblemType for RigScheimpflugExtrinsicsProblem {
             rig_se3_target: output.params.rig_from_target.clone(),
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: output.per_cam_reproj_errors.clone(),
+            per_feature_residuals: PerFeatureResiduals {
+                target,
+                laser: Vec::new(),
+                target_hist_per_camera: Some(target_hist_per_camera),
+                laser_hist_per_camera: None,
+            },
         })
     }
 }

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/problem.rs
@@ -398,6 +398,7 @@ impl ProblemType for RigScheimpflugHandeyeProblem {
             &output.params.handeye,
             &target_pose,
             &robot_poses,
+            output.robot_deltas.as_deref(),
         );
         let scheimpflug_cameras: Vec<_> = output
             .params

--- a/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_scheimpflug_handeye/problem.rs
@@ -7,10 +7,13 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    DistortionFixMask, IntrinsicsFixMask, Iso3, PinholeCamera, RigDataset, ScheimpflugParams,
+    Camera, DistortionFixMask, FeatureResidualHistogram, IntrinsicsFixMask, Iso3,
+    PerFeatureResiduals, Pinhole, PinholeCamera, RigDataset, ScheimpflugParams,
+    build_feature_histogram, compute_rig_target_residuals,
 };
 use vision_calibration_optim::{
     HandEyeMode, HandEyeScheimpflugEstimate, RobotPoseMeta, RobustLoss, ScheimpflugFixMask,
+    handeye_observer_se3_target,
 };
 
 use crate::session::{InvalidationPolicy, ProblemType};
@@ -252,6 +255,12 @@ pub struct RigScheimpflugHandeyeExport {
     pub mean_reproj_error: f64,
     /// Per-camera reprojection errors.
     pub per_cam_reproj_errors: Vec<f64>,
+
+    /// Per-feature reprojection residuals (ADR 0012). Per-view
+    /// `rig_se3_target` is derived from the handeye chain; projection uses
+    /// the full pinhole + Brown-Conrady + Scheimpflug chain.
+    #[serde(default)]
+    pub per_feature_residuals: PerFeatureResiduals,
 }
 
 /// Multi-camera Scheimpflug rig hand-eye calibration problem.
@@ -348,7 +357,7 @@ impl ProblemType for RigScheimpflugHandeyeProblem {
     }
 
     fn export(
-        _input: &Self::Input,
+        input: &Self::Input,
         output: &Self::Output,
         config: &Self::Config,
     ) -> Result<Self::Export, Error> {
@@ -377,6 +386,43 @@ impl ProblemType for RigScheimpflugHandeyeProblem {
                 }
             };
 
+        // Per-feature residuals: derive rig_se3_target per view from the
+        // handeye chain, build full Scheimpflug-tilted cameras, project.
+        let robot_poses: Vec<Iso3> = input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper)
+            .collect();
+        let rig_se3_target = handeye_observer_se3_target(
+            handeye_mode,
+            &output.params.handeye,
+            &target_pose,
+            &robot_poses,
+        );
+        let scheimpflug_cameras: Vec<_> = output
+            .params
+            .cameras
+            .iter()
+            .zip(output.params.sensors.iter())
+            .map(|(cam, sensor)| Camera::new(Pinhole, cam.dist, sensor.compile(), cam.k))
+            .collect();
+        let target = compute_rig_target_residuals(
+            &scheimpflug_cameras,
+            input,
+            &cam_se3_rig,
+            &rig_se3_target,
+        )?;
+        let target_hist_per_camera: Vec<FeatureResidualHistogram> = (0..input.num_cameras)
+            .map(|cam_idx| {
+                build_feature_histogram(
+                    target
+                        .iter()
+                        .filter(|r| r.camera == cam_idx)
+                        .filter_map(|r| r.error_px),
+                )
+            })
+            .collect();
+
         Ok(RigScheimpflugHandeyeExport {
             cameras: output.params.cameras.clone(),
             sensors: output.params.sensors.clone(),
@@ -389,6 +435,12 @@ impl ProblemType for RigScheimpflugHandeyeProblem {
             robot_deltas: output.robot_deltas.clone(),
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: output.per_cam_reproj_errors.clone(),
+            per_feature_residuals: PerFeatureResiduals {
+                target,
+                laser: Vec::new(),
+                target_hist_per_camera: Some(target_hist_per_camera),
+                laser_hist_per_camera: None,
+            },
         })
     }
 }

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
@@ -3,7 +3,8 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraParams, DistortionFixMask, IntrinsicsFixMask, Iso3, PlanarDataset,
+    CameraParams, DistortionFixMask, IntrinsicsFixMask, Iso3, PerFeatureResiduals, PlanarDataset,
+    build_feature_histogram, compute_planar_target_residuals,
 };
 use vision_calibration_optim::{RobustLoss, SolveReport};
 
@@ -116,6 +117,11 @@ pub struct ScheimpflugIntrinsicsExport {
     pub mean_reproj_error: f64,
     /// Per-camera reprojection errors (single element for single-camera workflows).
     pub per_cam_reproj_errors: Vec<f64>,
+    /// Per-feature reprojection residuals (ADR 0012). Single-camera, target
+    /// only — `laser` is empty; `target_hist_per_camera` is
+    /// `Some(vec![one_entry])`.
+    #[serde(default)]
+    pub per_feature_residuals: PerFeatureResiduals,
 }
 
 impl ProblemType for ScheimpflugIntrinsicsProblem {
@@ -173,15 +179,26 @@ impl ProblemType for ScheimpflugIntrinsicsProblem {
     }
 
     fn export(
-        _input: &Self::Input,
+        input: &Self::Input,
         output: &Self::Output,
         _config: &Self::Config,
     ) -> Result<Self::Export, Error> {
+        let camera = output.params.camera.build();
+        let target =
+            compute_planar_target_residuals(&camera, input, &output.params.camera_se3_target)?;
+        let target_hist = build_feature_histogram(target.iter().filter_map(|r| r.error_px));
+
         Ok(ScheimpflugIntrinsicsExport {
             params: output.params.clone(),
             report: output.report.clone(),
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: vec![output.mean_reproj_error],
+            per_feature_residuals: PerFeatureResiduals {
+                target,
+                laser: Vec::new(),
+                target_hist_per_camera: Some(vec![target_hist]),
+                laser_hist_per_camera: None,
+            },
         })
     }
 }

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
@@ -349,6 +349,7 @@ impl ProblemType for SingleCamHandeyeProblem {
             &output.params.handeye,
             &target_pose,
             &robot_poses,
+            output.robot_deltas.as_deref(),
         );
         let target = compute_planar_target_residuals_views(&camera, &input.views, &cam_se3_target)?;
         let target_hist = build_feature_histogram(target.iter().filter_map(|r| r.error_px));

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
@@ -5,8 +5,13 @@
 
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{Iso3, PinholeCamera, View};
-use vision_calibration_optim::{HandEyeEstimate, HandEyeMode, RobustLoss};
+use vision_calibration_core::{
+    Iso3, PerFeatureResiduals, PinholeCamera, View, build_feature_histogram,
+    compute_planar_target_residuals_views,
+};
+use vision_calibration_optim::{
+    HandEyeEstimate, HandEyeMode, RobustLoss, handeye_observer_se3_target,
+};
 
 use crate::session::{InvalidationPolicy, ProblemType};
 
@@ -187,6 +192,12 @@ pub struct SingleCamHandeyeExport {
 
     /// Per-camera reprojection errors (pixels). Single element for single-camera.
     pub per_cam_reproj_errors: Vec<f64>,
+
+    /// Per-feature reprojection residuals (ADR 0012). Single-camera, target
+    /// only. Per-view `cam_se3_target` is derived from the handeye chain
+    /// (see [`handeye_observer_se3_target`](vision_calibration_optim::handeye_observer_se3_target)).
+    #[serde(default)]
+    pub per_feature_residuals: PerFeatureResiduals,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -296,7 +307,7 @@ impl ProblemType for SingleCamHandeyeProblem {
     }
 
     fn export(
-        _input: &Self::Input,
+        input: &Self::Input,
         output: &Self::Output,
         config: &Self::Config,
     ) -> Result<Self::Export, Error> {
@@ -326,6 +337,22 @@ impl ProblemType for SingleCamHandeyeProblem {
                 }
             };
 
+        // Per-feature residuals: derive cam_se3_target per view from the
+        // handeye chain (camera == observer for single-cam) and project.
+        let robot_poses: Vec<Iso3> = input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper)
+            .collect();
+        let cam_se3_target = handeye_observer_se3_target(
+            config.handeye_mode,
+            &output.params.handeye,
+            &target_pose,
+            &robot_poses,
+        );
+        let target = compute_planar_target_residuals_views(&camera, &input.views, &cam_se3_target)?;
+        let target_hist = build_feature_histogram(target.iter().filter_map(|r| r.error_px));
+
         Ok(SingleCamHandeyeExport {
             camera,
             handeye_mode: config.handeye_mode,
@@ -336,6 +363,12 @@ impl ProblemType for SingleCamHandeyeProblem {
             robot_deltas: output.robot_deltas.clone(),
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: output.per_cam_reproj_errors.clone(),
+            per_feature_residuals: PerFeatureResiduals {
+                target,
+                laser: Vec::new(),
+                target_hist_per_camera: Some(vec![target_hist]),
+                laser_hist_per_camera: None,
+            },
         })
     }
 }

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -574,6 +574,14 @@ pub mod linear {
     pub use vision_calibration_linear::*;
 }
 
+/// Per-feature residual helpers from `vision-calibration-optim` re-exported
+/// for convenience: `handeye_observer_se3_target` (used by hand-eye exports)
+/// and `compute_*_feature_residuals` (used by laser exports).
+pub use vision_calibration_optim::{
+    compute_laserline_feature_residuals, compute_rig_laserline_feature_residuals,
+    handeye_observer_se3_target,
+};
+
 /// Non-linear optimization with backend-agnostic IR.
 ///
 /// Includes optimization problems, factors, and solver backends.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -109,7 +109,10 @@ future ambition.
 ## See also
 
 - [ADR index](adrs/README.md) — design records.
+- [Tutorials](tutorials/README.md) — hands-on walkthroughs for new users.
 - [MSRV notes](MSRV.md) — why the lockfile is frozen below latest releases.
-- Per-track ADRs: `0011-manual-initialization-workflow.md` (A1, ships with PR #27);
-  `0012-per-feature-residuals.md` (A2, pending); `0013-tauri-desktop-app.md` (B0, pending);
+- Per-track ADRs:
+  [`0011-manual-initialization-workflow.md`](adrs/0011-manual-initialization-workflow.md) (A1, landed in PR #32);
+  [`0012-per-feature-reprojection-residuals.md`](adrs/0012-per-feature-reprojection-residuals.md) (A2, landed in PR #33 + follow-ups);
+  `0013-tauri-desktop-app.md` (B0, pending);
   `0014-mvg-ceiling.md` (C1, pending).

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,36 @@
+# calibration-rs Tutorials
+
+Hands-on, copy-pasteable walkthroughs for the public surface of
+`vision-calibration` (the facade crate). Each tutorial pairs a narrative with
+a runnable example checked into the workspace; the example is the
+authoritative reference and stays green in CI.
+
+## When to use what
+
+| Goal | Tutorial | Runnable example |
+|---|---|---|
+| Calibrate intrinsics + multi-camera rig from scratch | [Five-minute calibration](./five-minute-calibration.md) | [`stereo_charuco_session.rs`](../../crates/vision-calibration/examples/stereo_charuco_session.rs) |
+| Seed prior knowledge into the pipeline (datasheet K, factory tilts, mechanical drawings) | [Manual initialization](./manual-init.md) | [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs) |
+| Drill into per-corner reprojection errors (diagnose mode) | [Per-feature residuals](./per-feature-residuals.md) | [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs) (Run A printout) |
+| Calibrate a Scheimpflug rig + laser device end-to-end on real data | [Puzzle 130×130 walkthrough](./puzzle-130x130-walkthrough.md) | [`puzzle_130x130_rig.rs`](../../crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs) (private dataset) |
+
+## Structure
+
+Each tutorial is self-contained and follows the same outline:
+
+1. **Why** — what problem the feature solves, who it is for.
+2. **Mental model** — one or two paragraphs of necessary background. No
+   geometry derivations — those live in the ADRs.
+3. **Walkthrough** — a minimum-viable code path with explanations between
+   each step.
+4. **Common variations** — small recipes for the obvious follow-on questions.
+5. **What to read next** — pointers into ADRs, source files, and other
+   tutorials.
+
+## How tutorials relate to ADRs
+
+ADRs in [`docs/adrs/`](../adrs/) explain *why* the API is shaped a particular
+way. Tutorials explain *how to use* the resulting API. When the two
+diverge, the ADR is authoritative for design intent and the tutorial is
+authoritative for the working code path; please file an issue when you spot
+drift.

--- a/docs/tutorials/five-minute-calibration.md
+++ b/docs/tutorials/five-minute-calibration.md
@@ -1,0 +1,158 @@
+# Five-minute calibration
+
+> Onboarding tutorial. Runnable companion:
+> [`stereo_charuco_session.rs`](../../crates/vision-calibration/examples/stereo_charuco_session.rs).
+
+## Why
+
+The fastest way to develop intuition for `calibration-rs` is to run a real
+end-to-end calibration on a public dataset. This tutorial gets you from
+"I just cloned the repo" to "I have calibrated intrinsics, distortion, and
+multi-camera extrinsics" in five minutes.
+
+## Mental model
+
+A calibration is a **session**: a state container plus a sequence of step
+functions you invoke in order.
+
+```
+Session::new()
+  → set_input(observations)
+  → step_intrinsics_init_all     ← Zhang's method per camera
+  → step_intrinsics_optimize_all ← non-linear refinement
+  → step_rig_init                ← linear cam_se3_rig + rig_se3_target
+  → step_rig_optimize            ← joint bundle adjustment
+  → export()                     ← stable JSON-serializable result
+```
+
+Each step reads the relevant fields from the session state and writes its
+own output back; you can inspect the intermediate state between any two
+steps. There is also a `run_calibration` convenience wrapper that calls
+the canonical step sequence.
+
+## Walkthrough
+
+We'll calibrate a 2-camera ChArUco rig from the dataset bundled in `data/`.
+
+### 1. Run the canned example
+
+```bash
+cargo run -p vision-calibration --example stereo_charuco_session --release -- --max-views 8
+```
+
+This compiles, detects ChArUco corners in 8 image pairs, and runs the
+canonical pipeline. Expected output (excerpt):
+
+```
+--- Step 2: Per-Camera Intrinsics Optimization ---
+  Camera 0: fx=21896.5, fy=21799.3, cx=918.4, cy=731.5, reproj_err=0.394px
+  Camera 1: fx=21652.4, fy=21562.0, cx=1304.9, cy=747.6, reproj_err=0.396px
+
+--- Step 4: Rig Bundle Adjustment ---
+  Rig BA mean reprojection error: 0.5435 px
+    Camera 0: 0.5969 px
+    Camera 1: 0.4869 px
+  Rig baseline (after BA): |t(cam1->rig)| = 0.1153 m (115.27 mm)
+```
+
+The full source is at
+[`crates/vision-calibration/examples/stereo_charuco_session.rs`](../../crates/vision-calibration/examples/stereo_charuco_session.rs).
+
+### 2. Walk the source
+
+The interesting part is just ten lines:
+
+```rust
+let mut session = CalibrationSession::<RigExtrinsicsProblem>::new();
+session.set_input(input)?;
+
+step_intrinsics_init_all(&mut session, None)?;
+step_intrinsics_optimize_all(&mut session, None)?;
+step_rig_init(&mut session)?;
+step_rig_optimize(&mut session, None)?;
+
+let export = session.export()?;
+let mean_reproj = export.mean_reproj_error;
+let baseline = (export.cam_se3_rig[1].translation.vector
+              - export.cam_se3_rig[0].translation.vector).norm();
+```
+
+Notice:
+
+- `RigExtrinsicsProblem` is a phantom marker type. It picks the input,
+  state, and export schemas via the `ProblemType` trait — the session
+  is fully typed.
+- `step_*` functions take an `Option<*Options>` for tweaks
+  (`max_iters`, `verbosity`, etc.). Passing `None` uses the config's
+  defaults.
+- `export()` returns a `RigExtrinsicsExport` — a stable, JSON-serializable
+  view of the result. It's the canonical handoff to other tools.
+
+### 3. Choose a different problem type
+
+Different camera setups call for different problem types. The pattern is
+the same; only the input shape and the step list change.
+
+| Problem type | Input | Steps |
+|---|---|---|
+| `PlanarIntrinsicsProblem` | `PlanarDataset` | `step_init` → `step_optimize` |
+| `SingleCamHandeyeProblem` | `SingleCamHandeyeInput` | 4 steps (intrinsics ×2, hand-eye ×2) |
+| `RigExtrinsicsProblem` | `RigDataset<NoMeta>` | 4 steps (this tutorial) |
+| `RigHandeyeProblem` | `RigDataset<RobotPoseMeta>` | 6 steps |
+| `LaserlineDeviceProblem` | `LaserlineDataset` | `step_init` → `step_optimize` |
+| `ScheimpflugIntrinsicsProblem` | `PlanarDataset` (with tilt) | `step_init` → `step_optimize` |
+| `RigScheimpflugExtrinsicsProblem` | `RigDataset<NoMeta>` (Scheimpflug) | 4 steps |
+| `RigScheimpflugHandeyeProblem` | `RigDataset<RobotPoseMeta>` (Scheimpflug) | 6 steps |
+| `RigLaserlineDeviceProblem` | `RigLaserlineDeviceInput` | `step_init` → `step_optimize` |
+
+Each problem type's facade module re-exports its types and step functions
+(see `vision_calibration::rig_extrinsics`, etc.).
+
+## Common variations
+
+### Pre-detect corners off-line
+
+The `stereo_charuco_session` example calls `calib-targets` to detect
+corners as part of loading. For production use you typically pre-detect
+once and persist the resulting `RigExtrinsicsInput` (which is pure data:
+JSON-serialisable, no images needed). Run calibrations against the cached
+detections.
+
+### Use the convenience wrapper
+
+```rust
+vision_calibration::rig_extrinsics::run_calibration(&mut session)?;
+```
+
+is equivalent to the four step calls above with default options.
+
+### Inspect the session log
+
+Every step appends a `LogEntry` to `session.log`. The log records what
+auto-init produced or which fields came from manual seeds:
+
+```rust
+for entry in &session.log {
+    println!("[{}] {:?} {}",
+        entry.operation, entry.success, entry.notes.as_deref().unwrap_or(""));
+}
+```
+
+### Snapshot and resume
+
+`CalibrationSession` is JSON-serialisable. Persist after `step_rig_init`
+and resume later for a fresh `step_rig_optimize` with different solver
+options.
+
+## What to read next
+
+- [Manual initialization](./manual-init.md) — seed datasheet values into
+  the pipeline.
+- [Per-feature residuals](./per-feature-residuals.md) — drill into the
+  per-corner errors after a calibration finishes.
+- [Puzzle 130×130 walkthrough](./puzzle-130x130-walkthrough.md) — the same
+  pattern at industrial scale (Scheimpflug rig, laser plane, robot
+  hand-eye, real data).
+- [ADR 0007](../adrs/0007-session-framework.md) — why the API is shaped
+  around sessions and external step functions instead of a single
+  `Calibrator::run()` call.

--- a/docs/tutorials/manual-init.md
+++ b/docs/tutorials/manual-init.md
@@ -1,0 +1,190 @@
+# Manual initialization (warm-start)
+
+> Onboarding tutorial for [ADR 0011](../adrs/0011-manual-initialization-workflow.md).
+> Runnable companion: [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs).
+
+## Why
+
+The default pipeline always runs automatic linear initialization (Zhang's
+method, Tsai-Lenz DLT). That is the right behaviour when the data is
+well-conditioned, but in industrial settings you often have *better*
+priors:
+
+- Datasheet focal lengths or principal points.
+- Factory-measured Scheimpflug tilts.
+- Laser-plane geometry from mechanical drawings.
+- A previously calibrated rig you want to nudge with new data.
+
+Manual initialization lets you seed any subset of these into the pipeline
+and let the non-linear optimizer do the rest.
+
+## Mental model
+
+For every problem type and every init stage there is:
+
+- A `step_set_*` function that takes a `*ManualInit` struct.
+- A typed `*ManualInit` struct whose fields are all `Option<T>`. `None`
+  means "auto-initialize this group"; `Some(value)` means "use this value
+  verbatim, do not auto-initialize".
+
+```rust
+// Automatic path (unchanged):
+step_init(&mut session, None)?;
+step_optimize(&mut session, None)?;
+
+// Manual path:
+step_set_init(&mut session, PlanarManualInit {
+    intrinsics: Some(nominal_camera_k),
+    distortion: None,  // auto-initialized (or zeros when intrinsics seeded)
+    poses: None,       // auto-recovered from homographies using manual intrinsics
+}, None)?;
+step_optimize(&mut session, None)?;
+```
+
+After `step_set_*` returns, the session state is fully initialized — same
+postcondition as the auto path. `step_optimize` does not need to know
+which fields came from where.
+
+The session's log records the source of every initialization stage, e.g.:
+
+```
+[intrinsics_init_all] initialized 2 cameras (manual: per_cam_intrinsics, per_cam_distortion)
+[rig_init] ref_cam=0, 8 views (manual: cam_se3_rig, rig_se3_target)
+```
+
+## Walkthrough
+
+We'll seed the rig stage of a stereo calibration from a previous run.
+
+### 1. Run the auto pipeline once
+
+```rust
+use vision_calibration::prelude::*;
+use vision_calibration::rig_extrinsics::{
+    RigExtrinsicsProblem, RigIntrinsicsManualInit, RigExtrinsicsManualInit,
+    step_set_intrinsics_init_all, step_intrinsics_optimize_all,
+    step_set_rig_init, step_rig_optimize,
+};
+
+let mut session_a = CalibrationSession::<RigExtrinsicsProblem>::new();
+session_a.set_input(load_dataset()?)?;
+step_set_intrinsics_init_all(&mut session_a, RigIntrinsicsManualInit::default(), None)?;
+step_intrinsics_optimize_all(&mut session_a, None)?;
+step_set_rig_init(&mut session_a, RigExtrinsicsManualInit::default())?;
+step_rig_optimize(&mut session_a, None)?;
+```
+
+`RigIntrinsicsManualInit::default()` and `RigExtrinsicsManualInit::default()`
+both have all-`None` fields, so this is exactly the auto path — the same as
+`run_calibration`.
+
+### 2. Capture the results
+
+```rust
+let cameras_a = session_a.state.per_cam_intrinsics.clone().unwrap();
+let cam_se3_rig_a = session_a.state.initial_cam_se3_rig.clone().unwrap();
+let rig_se3_target_a = session_a.state.initial_rig_se3_target.clone().unwrap();
+
+let per_cam_k = cameras_a.iter().map(|c| c.k).collect::<Vec<_>>();
+let per_cam_dist = cameras_a.iter().map(|c| c.dist).collect::<Vec<_>>();
+```
+
+### 3. Replay them on a fresh session
+
+```rust
+let mut session_b = CalibrationSession::<RigExtrinsicsProblem>::new();
+session_b.set_input(load_dataset()?)?;
+
+step_set_intrinsics_init_all(
+    &mut session_b,
+    RigIntrinsicsManualInit {
+        per_cam_intrinsics: Some(per_cam_k),
+        per_cam_distortion: Some(per_cam_dist),
+    },
+    None,
+)?;
+
+// Skip step_intrinsics_optimize_all: the seed is already optimized.
+
+step_set_rig_init(
+    &mut session_b,
+    RigExtrinsicsManualInit {
+        cam_se3_rig: Some(cam_se3_rig_a),
+        rig_se3_target: Some(rig_se3_target_a),
+    },
+)?;
+step_rig_optimize(&mut session_b, None)?;
+```
+
+The output is bit-exact (`|Δ reproj| < 3e-15` px on the stereo ChArUco
+dataset). The example in `manual_init_proof.rs` asserts this.
+
+## Common variations
+
+### Partial seeding
+
+When intrinsics are seeded but distortion is not, distortion defaults to
+`BrownConrady5::default()` (zeros) — the auto distortion fit is coupled
+with iterative intrinsics estimation and does not run when intrinsics are
+seeded.
+
+When intrinsics are seeded but poses are not, poses recover from per-view
+homographies using the **manually provided intrinsics** (not auto-estimated
+ones). This keeps the geometric chain consistent with the seed.
+
+### Seed from datasheet values
+
+For a homogeneous rig where all cameras share the same optical design:
+
+```rust
+use vision_calibration::core::{BrownConrady5, FxFyCxCySkew};
+
+let datasheet_k = FxFyCxCySkew {
+    fx: 1800.0, fy: 1800.0,
+    cx: 360.0, cy: 270.0,
+    skew: 0.0,
+};
+let nominal_distortion = BrownConrady5 { k1: -0.1, ..Default::default() };
+
+step_set_intrinsics_init_all(
+    &mut session,
+    RigIntrinsicsManualInit {
+        per_cam_intrinsics: Some(vec![datasheet_k; num_cameras]),
+        per_cam_distortion: Some(vec![nominal_distortion; num_cameras]),
+    },
+    None,
+)?;
+```
+
+This unblocks scenarios where Zhang's method fails on borderline data —
+e.g., the puzzle 130x130 rig case that motivated [ADR 0011](../adrs/0011-manual-initialization-workflow.md).
+
+### Coupling rule (rig stage)
+
+`cam_se3_rig` and `rig_se3_target` are geometrically coupled. The rig
+stage's `*ManualInit` requires both or neither, enforced at runtime with
+a typed `Error::InvalidInput`.
+
+### Hand-eye coupling
+
+`RigHandeye` and `RigScheimpflugHandeye` have three init stages
+(intrinsics, rig, hand-eye), each with its own `*ManualInit`. The hand-eye
+stage's `mode_target_pose` is mode-dependent:
+
+- `EyeInHand`: `handeye = T_G_R`, `mode_target_pose = T_B_T`.
+- `EyeToHand`: `handeye = T_R_B`, `mode_target_pose = T_G_T`.
+
+If you seed `handeye` but not `mode_target_pose`, the latter is auto-derived
+from the chain (see [ADR 0009](../adrs/0009-coordinate-and-pose-conventions.md)
+for the convention).
+
+## What to read next
+
+- [ADR 0011](../adrs/0011-manual-initialization-workflow.md) — full design
+  rationale, including the partial-seed semantics and the
+  `#[non_exhaustive]` rule.
+- [Per-feature residuals](./per-feature-residuals.md) — once a calibration
+  finishes, drill into per-corner errors.
+- [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs)
+  — the example this tutorial is built on. Run it with
+  `cargo run -p vision-calibration --example manual_init_proof --release -- --max-views=8`.

--- a/docs/tutorials/per-feature-residuals.md
+++ b/docs/tutorials/per-feature-residuals.md
@@ -1,0 +1,200 @@
+# Per-feature reprojection residuals
+
+> Onboarding tutorial for [ADR 0012](../adrs/0012-per-feature-reprojection-residuals.md).
+> Runnable companion: [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs).
+
+## Why
+
+After a calibration finishes, the only error metric most pipelines surface is
+**mean reprojection error in pixels**. That number tells you *something is
+wrong* but not *which corners are wrong*. To debug a low-quality calibration
+— a board that flexed, a corner detection that drifted, a camera with
+borderline FOV — you need the per-corner error broken down by view and
+camera.
+
+`calibration-rs` 0.4 attaches per-feature residual records to every
+`*Export` type so downstream consumers (a React diagnose UI, a Python
+notebook, a regression test) can drill in without re-running geometry.
+
+## Mental model
+
+Every `*Export` carries a `per_feature_residuals: PerFeatureResiduals`
+field. The container is always present (`Default` is empty); empty inner
+`Vec`s mean "this problem type does not produce observations of that flavor"
+(e.g., `PlanarIntrinsicsExport.per_feature_residuals.laser` is always
+empty).
+
+```
+PerFeatureResiduals
+├─ target: Vec<TargetFeatureResidual>     // per-corner reprojection records
+├─ laser:  Vec<LaserFeatureResidual>      // per-pixel laser residuals
+├─ target_hist_per_camera: Option<Vec<FeatureResidualHistogram>>
+└─ laser_hist_per_camera:  Option<Vec<FeatureResidualHistogram>>
+```
+
+The records carry an explicit `(pose, camera, feature)` triple and pose-major
+ordering. Iteration: outer = view, inner = camera (camera-`None` slots
+skipped), innermost = feature index in that view+camera's `points_3d`.
+
+`Option<f64>` semantics:
+
+- `error_px = None` → projection diverged for that record. Use this to
+  separate "feature absent" from "feature present but our model is bad".
+- `residual_m = None` → the back-projected ray missed the laser plane.
+
+Histogram bucket edges are fixed at `[1, 2, 5, 10]` px (so `<=1`, `<=2`,
+`<=5`, `<=10`, `>10`).
+
+## Walkthrough
+
+We will exercise it on the stereo ChArUco dataset shipped in `data/`.
+
+### 1. Run a calibration
+
+Same as any other rig calibration — no configuration knobs are needed for
+per-feature residuals; the schema is always populated.
+
+```rust
+use vision_calibration::prelude::*;
+use vision_calibration::rig_extrinsics::{
+    RigExtrinsicsProblem, run_calibration,
+};
+
+let mut session = CalibrationSession::<RigExtrinsicsProblem>::new();
+session.set_input(my_dataset)?;
+run_calibration(&mut session)?;
+let export = session.export()?;
+```
+
+### 2. Sum the histogram counts
+
+Every per-camera histogram aggregates only records that produced a finite
+`error_px`. The remaining records are projection failures.
+
+```rust
+let pf = &export.per_feature_residuals;
+let total = pf.target.len();
+let with_value = pf.target.iter().filter(|r| r.error_px.is_some()).count();
+println!("{total} target records ({with_value} converged, {} divergent)",
+         total - with_value);
+
+if let Some(hists) = pf.target_hist_per_camera.as_ref() {
+    for (i, h) in hists.iter().enumerate() {
+        println!("cam {i}: count={} mean={:.4}px max={:.4}px buckets {:?}",
+                 h.count, h.mean, h.max, h.counts);
+    }
+}
+```
+
+Real output from `manual_init_proof` (8-view stereo ChArUco):
+
+```
+4865 target records (4865 converged, 0 divergent)
+cam 0: count=2503 mean=0.5969px max=1.8740px buckets [2114, 389, 0, 0, 0]
+cam 1: count=2362 mean=0.4869px max=1.6632px buckets [2233, 129, 0, 0, 0]
+```
+
+### 3. Drill into the worst corner
+
+Filter to records with the highest `error_px` to triage outliers:
+
+```rust
+let mut worst: Vec<_> = pf
+    .target
+    .iter()
+    .filter_map(|r| r.error_px.map(|e| (e, r)))
+    .collect();
+worst.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+for (err, r) in worst.iter().take(5) {
+    println!(
+        "pose={} cam={} feat={} target_xy_m=({:.3},{:.3}) observed=({:.1},{:.1}) err={:.3}px",
+        r.pose, r.camera, r.feature,
+        r.target_xyz_m[0], r.target_xyz_m[1],
+        r.observed_px[0], r.observed_px[1],
+        err
+    );
+}
+```
+
+A diagnose UI typically projects this into a heatmap on the source image:
+the `(observed_px, projected_px)` pair lets you draw an arrow from observed
+to projected for every record.
+
+### 4. Cross-check with the aggregate mean
+
+If the per-camera histogram's `mean` field disagrees with the export's
+`per_cam_reproj_errors`, something is inconsistent. The
+`manual_init_proof` example asserts this round-trip:
+
+```rust
+let mean_from_records: f64 = pf
+    .target
+    .iter()
+    .filter(|r| r.camera == cam_idx)
+    .filter_map(|r| r.error_px)
+    .sum::<f64>()
+    / hist.count as f64;
+assert!((mean_from_records - hist.mean).abs() < 1e-9);
+```
+
+## Common variations
+
+### Laser residuals
+
+`LaserlineDeviceExport` and `RigLaserlineDeviceExport` populate `pf.laser`
+in addition to `pf.target`. Each `LaserFeatureResidual` carries:
+
+- `residual_m` — point-to-plane distance in meters from the back-projected
+  ray's intersection with the target plane to the calibrated laser plane.
+- `residual_px` — distance in image space from the observed pixel to the
+  projected laser line.
+- `projected_line_px` — two endpoints of the projected laser line, useful
+  for 2D overlays.
+
+### Hand-eye chain
+
+`SingleCamHandeyeExport`, `RigHandeyeExport`, and
+`RigScheimpflugHandeyeExport` derive per-view `cam_se3_target` from the
+hand-eye chain via
+[`handeye_observer_se3_target`](../../crates/vision-calibration-optim/src/problems/handeye.rs).
+You don't need to reproduce that math — the export already carries the
+ground truth records.
+
+### Scheimpflug projection
+
+`ScheimpflugIntrinsicsExport`, `RigScheimpflugExtrinsicsExport`, and
+`RigScheimpflugHandeyeExport` build the full pinhole + Brown-Conrady +
+Scheimpflug `Camera` for projection. The records are computed using the
+exact same chain the optimizer used.
+
+### JSON consumption
+
+Every record type derives `Serialize, Deserialize`. The export round-trips
+through JSON:
+
+```rust
+let json = serde_json::to_string(&export)?;
+let restored: RigExtrinsicsExport = serde_json::from_str(&json)?;
+assert_eq!(restored.per_feature_residuals, export.per_feature_residuals);
+```
+
+Empty `Vec`s and `None` histograms are skipped on the wire (`{}` for an
+empty container).
+
+### Python
+
+Python bindings deserialize the export via `pythonize`; the records appear
+as native dicts/lists.
+
+## What to read next
+
+- [ADR 0012](../adrs/0012-per-feature-reprojection-residuals.md) — schema
+  rationale, indexing convention, JSON-stability promise.
+- [ADR 0009](../adrs/0009-coordinate-and-pose-conventions.md) — pose
+  naming (`frame_se3_frame`).
+- [`PerFeatureResiduals`](../../crates/vision-calibration-core/src/types/residual.rs)
+  — the struct definitions with full doc comments.
+- [`compute_rig_target_residuals`](../../crates/vision-calibration-core/src/lib.rs)
+  — the workhorse that produces records for any rig pipeline.
+- [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs)
+  — the example this tutorial is built on; runs against `data/stereo_charuco/`.

--- a/docs/tutorials/puzzle-130x130-walkthrough.md
+++ b/docs/tutorials/puzzle-130x130-walkthrough.md
@@ -1,0 +1,178 @@
+# Puzzle 130×130 walkthrough
+
+> The full-scale "everything turned on" calibration: 6-camera Scheimpflug
+> rig + laser plane + robot hand-eye, on real data.
+> Runnable companion (private dataset):
+> [`puzzle_130x130_rig.rs`](../../crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs).
+
+## Why
+
+Most tutorials use one feature at a time. This walkthrough composes them:
+how the same session pattern handles a calibration where every advanced
+feature in the workspace is in play.
+
+You will not be able to run this on your own machine (the dataset is
+internal), but the source is the canonical reference for putting
+`calibration-rs` to work end-to-end. Use it as a recipe rather than a demo.
+
+## What's in the dataset
+
+`privatedata/130x130_puzzle/`:
+
+- 20 robot poses (`poses.json`).
+- For each pose: a target snapshot + (sometimes) a laser snapshot.
+- 6 cameras horizontally concatenated into a single 4320×540 image.
+- Puzzleboard target (130×130 cells, 1.014 mm per cell).
+- Each camera has a Scheimpflug-tilted sensor.
+
+## Pipeline shape
+
+```
+                 ┌─ stage 1 ─────────────────┐
+                 │  detect target corners    │
+                 │  detect laser pixels      │
+                 └─────────────┬─────────────┘
+                               ▼
+       ┌─ stage 2 ─ RigScheimpflugHandeyeProblem ─────────────┐
+       │  step_intrinsics_init_all   (Zhang per camera)       │
+       │  step_intrinsics_optimize_all (per-camera BA)        │
+       │  step_rig_init               (linear cam_se3_rig)    │
+       │  step_rig_optimize           (joint rig BA)          │
+       │  step_handeye_init           (Tsai-Lenz)             │
+       │  step_handeye_optimize       (final hand-eye BA)     │
+       │                                                       │
+       │  → RigScheimpflugHandeyeExport                        │
+       └─────────────┬─────────────────────────────────────────┘
+                     ▼
+       ┌─ stage 3 ─ RigLaserlineDeviceProblem ────────────────┐
+       │  step_init       (per-cam linear plane fit, frozen)  │
+       │  step_optimize   (per-cam laser BA, frozen upstream) │
+       │                                                       │
+       │  → RigLaserlineDeviceExport (per-cam laser planes)    │
+       └─────────────┬─────────────────────────────────────────┘
+                     ▼
+       ┌─ stage 4 ─ Joint BA (refine everything) ─────────────┐
+       │  Reuses the IR built across stage 2 + stage 3 and     │
+       │  unfreezes intrinsics, extrinsics, hand-eye, planes,  │
+       │  and (optionally) per-view robot pose corrections.    │
+       └───────────────────────────────────────────────────────┘
+```
+
+Each stage produces a typed `*Export` that the next stage consumes (via
+[`RigScheimpflugHandeyeExport::to_upstream_calibration`](../../crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs)
+in particular). The example glues them together.
+
+## Walkthrough
+
+### Stage 1 — detection
+
+Detection is delegated to `calib-targets` (puzzleboard) and
+`vision-metrology` (laser line). The output is structured input data for
+the calibration sessions:
+
+```rust
+let detected = build_datasets(&data_dir, &poses)?;
+```
+
+The example prints a per-camera detection diagnostic — how many target
+corners and laser pixels each camera produced.
+
+### Stage 2 — Scheimpflug rig + hand-eye
+
+```rust
+let mut rig_session =
+    CalibrationSession::<RigScheimpflugHandeyeProblem>::with_description("puzzle_130x130_rig");
+rig_session.set_input(detected.handeye_views)?;
+rig_session.set_config(stage2_cfg)?;
+
+run_calibration(&mut rig_session)?;
+let stage2_export = rig_session.export()?;
+```
+
+The example uses
+[manual init](./manual-init.md) to seed every camera's intrinsics with a
+shared datasheet K (homogeneous rig assumption) and recover the
+Scheimpflug tilts via the non-linear stages.
+
+Stage 2 produces a mean reprojection error around 0.74 px on this dataset.
+
+### Stage 3 — rig laserline
+
+Wire the upstream Scheimpflug rig + hand-eye into the laserline solver:
+
+```rust
+let upstream = stage2_export.to_upstream_calibration(rig_se3_target_per_view);
+let laser_input = RigLaserlineDeviceInput {
+    dataset: detected.laserline_views,
+    upstream,
+    initial_planes_cam: None, // default to z=-0.2m per camera
+};
+
+let mut laser_session = CalibrationSession::<RigLaserlineDeviceProblem>::new();
+laser_session.set_input(laser_input)?;
+laser_session.run_calibration()?;
+let stage3_export = laser_session.export()?;
+```
+
+Stage 3 produces six laser planes (one per camera, both in camera frame
+and rig frame).
+
+### Stage 4 — joint BA
+
+The example reaches into `vision-calibration-optim` for `optimize_rig_handeye_laserline`
+to refine everything jointly with the upstream stages no longer frozen.
+Stage 4 brings the mean reprojection error from 0.74 px down to ~0.45 px.
+
+## Per-feature residuals
+
+After stage 2 every export carries
+[`per_feature_residuals`](./per-feature-residuals.md) automatically:
+
+```rust
+let pf = &stage2_export.per_feature_residuals;
+for (i, h) in pf.target_hist_per_camera.as_ref().unwrap().iter().enumerate() {
+    println!("cam {i}: {} corners, mean {:.3}px max {:.3}px",
+             h.count, h.mean, h.max);
+}
+```
+
+`stage3_export.per_feature_residuals` extends this with `laser` records
+giving per-pixel point-to-plane and pixel-to-projected-line distances.
+
+The puzzle viewer in
+[`puzzle_130x130_rig/viewer.rs`](../../crates/vision-calibration-examples-private/examples/puzzle_130x130_rig/viewer.rs)
+predates the `per_feature_residuals` schema — it builds the same shape
+inline. A planned follow-up swaps it to consume the export field directly.
+
+## Pixel → gripper mapping
+
+The example demonstrates `pixel_to_gripper_point`, which back-projects a
+laser pixel through the calibrated rig and intersects with the laser plane
+to recover a 3D point in the robot gripper frame:
+
+```rust
+let p = vision_calibration::pixel_to_gripper_point(
+    cam_idx,
+    &observed_pixel,
+    &stage2_export,        // upstream rig + handeye
+    &stage3_export.laser_planes_rig,
+    &robot_base_se3_gripper, // only required for EyeToHand
+)?;
+```
+
+This is the load-bearing measurement primitive on top of the calibration
+stack.
+
+## What to read next
+
+- [Five-minute calibration](./five-minute-calibration.md) — start small,
+  one problem type at a time.
+- [Manual initialization](./manual-init.md) — the seeding mechanism stage
+  2 uses for intrinsics.
+- [Per-feature residuals](./per-feature-residuals.md) — how to drill into
+  the per-corner errors emitted at every stage.
+- [ADR 0006](../adrs/0006-layered-crate-architecture.md) — why the
+  workspace is split into `core` / `linear` / `optim` / `pipeline` /
+  facade.
+- [Roadmap](../ROADMAP.md) — where the puzzle rig sits in the broader
+  4-track plan.


### PR DESCRIPTION
## Summary

Replaces #34 (auto-closed when base branch was deleted on PR #33 merge). Same content, retargeted to `main`.

Lands the remaining 6 of 9 `*Export` types with the per-feature residuals schema (ADR 0012), adds onboarding tutorials, and consolidates the residual helpers behind a small `CameraProject` trait.

After this PR, **every problem type's `*Export` carries `per_feature_residuals: PerFeatureResiduals`** — A2 schema track complete.

## Commits

```
a2894e5 fix(pipeline+optim): apply robot_deltas in handeye export residuals
43e9fed docs: tutorials/ structure + onboarding walkthroughs
6220afd feat(pipeline+optim): per-feature residuals on RigLaserlineDeviceExport
e299e08 feat(pipeline+optim): per-feature residuals on hand-eye exports
0b7339f feat(pipeline): per-feature residuals on Scheimpflug exports
e98c0e9 refactor(core): generify residual helpers over CameraProject trait
```

## What lands per export

| Export | Helpers used | Per-feature output |
|---|---|---|
| `ScheimpflugIntrinsicsExport` | `compute_planar_target_residuals` (single cam, full Scheimpflug) | target |
| `RigScheimpflugExtrinsicsExport` | `compute_rig_target_residuals` over full Scheimpflug `Camera`s | target |
| `SingleCamHandeyeExport` | `handeye_observer_se3_target` (with robot_deltas) + `compute_planar_target_residuals_views` | target |
| `RigHandeyeExport` | `handeye_observer_se3_target` (with robot_deltas) + `compute_rig_target_residuals` | target |
| `RigScheimpflugHandeyeExport` | `handeye_observer_se3_target` (with robot_deltas) + `compute_rig_target_residuals` (Scheimpflug) | target |
| `RigLaserlineDeviceExport` | `compute_rig_target_residuals` + `compute_rig_laserline_feature_residuals` | target + laser |

## New core helpers

- **`CameraProject` trait** in `vision-calibration-core`: blanket impl for `Camera<f64, P, D, Sm, K>`. Lets `compute_planar_target_residuals` / `compute_rig_target_residuals` accept any pinhole-style camera (PinholeCamera, Scheimpflug-tilted, future fisheye).
- **`apply_robot_delta`** in `vision-calibration-optim`: applies a per-view `[rx, ry, rz, tx, ty, tz]` correction with the optimizer's left-multiply convention (`T_B_G_corr = exp(delta) * T_B_G`).
- **`handeye_observer_se3_target`** in `vision-calibration-optim`: derives per-view observer-to-target poses from the hand-eye chain. Optionally applies `robot_deltas` so per-feature records match the optimizer's corrected poses (Codex P1 fix).
- **`compute_rig_laserline_feature_residuals`** in `vision-calibration-optim`: multi-camera laser feature helper.

All re-exported from the facade.

## Tutorials (`docs/tutorials/`)

- `README.md` — index, when-to-use-what.
- `five-minute-calibration.md` — smallest end-to-end path on `data/stereo_charuco`.
- `manual-init.md` — companion to ADR 0011.
- `per-feature-residuals.md` — companion to ADR 0012.
- `puzzle-130x130-walkthrough.md` — full-stack composition.

Each tutorial pairs narrative with a runnable example checked into the workspace.

`docs/ROADMAP.md` and `.claude/CLAUDE.md` link tutorials so they surface alongside ADRs.

## Codex feedback

- 👍 reacted to PR #34's P1 (`discussion_r3166955851`) about applying `robot_deltas` in hand-eye exports. The fix is included as `a2894e5`. The fix lifts the chain math into `handeye_observer_se3_target`'s new optional `robot_deltas` parameter and updates all three hand-eye exports to pass `output.robot_deltas.as_deref()`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — all green
- [x] `cargo doc --workspace --no-deps` clean
- [x] Real-data: puzzle 130x130 example end-to-end (mean reproj 0.45 px) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)