### PR TITLE
A6.4: rig_family ADR 0013 + roadmap hygiene + CLAUDE.md refresh

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,7 +58,7 @@ step_optimize(&mut session, None)?;
 let result = session.export()?;
 ```
 
-Nine problem types: `PlanarIntrinsics`, `ScheimpflugIntrinsics`, `SingleCamHandeye`, `RigExtrinsics`, `RigHandeye`, `LaserlineDevice`, plus the Scheimpflug family — `RigScheimpflugExtrinsics`, `RigScheimpflugHandeye` (EyeInHand), and `RigLaserlineDevice`.
+Seven problem types (post A6 sensor-axis collapse, see [ADR 0013](../docs/adrs/0013-rig-family-sensor-axis-refactor.md)): `PlanarIntrinsics`, `ScheimpflugIntrinsics`, `SingleCamHandeye`, `LaserlineDevice`, `RigExtrinsics`, `RigHandeye`, and `RigLaserlineDevice`. The two rig problem types (`RigExtrinsics`, `RigHandeye`) cover both pinhole and Scheimpflug rigs via `RigExtrinsicsConfig::sensor` / `RigHandeyeConfig::sensor` (`SensorMode::Pinhole` | `SensorMode::Scheimpflug { … }`). `RigLaserlineDevice` accepts a frozen Scheimpflug rig hand-eye export as upstream calibration.
 
 ## Optimization IR (ADR 0008)
 
@@ -110,23 +110,25 @@ be re-pinned manually after any update.
 ## Planning
 
 - ADRs in `docs/adrs/` — design decisions (see README there). 0011 covers
-  manual init (PR #32), 0012 covers per-feature residuals (PR #33 + follow-ups).
+  manual init, 0012 covers per-feature residuals, 0013 covers the
+  `rig_family` sensor-axis refactor (the Scheimpflug rig modules collapse).
 - Tutorials in `docs/tutorials/` — hands-on onboarding for new users. New
   features should ship with a tutorial entry.
 - Automated workflow skills: `/orchestrate`, `/architect`, `/implement`, `/review`, `/gate-check`
 
 ## Strategic Roadmap (>40 weeks)
 
-We work to a multi-quarter, four-track plan summarized in `docs/ROADMAP.md`. The
-load-bearing path is **A1 → A2 → B5**:
+We work to a multi-quarter, four-track plan summarized in `docs/ROADMAP.md`. **Track A is
+done as of 2026-05-01** (A1 + A2 + A4 + A6 shipped; A3 closed, A5 dropped). The
+remaining load-bearing path is **B0 → … → B5**:
 
-- **A — Calibration core** (puzzle-rig-anchored). A1 = manual init (this is PR #32,
-  superseding PR #27); A2 = per-feature residuals on every `*Export`; A3 = Zhang init
-  robustness; A4 = EyeToHand for Scheimpflug; A5 = Python parity; A6 = rig_family
-  refactor.
-- **B — Tauri 2 + React + TypeScript desktop app**. B0 scaffold → B1 file load →
+- **A — Calibration core (DONE).** Two rig problem types (`RigExtrinsics`,
+  `RigHandeye`) handle both pinhole and Scheimpflug via `SensorMode`; eight
+  problem types in total. Manual init (ADR 0011) and per-feature residuals on
+  export (ADR 0012) ship across the family.
+- **B — Tauri 2 + React + TypeScript desktop app.** B0 scaffold → B1 file load →
   B2 detection wrap → B3 calibration runner → B4 3D rig viewer → **B5 diagnose mode
-  (the MVP)** → B6 polish.
+  (the MVP)** → B6 polish. Next up.
 - **C — MVG** (postponed until B5). C1 PR #28 land → C2 N-view triangulation →
   C3 BA frozen-intrinsics → C4 Scheimpflug-aware rectification → C5 dense matcher
   (opencv-rust SGBM, feature-flagged).

--- a/crates/vision-calibration-pipeline/src/rig_family.rs
+++ b/crates/vision-calibration-pipeline/src/rig_family.rs
@@ -121,14 +121,15 @@ impl RigSensorBundle {
         }
     }
 
-    /// Number of cameras in the bundle.
-    #[allow(dead_code)] // Public accessor; consumed by upcoming A6.2b/A6.3 collapse.
+    /// Number of cameras in the bundle. Used by the `rig_family` test suite;
+    /// keep `pub(crate)` even when unused in production callers.
+    #[cfg(test)]
     pub fn num_cameras(&self) -> usize {
         self.cameras.len()
     }
 
     /// `true` when the bundle carries Scheimpflug sensor params.
-    #[allow(dead_code)] // Public accessor; consumed by upcoming A6.2b/A6.3 collapse.
+    #[cfg(test)]
     pub fn is_scheimpflug(&self) -> bool {
         self.scheimpflug.is_some()
     }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,62 +3,69 @@
 Canonical short-form summary of the multi-quarter direction. Detailed reasoning per track
 lives in ADRs (`docs/adrs/`); work-in-flight lives in open PRs.
 
-## Status (as of 2026-04-29)
+## Status (as of 2026-05-01)
 
 - **Version line:** 0.x. v1.0 (= stable public API) is deferred until the API has been
   stable across two minor releases without breaking changes. Pre-1.0 means breaking changes
   are acceptable.
 - **Active branch:** `main`.
+- **Track A — Calibration core: COMPLETE.** A1 (manual init), A2 (per-feature
+  residuals), A4 (Scheimpflug EyeToHand) shipped. A3 closed (false premise — the
+  reported Zhang failure was a fixed puzzleboard-detector bug). A5 dropped (no real
+  Python consumer; revisit after the Rust API stabilises). A6 (`rig_family` sensor-
+  axis refactor) shipped across PRs #36 + #37 + this PR; see
+  [ADR 0013](adrs/0013-rig-family-sensor-axis-refactor.md).
 - **In-flight PRs:**
-  [#27 Manual init](https://github.com/VitalyVorobyev/calibration-rs/pull/27) — calibration
-  warm-start across all problem types.
   [#28 mvg](https://github.com/VitalyVorobyev/calibration-rs/pull/28) — multiple-view
-  geometry crate split.
+  geometry crate split (Track C, deferred until B5 ships).
 
 ## Four tracks
 
-### Track A — Calibration core
+### Track A — Calibration core (DONE)
 
-Anchored to the **puzzle 130x130 rig** — the workspace's primary internal use case. The rig
-is structurally complete; its only blocker is Zhang's intrinsics init failing on a specific
-real-data camera ("invalid sign for lambda"). PR #27 is the literal unblocker.
+Eight problem types across four workflow modules: `planar_intrinsics`,
+`scheimpflug_intrinsics`, `single_cam_handeye`, `laserline_device`,
+`rig_extrinsics` (pinhole + Scheimpflug via `SensorMode`), `rig_handeye`
+(pinhole + Scheimpflug via `SensorMode`), and `rig_laserline_device`. All carry
+manual init (ADR 0011) and per-feature residuals on export (ADR 0012).
 
-- **A1** Land PR #27 — manual init / warm-start across all nine problem types. See
-  [ADR 0011](adrs/0011-manual-initialization-workflow.md).
-- **A2** Per-feature residuals on every `*Export` type (gates the diagnose UI). New
-  ADR 0012 pending.
-- **A3** Zhang's init robustness: detect the lambda-sign failure and fall back to a
-  constant-K estimate.
-- **A4** EyeToHand mode for the Scheimpflug hand-eye family (currently EyeInHand only).
-- **A5** Python bindings parity for `RigScheimpflugExtrinsics`, `RigScheimpflugHandeye`,
-  `RigLaserlineDevice`.
-- **A6** `rig_family` shared-helpers refactor (defer until a third sibling problem type
-  exists).
+| Item | Status | Notes |
+|------|--------|-------|
+| **A1** Manual init | **SHIPPED** (PR #32) | ADR 0011, all problem types, `manual_init_proof` example, tutorial. |
+| **A2** Per-feature residuals | **SHIPPED** (PR #33 + #35) | ADR 0012, every `*Export` carries `per_feature_residuals`, tutorial. |
+| **A3** Zhang lambda-sign fallback | **CLOSED — false premise** | The reported failure was a puzzleboard-detector bug, since fixed. No real-data Zhang failure to defend against. |
+| **A4** Scheimpflug EyeToHand | **SHIPPED** | `RigHandeyeProblem` (Scheimpflug variant) supports both `EyeInHand` and `EyeToHand` via `RigHandeyeInitConfig::handeye_mode`. |
+| **A5** Python parity | **DROPPED** | No real Python consumer; revisit *after* the Rust API stabilises, as one coherent build, not parity patches. |
+| **A6** `rig_family` refactor | **SHIPPED** (PRs #36 + #37 + this PR) | Sensor-axis-only collapse. Five rig sibling modules → three. Net ~−2,300 LoC. See [ADR 0013](adrs/0013-rig-family-sensor-axis-refactor.md). |
+
+**Track A exit criterion (met):** the `vision-calibration` facade is stable enough
+that B0 (Tauri scaffold) can compile against it with no breaking churn back into core.
 
 ### Track B — Tauri 2 + React + TypeScript desktop app
 
-A production-grade internal tool wrapping the calibration library. ~4–6 months end-to-end
-at one-engineer cadence. ADR 0013 pending — records the choice over `rerun.io` and `egui`
-(rejected: `rerun`'s developer-tool aesthetic + gRPC clashes with this project's zenoh-Rust
-stack; `egui` has less ecosystem leverage for production polish).
+A production-grade internal tool wrapping the calibration library. ~4–6 months
+end-to-end at one-engineer cadence. ADR 0014 will record the choice over
+`rerun.io` and `egui` (rejected: `rerun`'s developer-tool aesthetic + gRPC
+clashes with this project's zenoh-Rust stack; `egui` has less ecosystem leverage
+for production polish).
 
 - **B0** Scaffolding — new `app/` directory with conventional Tauri 2 layout
-  (`app/src-tauri/` Rust + `app/src/` React + TS).
+  (`app/src-tauri/` Rust + `app/src/` React + TS). **Next up.**
 - **B1** Project model + file loading (images + calibration config in).
 - **B2** Feature detection pipeline wrapping `chess-corners` and `calib-targets`.
 - **B3** Calibration runner with live progress streaming via Tauri events.
 - **B4** 3D rig viewer (Three.js / React Three Fiber: camera frustums, target poses,
   laser plane).
-- **B5** **Diagnose mode — the MVP.** Per-feature reprojection arrows, per-image residual
-  heatmaps, drill-down, coordinated highlighting between 2D image, 3D scene, and sidebar.
-  Depends on A2.
+- **B5** **Diagnose mode — the MVP.** Per-feature reprojection arrows, per-image
+  residual heatmaps, drill-down, coordinated highlighting between 2D image, 3D
+  scene, and sidebar. Consumes A2's per-feature residuals.
 - **B6** Production polish — wizard, settings persistence, signed installers per OS.
 
 ### Track C — MVG (postponed; depends on B5 done)
 
 PR #28 splits two-view geometry into `vision-geometry` (deterministic solvers) and
 `vision-mvg` (pipelines, robust estimation). Post-merge the track extends to multi-view
-geometry over already-calibrated rigs. ADR 0014 will cap the ceiling explicitly: no
+geometry over already-calibrated rigs. ADR 0015 will cap the ceiling explicitly: no
 in-house dense matcher, no full SfM.
 
 - **C1** Land PR #28.
@@ -76,24 +83,16 @@ in-house dense matcher, no full SfM.
 - **D1** Typed errors only — no `String`-typed escape hatches in public APIs.
 - **D2** Doc-warning-free, MSRV 1.88 frozen.
 - **D3** Python binding parity audited at every minor version bump.
-- **D4** v1.0 release once all puzzle rig phases run green via the Tauri app, PRs #27 and
-  #28 + A2 + B5 + C4 have all landed, and the API has been stable across two minor releases.
+- **D4** v1.0 release once the puzzle rig runs green end-to-end via the Tauri app,
+  PR #28 + B5 + C4 have all landed, and the API has been stable across two minor
+  releases.
 
-## Sequencing
+## Load-bearing path
 
-```
-Weeks 1–2:    A1 (PR #27 rebase + land)   +  B0 (Tauri scaffolding)
-Weeks 3–6:    A2, A3                      +  B1 (file load) → B2 (detection)
-Weeks 7–12:   A4, A5, A6 cleanup          +  B3 (runner) → B4 (3D viewer)
-Weeks 13–24:  (A done)                    +  B5 — the MVP
-Weeks 25+:                                   B6 polish + C1 (PR #28 land)
-Weeks 28–40:                                                C2 → C3 → C4 → C5
-Weeks 40+:                                                                   D-ratchets, v1.0
-```
-
-Load-bearing path: **A1 → A2 → B5**. A1 unblocks the rig immediately. A2 is the small
-schema extension that gates the diagnose UI. Everything else is parallelizable cleanup or
-future ambition.
+**B0 → … → B5.** Track A is done; the diagnose UI (B5) is the next user-facing
+milestone and consumes the A2 per-feature-residuals foundation that already
+ships on every export. C is parallelizable once B5 lands; D is a continuous
+ratchet.
 
 ## Out of scope (explicit)
 
@@ -113,6 +112,7 @@ future ambition.
 - [MSRV notes](MSRV.md) — why the lockfile is frozen below latest releases.
 - Per-track ADRs:
   [`0011-manual-initialization-workflow.md`](adrs/0011-manual-initialization-workflow.md) (A1, landed in PR #32);
-  [`0012-per-feature-reprojection-residuals.md`](adrs/0012-per-feature-reprojection-residuals.md) (A2, landed in PR #33 + follow-ups);
-  `0013-tauri-desktop-app.md` (B0, pending);
-  `0014-mvg-ceiling.md` (C1, pending).
+  [`0012-per-feature-reprojection-residuals.md`](adrs/0012-per-feature-reprojection-residuals.md) (A2, landed in PR #33 + #35);
+  [`0013-rig-family-sensor-axis-refactor.md`](adrs/0013-rig-family-sensor-axis-refactor.md) (A6, landed in PRs #36 + #37 + this PR);
+  `0014-tauri-desktop-app.md` (B0, pending);
+  `0015-mvg-ceiling.md` (C1, pending).

--- a/docs/adrs/0013-rig-family-sensor-axis-refactor.md
+++ b/docs/adrs/0013-rig-family-sensor-axis-refactor.md
@@ -1,0 +1,235 @@
+# ADR 0013: rig_family Sensor-Axis Refactor (Pinhole + Scheimpflug Unification)
+
+- Status: Accepted
+- Date: 2026-05-01
+
+## Context
+
+By 2026-04-30, the calibration pipeline had grown five sibling **rig** modules
+that calibrated multi-camera rigs in structurally similar but flavour-specific
+ways:
+
+| Module | Sensor | Workflow | LoC |
+|--------|--------|----------|----:|
+| `rig_extrinsics` | Pinhole | extrinsics-only | 1,760 |
+| `rig_scheimpflug_extrinsics` | Scheimpflug | extrinsics-only | 933 |
+| `rig_handeye` | Pinhole | hand-eye | 2,198 |
+| `rig_scheimpflug_handeye` | Scheimpflug | hand-eye | 1,798 |
+| `rig_laserline_device` | (Scheimpflug, frozen upstream) | laser-plane | 542 |
+| **Total** | | | **~7,200** |
+
+The four extrinsics + hand-eye modules were natural pairs (pinhole ↔
+Scheimpflug). A duplication audit found ~30–40% structural overlap:
+
+- `state.rs` files mirrored each other ~90% (the Scheimpflug variant added
+  one `per_cam_sensors` field).
+- `*Config` structs duplicated ~60–75% (Scheimpflug added 3–4 tilt-related
+  fields).
+- `*Steps.rs` files shared a near-identical six-step skeleton (intrinsics ×2,
+  rig ×2, hand-eye ×2 for the hand-eye flavour) with the same per-camera
+  bootstrap loop and view-extraction helpers re-implemented in each.
+
+Earlier prior to PR #35, the per-feature-residuals follow-up touched all six
+exports independently, demonstrating that the duplication was an active tax
+on every cross-cutting change rather than a one-time copy.
+
+## Decision
+
+Factor the rig family along a **single axis — sensor model (pinhole vs
+Scheimpflug)** — and only that axis. Workflow remains per-module because each
+workflow has fundamentally different state, step sequences, residual blocks,
+and exports.
+
+The factoring uses **composition over traits**:
+
+1. A new internal helper module `crate::rig_family` owns shared
+   sensor-axis-aware primitives:
+
+   - `RigSensorBundle` — a `pub(crate)` payload carrying
+     `cameras: Vec<PinholeCamera>` plus an optional
+     `scheimpflug: Option<Vec<ScheimpflugParams>>`.
+   - `RigIntrinsicsSeeds` — manual-init seeds that carry both pinhole
+     intrinsics/distortion and Scheimpflug sensors as `Option<Vec<…>>`.
+   - `SensorFlavour` — a `pub(crate)` enum tagging which kind of bootstrap
+     the helper should run.
+   - `bootstrap_rig_intrinsics(num_cameras, num_views, |cam_idx| views, …)` —
+     the per-camera bootstrap loop, sensor-aware: for `Pinhole` it produces
+     plain `PinholeCamera`s; for `Scheimpflug` it also threads per-camera
+     tilt params (seeded or default).
+   - `views_to_planar_dataset`, `estimate_target_pose`,
+     `intrinsics_k_matrix`, `format_init_source` — small pure helpers used
+     across workflow modules.
+
+2. A user-facing `SensorMode` enum (also defined in `rig_family` and
+   re-exported by both `rig_extrinsics::SensorMode` and
+   `rig_handeye::SensorMode`):
+
+   ```rust
+   #[non_exhaustive]
+   #[serde(tag = "kind")]
+   pub enum SensorMode {
+       Pinhole,
+       Scheimpflug {
+           init_tilt_x: f64,
+           init_tilt_y: f64,
+           fix_scheimpflug_in_intrinsics: ScheimpflugFixMask,
+           refine_scheimpflug_in_rig_ba: bool,
+       },
+   }
+   ```
+
+   Workflow configs (`RigExtrinsicsConfig`, `RigHandeyeConfig`) carry
+   `sensor: SensorMode`. Workflow step functions match on it and dispatch
+   to either the pinhole or Scheimpflug optim entry point.
+
+3. Workflow `Output` types become enums to preserve both flavours' optim
+   estimates without losing structural fidelity:
+
+   ```rust
+   pub enum RigExtrinsicsOutput {
+       Pinhole(vision_calibration_optim::RigExtrinsicsEstimate),
+       Scheimpflug(vision_calibration_optim::RigExtrinsicsScheimpflugEstimate),
+   }
+   ```
+
+   (and analogously `RigHandeyeOutput`). Public accessor methods
+   (`cam_to_rig()`, `cameras()`, `sensors()`, `mean_reproj_error()`, …)
+   provide a uniform read surface so downstream code rarely needs to match
+   on the variant.
+
+4. Workflow `Export` types gain optional Scheimpflug-only fields:
+
+   - `RigExtrinsicsExport.sensors: Option<Vec<ScheimpflugParams>>`
+   - `RigHandeyeExport.sensors: Option<Vec<ScheimpflugParams>>`
+
+   `None` for pinhole rigs, `Some(_)` for Scheimpflug rigs.
+
+The four pre-A6 workflow modules collapse to three:
+`rig_extrinsics`, `rig_handeye`, `rig_laserline_device`. The two
+Scheimpflug siblings (`rig_scheimpflug_extrinsics`,
+`rig_scheimpflug_handeye`) are deleted; their integration tests are
+rewritten to drive the unified problems with `SensorMode::Scheimpflug`.
+
+`rig_laserline_device` keeps its own existence — it is the only laser-plane
+sibling and there is no second variant to collapse with. It now consumes
+`RigHandeyeExport` directly via
+`RigHandeyeExport::to_upstream_calibration(...)`, which returns
+`Result<…>` and errors on pinhole rigs (the laser-plane fit currently
+requires Scheimpflug sensor params).
+
+## Considered alternatives
+
+### Two-axis trait matrix (sensor × workflow)
+
+Defining a `RigWorkflow` trait parameterised by sensor model would maximise
+generic reuse. Rejected:
+
+- Hand-eye and extrinsics-only workflows have genuinely different state
+  shapes (hand-eye carries `initial_handeye`, `final_cost`, …); making
+  state generic adds 2–3 layers of associated types that future readers
+  have to re-derive every time.
+- Step sequences differ (4 vs 6 steps); abstracting the sequence into a
+  trait obscures the per-workflow control flow that a calibration engineer
+  needs to reason about.
+- Composition over traits is more idiomatic Rust here — the common code
+  is small free functions, not behaviour worth an interface.
+
+### Keep all five modules, share a helper module only
+
+A6.1 shipped exactly this — a `rig_family.rs` helper module that
+`rig_extrinsics` + `rig_scheimpflug_extrinsics` consume — and proved its
+value (-255 LoC of pure dedup, no API change). But leaving the four
+sibling modules in place preserves the pattern that makes every cross-
+cutting change cost 4× (PR #35 was the trigger). The collapse to three
+modules was the load-bearing simplification, not the helper extraction.
+
+### Lift Scheimpflug-only advanced fields into the unified config
+
+The pre-A6 `RigScheimpflugHandeyeIntrinsicsConfig` carried six
+Scheimpflug-only knobs (`initial_cameras`, `initial_sensors`,
+`fallback_to_shared_init`, `fix_intrinsics_when_overridden`,
+`fix_intrinsics_in_percam_ba`, `fix_distortion_in_percam_ba`) that the
+pinhole config did not. We considered preserving them in either a nested
+struct under `SensorMode::Scheimpflug` or a new
+`RigHandeyeAdvancedScheimpflugConfig` section. Rejected for A6.3: those
+fields were workarounds for narrow-FOV / Zhang-failure cases that have
+not surfaced in practice on the unified pipeline; the most load-bearing
+default — `DistortionFixMask::radial_only()` for Scheimpflug per-camera
+intrinsics refinement — is preserved as a hard-coded constant in
+`step_intrinsics_optimize_all`. Pre-1.0 breakage is acceptable; if a
+real workflow needs them back, they can be re-added without disturbing
+the `SensorMode` shape.
+
+## Consequences
+
+### Positive
+
+- **Sibling count**: 5 rig modules → 3. Adding a new sensor variant
+  (e.g., omnidirectional) is a `SensorMode` enum variant + an inner
+  branch in 4 step functions, not a new ~1,500-line module.
+- **Net LoC delta** across the staged refactor (PRs #36 + #37):
+  ~−2,300 lines.
+  - PR #36 (A6.1 + A6.2): ≈ +1,250 / −1,720 — foundation, dedup, and
+    `rig_extrinsics` collapse.
+  - PR #37 (A6.3): +698 / −2,541 — `rig_handeye` collapse.
+- **Cross-cutting changes** (e.g., the next per-feature-residuals tweak)
+  touch one file per workflow instead of two. PR #35 demonstrated the
+  4×-multiplier; the post-A6 baseline is 2×.
+- **Single source of truth** for `SensorMode` (`rig_family.rs`) avoids
+  the temptation to duplicate the enum across workflow modules.
+
+### Negative
+
+- **Breaking changes** at the public API: every rename, type-change, and
+  module deletion is a downstream migration cost. Pre-1.0 absorbs this,
+  but consumers (e.g., the puzzle 130x130 walkthrough, the deleted
+  Python `run_rig_scheimpflug_*` wrappers) had to migrate.
+- **Output enum verbosity**: `RigExtrinsicsOutput::Pinhole(…)` and
+  `RigHandeyeOutput::Scheimpflug(…)` matches at every internal use site.
+  Mitigated by accessor methods so most call sites just write
+  `output.cam_to_rig()`.
+- **`Option<Vec<ScheimpflugParams>>` on exports** introduces a runtime
+  invariant ("`Some(_)` iff sensor mode was Scheimpflug") that the type
+  system does not enforce. Documented; downstream helpers that need
+  sensors error explicitly when they receive a pinhole export.
+
+### Risk: Scheimpflug calibration regression on real data
+
+The two Scheimpflug integration tests (one for extrinsics, one for
+hand-eye) preserve their exact convergence assertions (intrinsics within
+5%, baseline within 2 cm, hand-eye within 2 cm + 0.02 rad, mean reproj
+< 1 px). They cover both `EyeInHand` and `EyeToHand` for the hand-eye
+variant. Real-data validation on the puzzle 130x130 rig is the next gate
+once the post-A6 facade is exercised end-to-end.
+
+## Implementation map
+
+- **PR #36** — `rig_family` helper module + `rig_extrinsics`
+  consolidation: A6.1 foundation, A6.2a dedup, A6.2b structural
+  collapse of `rig_scheimpflug_extrinsics`.
+- **PR #37** — `rig_handeye` consolidation: A6.3 lifts `SensorMode` to
+  `rig_family`, branches all six step functions, deletes
+  `rig_scheimpflug_handeye`, migrates the integration test.
+- **This PR (A6.4)** — ADR + roadmap hygiene + tutorial cross-link
+  refresh. No new code in workflow modules; `rig_laserline_device` is
+  intentionally untouched (only sibling, no collapse target).
+
+## Status of related ADRs
+
+- **ADR 0011 (Manual init)** — unchanged in semantics. The rig handeye
+  manual-init struct gained `per_cam_sensors`. Documentation refers to
+  the unified `RigHandeyeProblem`.
+- **ADR 0012 (Per-feature residuals)** — unchanged in contract. Both
+  unified rig exports carry `per_feature_residuals`. The ADR's table
+  of nine `*Export` types now lists eight (with one `RigHandeyeExport`
+  serving the pinhole + Scheimpflug pair).
+
+## Out of scope
+
+- Workflow-axis abstraction (kept per-module).
+- Adding new sensor variants beyond Pinhole/Scheimpflug.
+- Python parity for the unified API (deferred per the Track A re-plan,
+  A5).
+- A `rig_scheimpflug_laserline_device` collapse — that variant did not
+  exist as a separate module pre-A6 (`rig_laserline_device` was
+  Scheimpflug-only by upstream contract); no work needed.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -34,3 +34,4 @@ Status legend:
 
 - [0011 - Manual Parameter Initialization Workflow](0011-manual-initialization-workflow.md)
 - [0012 - Per-Feature Reprojection Residuals on Export Types](0012-per-feature-reprojection-residuals.md)
+- [0013 - rig_family Sensor-Axis Refactor (Pinhole + Scheimpflug Unification)](0013-rig-family-sensor-axis-refactor.md)


### PR DESCRIPTION
## Summary

Closes the rig_family sensor-axis refactor (Track A item A6) by recording the design decision and bringing surrounding docs in sync with the post-A6 layout. **No code changes in workflow modules** — only the ADR, roadmap, project-level docs, and an internal cleanup of two test-only accessor methods.

- **ADR 0013** — `rig_family` Sensor-Axis Refactor (Pinhole + Scheimpflug Unification). Captures the duplication audit that motivated the collapse, the decision to factor only the sensor axis via composition (not traits), the alternatives considered (two-axis trait matrix, helper-only with all sibling modules retained, advanced-Scheimpflug-knobs preservation), the consequences (sibling count 5 → 3, ~−2,300 LoC across PRs #36 + #37, single source of truth for `SensorMode`, output-enum verbosity, runtime invariant on `Option<Vec<ScheimpflugParams>>`), and the implementation map across the staged PRs.
- **`docs/ROADMAP.md`** refreshed: **Track A marked DONE** (A1 + A2 + A4 + A6 shipped, A3 closed, A5 dropped); load-bearing path is now `B0 → … → B5`; the stylized Weeks 1–40 sequencing block is deleted; Status header bumped to 2026-05-01. PR #28 (mvg) is the only in-flight reference. Tauri/MVG ADR slots renumbered (0014/0015) since 0013 is now claimed by the rig_family refactor.
- **`docs/adrs/README.md`** indexes ADR 0013.
- **`.claude/CLAUDE.md`** updated: 9 problem types → 7 (the two rig modules are now flavour-aware via `SensorMode`); planning section points to ADR 0013; the strategic-roadmap blurb declares Track A done and the next step `B0`.
- **`rig_family.rs`** internal cleanup: `RigSensorBundle::{num_cameras, is_scheimpflug}` switch from `#[allow(dead_code)]` to `#[cfg(test)]` since they are test-only accessors.

## Why no `rig_laserline_device` collapse

`rig_laserline_device` is the only laser-plane sibling and has no pinhole-vs-Scheimpflug pair to collapse with. After A6.3, it already consumes the unified `RigHandeyeExport` for its upstream calibration (`RigHandeyeExport::to_upstream_calibration` returns `Result<…>` and errors on pinhole rigs — laserline still requires Scheimpflug sensor params).

## Track A is done

The remaining load-bearing path is now `B0 → … → B5`. The post-A6 facade has been the contract for three consecutive PRs (#36, #37, this PR — soon #38) without internal API churn, meeting the testable Track A exit criterion.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — all green
- [x] `cargo doc --workspace --no-deps` — no warnings
- [x] No code changes in workflow modules; `rig_family.rs` change is the only Rust diff (cosmetic — `#[allow(dead_code)]` → `#[cfg(test)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)