### PR TITLE
B0.5+B0.6: rig manifest + viewer UX overhaul (cam-ROI fix, tokens, nav, zoom, histogram, compare)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -136,18 +136,32 @@ be re-pinned manually after any update.
 
 We work to a multi-quarter, four-track plan summarized in `docs/ROADMAP.md`. **Track A is
 done as of 2026-05-01** (A1 + A2 + A4 + A6 shipped; A3 closed, A5 dropped). The
-remaining load-bearing path is **B0 → … → B5**:
+B-track was re-sequenced post-grill on 2026-05-01 to **diagnose-first** because
+the residual visualisation is the actual new capability; everything else
+re-implements what `cargo run --example` already gives a terminal user.
 
 - **A — Calibration core (DONE).** Two rig problem types (`RigExtrinsics`,
   `RigHandeye`) handle both pinhole and Scheimpflug via `SensorMode`; eight
   problem types in total. Manual init (ADR 0011) and per-feature residuals on
   export (ADR 0012) ship across the family.
-- **B — Tauri 2 + React + TypeScript desktop app.** B0 scaffold → B1 file load →
-  B2 detection wrap → B3 calibration runner → B4 3D rig viewer → **B5 diagnose mode
-  (the MVP)** → B6 polish. Next up.
-- **C — MVG** (postponed until B5). C1 PR #28 land → C2 N-view triangulation →
-  C3 BA frozen-intrinsics → C4 Scheimpflug-aware rectification → C5 dense matcher
-  (opencv-rust SGBM, feature-flagged).
+- **B — Tauri 2 + React + TypeScript desktop app (current).**
+  - **B0 — diagnose viewer v0 (DONE, PR #40 + #41).** Passive viewer of one
+    `PlanarIntrinsicsExport`; `ImageManifest` Export-side contract; Tauri 2 +
+    React 19 + Vite 8 + TS 6 shell at `app/`; Tailwind 4 styling. ADR 0014.
+  - **B0.5 — real-data acceptance (current).** Extend `RigHandeyeExport` with
+    `image_manifest`; populate it against the puzzle 130×130 Scheimpflug rig
+    dataset; verify ROI + tiled multi-camera strips render correctly.
+  - **Post-B0 enrichments — priority TBD by user feedback.** Order is no
+    longer pre-committed; will be driven by what the engineer actually
+    misses while using v0. Likely candidates: re-run button calling the
+    facade in-process; multi-pose residual stats panel; cross-camera
+    residual matrix; manifest support on the remaining `*Export` types;
+    in-app detection wrap; 3D rig viewer; init-failure diagnosis;
+    signed installers.
+- **C — MVG** (postponed until B-track diagnose viewer matures). C1 PR #28
+  land → C2 N-view triangulation → C3 BA frozen-intrinsics → C4
+  Scheimpflug-aware rectification → C5 dense matcher (opencv-rust SGBM,
+  feature-flagged).
 - **D — Earn v1.0** (continuous ratchet). Typed errors → doc-warning-free → Python
   parity audit → v1.0 release.
 

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -11,6 +11,8 @@
         "react-dom": "^19.2.5",
       },
       "devDependencies": {
+        "@fontsource/geist-mono": "^5.2.7",
+        "@fontsource/inter": "^5.2.8",
         "@tailwindcss/vite": "^4.2.4",
         "@tauri-apps/cli": "^2.11.0",
         "@types/react": "^19.2.14",
@@ -28,6 +30,10 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.7", "", {}, "sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg=="],
+
+    "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,8 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
+    "@fontsource/geist-mono": "^5.2.7",
+    "@fontsource/inter": "^5.2.8",
     "@tailwindcss/vite": "^4.2.4",
     "@tauri-apps/cli": "^2.11.0",
     "@types/react": "^19.2.14",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,17 +1,94 @@
+import { useEffect, useState } from "react";
+import { Logo } from "./components/Logo";
 import { ResidualViewer } from "./components/ResidualViewer";
 
+const THEME_STORAGE_KEY = "calib-theme";
+
+function isDocumentDark(): boolean {
+  return document.documentElement.classList.contains("dark");
+}
+
 export function App() {
+  const [dark, setDark] = useState<boolean>(isDocumentDark);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+    localStorage.setItem(THEME_STORAGE_KEY, dark ? "dark" : "light");
+  }, [dark]);
+
   return (
     <main className="flex h-full w-full flex-col gap-3 p-4">
-      <header className="flex items-baseline justify-between gap-3">
-        <h1 className="m-0 text-lg font-semibold">
-          calibration-rs · diagnose
-        </h1>
-        <span className="text-xs opacity-60">
-          v0 — passive residual viewer (ADR 0014)
-        </span>
+      <header className="flex items-center justify-between gap-4 border-b border-border pb-3">
+        <div className="flex items-center gap-3">
+          <Logo size={28} className="text-foreground" />
+          <div className="flex flex-col">
+            <h1 className="m-0 text-base font-semibold tracking-tight">
+              calibration-rs · diagnose
+            </h1>
+            <span className="text-[11px] text-muted-foreground">
+              v0 — passive residual viewer (ADR 0014)
+            </span>
+          </div>
+        </div>
+        <ThemeToggle dark={dark} onToggle={() => setDark((d) => !d)} />
       </header>
       <ResidualViewer />
     </main>
+  );
+}
+
+interface ThemeToggleProps {
+  dark: boolean;
+  onToggle: () => void;
+}
+
+function ThemeToggle({ dark, onToggle }: ThemeToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      title={`Switch to ${dark ? "light" : "dark"} theme`}
+      aria-label="Toggle theme"
+      className="grid h-8 w-8 place-items-center !p-0"
+    >
+      {dark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
   );
 }

--- a/app/src/components/CompareViewer.tsx
+++ b/app/src/components/CompareViewer.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useImageData, getPixelLum } from "../hooks/useImageData";
+import type {
+  CursorReadout,
+  FrameKey,
+  TargetFeatureResidual,
+  ViewportTransform,
+} from "../types";
+import { IDENTITY_TRANSFORM } from "../types";
+import { FrameCanvas, type FrameCanvasHandle } from "./FrameCanvas";
+
+interface CompareViewerProps {
+  leftFrame: FrameKey;
+  rightFrame: FrameKey;
+  residuals: TargetFeatureResidual[];
+  /** Active pane receives stepper input + zoom/key shortcuts. */
+  activePane: "left" | "right";
+  onActivePane: (next: "left" | "right") => void;
+  /** When true the two panes share a single viewport transform — wheel
+   * zoom + drag pan in one applies to both, so the same image-pixel
+   * sits at the same canvas pixel on both sides (the workhorse of
+   * cross-camera comparison). */
+  linked: boolean;
+  onCursorChange?: (cursor: CursorReadout | null) => void;
+  onError?: (msg: string) => void;
+}
+
+/** Imperative handle the toolbar uses to drive zoom/fit on whichever
+ * pane is currently active (or both panes when linked). */
+export interface CompareViewerHandle {
+  fitActive(): void;
+  reset1to1Active(): void;
+  zoomActiveBy(factor: number): void;
+}
+
+export function CompareViewer({
+  leftFrame,
+  rightFrame,
+  residuals,
+  activePane,
+  onActivePane,
+  linked,
+  onCursorChange,
+  onError,
+  innerRef,
+}: CompareViewerProps & {
+  innerRef?: React.MutableRefObject<CompareViewerHandle | null>;
+}) {
+  const leftRef = useRef<FrameCanvasHandle | null>(null);
+  const rightRef = useRef<FrameCanvasHandle | null>(null);
+
+  const [linkedTransform, setLinkedTransform] = useState<ViewportTransform>(
+    IDENTITY_TRANSFORM,
+  );
+  const leftImageData = useImageData(leftFrame, onError);
+  const rightImageData = useImageData(rightFrame, onError);
+
+  // Re-fit the linked transform whenever either frame's image becomes
+  // ready and we don't have a meaningful transform yet (initial mount
+  // or post-toggle). After that, the user drives transforms via
+  // wheel / drag / toolbar.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (!linked) return;
+    if (seededRef.current) return;
+    if (!leftImageData) return;
+    seededRef.current = true;
+    leftRef.current?.fit();
+  }, [linked, leftImageData]);
+
+  // When `linked` flips on, force a re-fit so both panes start aligned.
+  // When it flips off, clear the seeded flag so the next link toggle
+  // re-fits.
+  useEffect(() => {
+    if (linked) {
+      leftRef.current?.fit();
+    } else {
+      seededRef.current = false;
+    }
+  }, [linked]);
+
+  const handleCursor = useCallback(
+    (pane: "left" | "right", c: { x: number; y: number } | null) => {
+      const data = pane === "left" ? leftImageData : rightImageData;
+      const frame = pane === "left" ? leftFrame : rightFrame;
+      if (!c || !data) {
+        onCursorChange?.(null);
+        return;
+      }
+      const roi = frame.roi;
+      const srcX = (roi?.x ?? 0) + c.x;
+      const srcY = (roi?.y ?? 0) + c.y;
+      onCursorChange?.({
+        x: c.x,
+        y: c.y,
+        intensity: getPixelLum(data, srcX, srcY),
+      });
+    },
+    [leftImageData, rightImageData, leftFrame, rightFrame, onCursorChange],
+  );
+
+  // Wire the imperative handle so ResidualViewer's toolbar can drive
+  // whichever pane is active. In linked mode the canvases share state,
+  // so calling either pane's methods produces the same effect.
+  useEffect(() => {
+    if (!innerRef) return;
+    innerRef.current = {
+      fitActive: () => {
+        if (linked) {
+          leftRef.current?.fit();
+        } else {
+          (activePane === "left" ? leftRef : rightRef).current?.fit();
+        }
+      },
+      reset1to1Active: () => {
+        if (linked) {
+          leftRef.current?.reset1to1();
+        } else {
+          (activePane === "left" ? leftRef : rightRef).current?.reset1to1();
+        }
+      },
+      zoomActiveBy: (factor) => {
+        if (linked) {
+          leftRef.current?.zoomBy(factor);
+        } else {
+          (activePane === "left" ? leftRef : rightRef).current?.zoomBy(factor);
+        }
+      },
+    };
+    return () => {
+      if (innerRef) innerRef.current = null;
+    };
+  }, [innerRef, linked, activePane]);
+
+  // Tab swaps the active pane in unlinked mode; in linked mode it's
+  // still useful for routing stepper input to the other side.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null;
+      if (
+        tgt &&
+        (tgt.tagName === "INPUT" ||
+          tgt.tagName === "SELECT" ||
+          tgt.tagName === "TEXTAREA" ||
+          tgt.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        onActivePane(activePane === "left" ? "right" : "left");
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [activePane, onActivePane]);
+
+  return (
+    <div className="grid h-full w-full grid-cols-2 gap-2">
+      <div
+        className="flex h-full flex-col"
+        onMouseDown={() => onActivePane("left")}
+      >
+        <FrameCanvas
+          ref={leftRef}
+          frame={leftFrame}
+          residuals={residuals}
+          image={leftImageData?.image ?? null}
+          transform={linked ? linkedTransform : undefined}
+          onTransformChange={linked ? setLinkedTransform : undefined}
+          onCursor={(c) => handleCursor("left", c)}
+          onError={onError}
+          active={activePane === "left"}
+        />
+        <PaneLabel frame={leftFrame} active={activePane === "left"} />
+      </div>
+      <div
+        className="flex h-full flex-col"
+        onMouseDown={() => onActivePane("right")}
+      >
+        <FrameCanvas
+          ref={rightRef}
+          frame={rightFrame}
+          residuals={residuals}
+          image={rightImageData?.image ?? null}
+          transform={linked ? linkedTransform : undefined}
+          onTransformChange={linked ? setLinkedTransform : undefined}
+          onCursor={(c) => handleCursor("right", c)}
+          onError={onError}
+          active={activePane === "right"}
+        />
+        <PaneLabel frame={rightFrame} active={activePane === "right"} />
+      </div>
+    </div>
+  );
+}
+
+function PaneLabel({ frame, active }: { frame: FrameKey; active: boolean }) {
+  return (
+    <div
+      className={`mt-1 font-mono text-[11px] ${
+        active ? "text-brand" : "text-muted-foreground"
+      }`}
+    >
+      pose {frame.pose} · cam {frame.camera}
+    </div>
+  );
+}

--- a/app/src/components/FrameCanvas.tsx
+++ b/app/src/components/FrameCanvas.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type {
   FrameKey,
   TargetFeatureResidual,
@@ -16,24 +15,23 @@ import type {
 
 interface FrameCanvasProps {
   frame: FrameKey;
-  /** All target residuals for the loaded export; the canvas filters
-   * down to those matching `frame.{pose, camera}` before drawing. */
+  /** All target residuals for the loaded export; filtered down to
+   * `frame.{pose, camera}` before drawing. */
   residuals: TargetFeatureResidual[];
-  /** Surfaced when the underlying image fails to decode. */
+  /** Decoded image element from `useImageData`. `null` while loading. */
+  image: HTMLImageElement | null;
+  /** Surfaced when something fails (the parent owns the error UI). */
   onError?: (msg: string) => void;
+  /** Called on `mousemove` with image-pixel coordinates (ROI-local,
+   * matching the residual frame). `null` when the cursor leaves the
+   * image area. */
+  onCursor?: (cursor: { x: number; y: number } | null) => void;
 }
 
-/** Imperative handle the toolbar uses to drive zoom/fit without
- * lifting transform state into the parent. We will lift it later
- * (compare mode wants linked transforms across two canvases), but
- * the imperative shape keeps the single-canvas case simple. */
+/** Imperative handle the toolbar uses to drive zoom/fit. */
 export interface FrameCanvasHandle {
-  /** Set transform so the ROI fills the container with letterbox. */
   fit(): void;
-  /** Set transform so 1 image-pixel = 1 display-pixel, centred. */
   reset1to1(): void;
-  /** Multiply current scale by `factor`, anchored at the canvas
-   * centre. Clamped to [0.25, 16]. */
   zoomBy(factor: number): void;
 }
 
@@ -43,47 +41,19 @@ const SCALE_MIN = 0.25;
 const SCALE_MAX = 16;
 
 export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
-  function FrameCanvas({ frame, residuals, onError }, ref) {
+  function FrameCanvas({ frame, residuals, image, onError, onCursor }, ref) {
+    void onError; // Reserved for future canvas-internal failures.
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const [container, setContainer] = useState({ w: 0, h: 0 });
-    const [imgEl, setImgEl] = useState<HTMLImageElement | null>(null);
     const [transform, setTransform] = useState<ViewportTransform>({
       scale: 1,
       tx: 0,
       ty: 0,
     });
 
-    // ROI helpers — the image is the manifest source PNG; we crop down
-    // to the camera tile via roi when present.
     const roi = frame.roi;
 
-    // Load + decode the image.
-    useEffect(() => {
-      let cancelled = false;
-      setImgEl(null);
-      invoke<string>("load_image", { path: frame.abs_path })
-        .then((dataUrl) => {
-          if (cancelled) return;
-          const img = new Image();
-          img.onload = () => {
-            if (!cancelled) setImgEl(img);
-          };
-          img.onerror = () => {
-            if (!cancelled) onError?.("Image failed to decode.");
-          };
-          img.src = dataUrl;
-        })
-        .catch((e) => {
-          if (!cancelled) onError?.(`Could not load image: ${e}`);
-        });
-      return () => {
-        cancelled = true;
-      };
-    }, [frame.abs_path, onError]);
-
-    // Track container size so the canvas can fill it at 1:1 device
-    // pixels (no CSS scaling — keeps zoomed pixels crisp).
     useLayoutEffect(() => {
       const el = containerRef.current;
       if (!el) return;
@@ -97,11 +67,9 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       return () => observer.disconnect();
     }, []);
 
-    // Compute the canonical "fit" transform: scale ROI uniformly into
-    // the container, centred.
     const computeFit = useCallback((): ViewportTransform => {
-      const sw = roi?.w ?? imgEl?.naturalWidth ?? 0;
-      const sh = roi?.h ?? imgEl?.naturalHeight ?? 0;
+      const sw = roi?.w ?? image?.naturalWidth ?? 0;
+      const sh = roi?.h ?? image?.naturalHeight ?? 0;
       if (sw === 0 || sh === 0 || container.w === 0 || container.h === 0) {
         return { scale: 1, tx: 0, ty: 0 };
       }
@@ -109,25 +77,20 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       const tx = (container.w - scale * sw) / 2;
       const ty = (container.h - scale * sh) / 2;
       return { scale, tx, ty };
-    }, [roi, imgEl, container]);
+    }, [roi, image, container]);
 
-    // Reset to fit whenever the frame or the image/container sizes
-    // change. The dependency on `imgEl` ensures we wait until the
-    // image is decoded; without it the first fit happens against the
-    // wrong (zero) image dimensions.
     useEffect(() => {
-      if (!imgEl || container.w === 0 || container.h === 0) return;
+      if (!image || container.w === 0 || container.h === 0) return;
       setTransform(computeFit());
-    }, [frame.abs_path, imgEl, container, computeFit]);
+    }, [frame.abs_path, image, container, computeFit]);
 
-    // Imperative API for the toolbar.
     useImperativeHandle(
       ref,
       () => ({
         fit: () => setTransform(computeFit()),
         reset1to1: () => {
-          const sw = roi?.w ?? imgEl?.naturalWidth ?? 0;
-          const sh = roi?.h ?? imgEl?.naturalHeight ?? 0;
+          const sw = roi?.w ?? image?.naturalWidth ?? 0;
+          const sh = roi?.h ?? image?.naturalHeight ?? 0;
           setTransform({
             scale: 1,
             tx: (container.w - sw) / 2,
@@ -135,12 +98,13 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
           });
         },
         zoomBy: (factor) =>
-          setTransform((t) => zoomAround(t, factor, container.w / 2, container.h / 2)),
+          setTransform((t) =>
+            zoomAround(t, factor, container.w / 2, container.h / 2),
+          ),
       }),
-      [computeFit, roi, imgEl, container],
+      [computeFit, roi, image, container],
     );
 
-    // Wheel-to-zoom anchored at the cursor.
     const handleWheel = useCallback(
       (e: React.WheelEvent<HTMLCanvasElement>) => {
         e.preventDefault();
@@ -155,7 +119,6 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       [],
     );
 
-    // Drag-to-pan with the primary button.
     const dragRef = useRef<{
       startX: number;
       startY: number;
@@ -172,22 +135,41 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       };
     };
     const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (canvas) {
+        const rect = canvas.getBoundingClientRect();
+        const cx = e.clientX - rect.left;
+        const cy = e.clientY - rect.top;
+        const ix = (cx - transform.tx) / transform.scale;
+        const iy = (cy - transform.ty) / transform.scale;
+        const sw = roi?.w ?? image?.naturalWidth ?? 0;
+        const sh = roi?.h ?? image?.naturalHeight ?? 0;
+        if (ix >= 0 && iy >= 0 && ix < sw && iy < sh) {
+          onCursor?.({ x: ix, y: iy });
+        } else {
+          onCursor?.(null);
+        }
+      }
       const d = dragRef.current;
-      if (!d) return;
-      setTransform((t) => ({
-        ...t,
-        tx: d.tx0 + (e.clientX - d.startX),
-        ty: d.ty0 + (e.clientY - d.startY),
-      }));
+      if (d) {
+        setTransform((t) => ({
+          ...t,
+          tx: d.tx0 + (e.clientX - d.startX),
+          ty: d.ty0 + (e.clientY - d.startY),
+        }));
+      }
     };
     const handleMouseUp = () => {
       dragRef.current = null;
     };
+    const handleMouseLeave = () => {
+      dragRef.current = null;
+      onCursor?.(null);
+    };
 
-    // Render: clear, apply transform, blit ROI, draw arrows.
     useEffect(() => {
       const canvas = canvasRef.current;
-      if (!canvas || !imgEl || container.w === 0) return;
+      if (!canvas || !image || container.w === 0) return;
       canvas.width = container.w;
       canvas.height = container.h;
       const ctx = canvas.getContext("2d");
@@ -205,14 +187,11 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       );
       const sx = roi?.x ?? 0;
       const sy = roi?.y ?? 0;
-      const sw = roi?.w ?? imgEl.naturalWidth;
-      const sh = roi?.h ?? imgEl.naturalHeight;
-      ctx.drawImage(imgEl, sx, sy, sw, sh, 0, 0, sw, sh);
-      // Per ImageManifest convention residual coords are already in the
-      // ROI-local frame, so we draw them directly in canvas-px space —
-      // the transform takes care of zoom/pan.
+      const sw = roi?.w ?? image.naturalWidth;
+      const sh = roi?.h ?? image.naturalHeight;
+      ctx.drawImage(image, sx, sy, sw, sh, 0, 0, sw, sh);
       drawResidualArrows(ctx, residuals, frame, transform.scale);
-    }, [imgEl, container, transform, roi, residuals, frame]);
+    }, [image, container, transform, roi, residuals, frame]);
 
     return (
       <div
@@ -225,7 +204,7 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
           onMouseDown={handleMouseDown}
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseUp}
+          onMouseLeave={handleMouseLeave}
           className="block h-full w-full cursor-grab [image-rendering:pixelated] active:cursor-grabbing"
         />
       </div>
@@ -261,9 +240,6 @@ function drawResidualArrows(
   const arrows = all.filter(
     (r) => r.pose === frame.pose && r.camera === frame.camera,
   );
-  // Draw stroke widths in canvas-px (scale-invariant), so arrows stay
-  // crisp at any zoom level. We pre-scale lineWidth + arrowhead size
-  // by 1/scale because the transform expands them otherwise.
   const inv = 1 / scale;
   for (const r of arrows) {
     if (!r.projected_px) continue;
@@ -311,9 +287,6 @@ function drawArrow(
   ctx.stroke();
 }
 
-/** Cool→warm ramp matching the histogram bucket edges (1, 2, 5, 10 px)
- * already used for `target_hist_per_camera`. Keeps the visual scale
- * consistent across UI surfaces. */
 export function colorForError(err: number): string {
   if (err < 1) return "#1abc9c";
   if (err < 2) return "#2ecc71";

--- a/app/src/components/FrameCanvas.tsx
+++ b/app/src/components/FrameCanvas.tsx
@@ -1,71 +1,199 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type {
   FrameKey,
   TargetFeatureResidual,
   ViewportTransform,
 } from "../types";
-import { IDENTITY_TRANSFORM } from "../types";
 
 interface FrameCanvasProps {
   frame: FrameKey;
   /** All target residuals for the loaded export; the canvas filters
    * down to those matching `frame.{pose, camera}` before drawing. */
   residuals: TargetFeatureResidual[];
-  /** Render-time transform applied via `ctx.setTransform`. Defaults to
-   * identity. Future commits introduce wheel zoom / drag pan against
-   * this prop. */
-  transform?: ViewportTransform;
   /** Surfaced when the underlying image fails to decode. */
   onError?: (msg: string) => void;
 }
 
-/** Cap on rendered arrow length so a freak diverged feature does not
- * dominate the canvas. */
+/** Imperative handle the toolbar uses to drive zoom/fit without
+ * lifting transform state into the parent. We will lift it later
+ * (compare mode wants linked transforms across two canvases), but
+ * the imperative shape keeps the single-canvas case simple. */
+export interface FrameCanvasHandle {
+  /** Set transform so the ROI fills the container with letterbox. */
+  fit(): void;
+  /** Set transform so 1 image-pixel = 1 display-pixel, centred. */
+  reset1to1(): void;
+  /** Multiply current scale by `factor`, anchored at the canvas
+   * centre. Clamped to [0.25, 16]. */
+  zoomBy(factor: number): void;
+}
+
 const ARROW_LENGTH_CAP_PX = 40;
-/** Multiplier applied to the residual vector so sub-pixel errors are
- * actually visible on a 640×480 canvas. */
 const ARROW_GAIN = 30;
+const SCALE_MIN = 0.25;
+const SCALE_MAX = 16;
 
-export function FrameCanvas({
-  frame,
-  residuals,
-  transform = IDENTITY_TRANSFORM,
-  onError,
-}: FrameCanvasProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const [imgUrl, setImgUrl] = useState<string | null>(null);
+export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
+  function FrameCanvas({ frame, residuals, onError }, ref) {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [container, setContainer] = useState({ w: 0, h: 0 });
+    const [imgEl, setImgEl] = useState<HTMLImageElement | null>(null);
+    const [transform, setTransform] = useState<ViewportTransform>({
+      scale: 1,
+      tx: 0,
+      ty: 0,
+    });
 
-  useEffect(() => {
-    let cancelled = false;
-    setImgUrl(null);
-    invoke<string>("load_image", { path: frame.abs_path })
-      .then((dataUrl) => {
-        if (!cancelled) setImgUrl(dataUrl);
-      })
-      .catch((e) => {
-        if (!cancelled) onError?.(`Could not load image: ${e}`);
+    // ROI helpers — the image is the manifest source PNG; we crop down
+    // to the camera tile via roi when present.
+    const roi = frame.roi;
+
+    // Load + decode the image.
+    useEffect(() => {
+      let cancelled = false;
+      setImgEl(null);
+      invoke<string>("load_image", { path: frame.abs_path })
+        .then((dataUrl) => {
+          if (cancelled) return;
+          const img = new Image();
+          img.onload = () => {
+            if (!cancelled) setImgEl(img);
+          };
+          img.onerror = () => {
+            if (!cancelled) onError?.("Image failed to decode.");
+          };
+          img.src = dataUrl;
+        })
+        .catch((e) => {
+          if (!cancelled) onError?.(`Could not load image: ${e}`);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }, [frame.abs_path, onError]);
+
+    // Track container size so the canvas can fill it at 1:1 device
+    // pixels (no CSS scaling — keeps zoomed pixels crisp).
+    useLayoutEffect(() => {
+      const el = containerRef.current;
+      if (!el) return;
+      const observer = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const { width, height } = entry.contentRect;
+          setContainer({ w: Math.max(1, width | 0), h: Math.max(1, height | 0) });
+        }
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [frame.abs_path, onError]);
+      observer.observe(el);
+      return () => observer.disconnect();
+    }, []);
 
-  useEffect(() => {
-    if (!imgUrl) return;
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const img = new Image();
-    img.onload = () => {
+    // Compute the canonical "fit" transform: scale ROI uniformly into
+    // the container, centred.
+    const computeFit = useCallback((): ViewportTransform => {
+      const sw = roi?.w ?? imgEl?.naturalWidth ?? 0;
+      const sh = roi?.h ?? imgEl?.naturalHeight ?? 0;
+      if (sw === 0 || sh === 0 || container.w === 0 || container.h === 0) {
+        return { scale: 1, tx: 0, ty: 0 };
+      }
+      const scale = Math.min(container.w / sw, container.h / sh);
+      const tx = (container.w - scale * sw) / 2;
+      const ty = (container.h - scale * sh) / 2;
+      return { scale, tx, ty };
+    }, [roi, imgEl, container]);
+
+    // Reset to fit whenever the frame or the image/container sizes
+    // change. The dependency on `imgEl` ensures we wait until the
+    // image is decoded; without it the first fit happens against the
+    // wrong (zero) image dimensions.
+    useEffect(() => {
+      if (!imgEl || container.w === 0 || container.h === 0) return;
+      setTransform(computeFit());
+    }, [frame.abs_path, imgEl, container, computeFit]);
+
+    // Imperative API for the toolbar.
+    useImperativeHandle(
+      ref,
+      () => ({
+        fit: () => setTransform(computeFit()),
+        reset1to1: () => {
+          const sw = roi?.w ?? imgEl?.naturalWidth ?? 0;
+          const sh = roi?.h ?? imgEl?.naturalHeight ?? 0;
+          setTransform({
+            scale: 1,
+            tx: (container.w - sw) / 2,
+            ty: (container.h - sh) / 2,
+          });
+        },
+        zoomBy: (factor) =>
+          setTransform((t) => zoomAround(t, factor, container.w / 2, container.h / 2)),
+      }),
+      [computeFit, roi, imgEl, container],
+    );
+
+    // Wheel-to-zoom anchored at the cursor.
+    const handleWheel = useCallback(
+      (e: React.WheelEvent<HTMLCanvasElement>) => {
+        e.preventDefault();
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const rect = canvas.getBoundingClientRect();
+        const cx = e.clientX - rect.left;
+        const cy = e.clientY - rect.top;
+        const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+        setTransform((t) => zoomAround(t, factor, cx, cy));
+      },
+      [],
+    );
+
+    // Drag-to-pan with the primary button.
+    const dragRef = useRef<{
+      startX: number;
+      startY: number;
+      tx0: number;
+      ty0: number;
+    } | null>(null);
+    const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (e.button !== 0) return;
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        tx0: transform.tx,
+        ty0: transform.ty,
+      };
+    };
+    const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const d = dragRef.current;
+      if (!d) return;
+      setTransform((t) => ({
+        ...t,
+        tx: d.tx0 + (e.clientX - d.startX),
+        ty: d.ty0 + (e.clientY - d.startY),
+      }));
+    };
+    const handleMouseUp = () => {
+      dragRef.current = null;
+    };
+
+    // Render: clear, apply transform, blit ROI, draw arrows.
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas || !imgEl || container.w === 0) return;
+      canvas.width = container.w;
+      canvas.height = container.h;
       const ctx = canvas.getContext("2d");
       if (!ctx) return;
-      const roi = frame.roi;
-      const sx = roi?.x ?? 0;
-      const sy = roi?.y ?? 0;
-      const sw = roi?.w ?? img.naturalWidth;
-      const sh = roi?.h ?? img.naturalHeight;
-      canvas.width = sw;
-      canvas.height = sh;
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.imageSmoothingEnabled = false;
       ctx.setTransform(
         transform.scale,
@@ -75,33 +203,68 @@ export function FrameCanvas({
         transform.tx,
         transform.ty,
       );
-      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
-      // Per ImageManifest convention, residual pixel coords are already
-      // ROI-local — the canvas was just blitted from `[sx, sx+sw) ×
-      // [sy, sy+sh)` to `(0, 0)`, so we draw residuals in canvas-pixel
-      // space directly.
-      drawResidualArrows(ctx, residuals, frame);
-    };
-    img.onerror = () => onError?.("Image failed to decode.");
-    img.src = imgUrl;
-  }, [frame, residuals, imgUrl, transform, onError]);
+      const sx = roi?.x ?? 0;
+      const sy = roi?.y ?? 0;
+      const sw = roi?.w ?? imgEl.naturalWidth;
+      const sh = roi?.h ?? imgEl.naturalHeight;
+      ctx.drawImage(imgEl, sx, sy, sw, sh, 0, 0, sw, sh);
+      // Per ImageManifest convention residual coords are already in the
+      // ROI-local frame, so we draw them directly in canvas-px space —
+      // the transform takes care of zoom/pan.
+      drawResidualArrows(ctx, residuals, frame, transform.scale);
+    }, [imgEl, container, transform, roi, residuals, frame]);
 
-  return (
-    <canvas
-      ref={canvasRef}
-      className="max-h-full max-w-full border border-border [image-rendering:pixelated]"
-    />
-  );
+    return (
+      <div
+        ref={containerRef}
+        className="relative h-full w-full overflow-hidden rounded-md bg-bg-soft"
+      >
+        <canvas
+          ref={canvasRef}
+          onWheel={handleWheel}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={handleMouseUp}
+          className="block h-full w-full cursor-grab [image-rendering:pixelated] active:cursor-grabbing"
+        />
+      </div>
+    );
+  },
+);
+
+function zoomAround(
+  t: ViewportTransform,
+  factor: number,
+  cx: number,
+  cy: number,
+): ViewportTransform {
+  const next = clampScale(t.scale * factor);
+  const real = next / t.scale;
+  return {
+    scale: next,
+    tx: cx - (cx - t.tx) * real,
+    ty: cy - (cy - t.ty) * real,
+  };
+}
+
+function clampScale(s: number): number {
+  return Math.min(SCALE_MAX, Math.max(SCALE_MIN, s));
 }
 
 function drawResidualArrows(
   ctx: CanvasRenderingContext2D,
   all: TargetFeatureResidual[],
   frame: FrameKey,
+  scale: number,
 ) {
   const arrows = all.filter(
     (r) => r.pose === frame.pose && r.camera === frame.camera,
   );
+  // Draw stroke widths in canvas-px (scale-invariant), so arrows stay
+  // crisp at any zoom level. We pre-scale lineWidth + arrowhead size
+  // by 1/scale because the transform expands them otherwise.
+  const inv = 1 / scale;
   for (const r of arrows) {
     if (!r.projected_px) continue;
     const ox = r.observed_px[0];
@@ -114,11 +277,11 @@ function drawResidualArrows(
     const dx = dx0 * gain;
     const dy = dy0 * gain;
     ctx.strokeStyle = colorForError(r.error_px ?? mag);
-    ctx.lineWidth = 1.5;
-    drawArrow(ctx, ox, oy, ox + dx, oy + dy);
+    ctx.lineWidth = 1.5 * inv;
+    drawArrow(ctx, ox, oy, ox + dx, oy + dy, inv);
     ctx.fillStyle = "rgba(255,255,255,0.85)";
     ctx.beginPath();
-    ctx.arc(ox, oy, 1.6, 0, Math.PI * 2);
+    ctx.arc(ox, oy, 1.6 * inv, 0, Math.PI * 2);
     ctx.fill();
   }
 }
@@ -129,9 +292,10 @@ function drawArrow(
   y1: number,
   x2: number,
   y2: number,
+  inv: number,
 ) {
   const angle = Math.atan2(y2 - y1, x2 - x1);
-  const head = 4;
+  const head = 4 * inv;
   ctx.beginPath();
   ctx.moveTo(x1, y1);
   ctx.lineTo(x2, y2);
@@ -149,7 +313,7 @@ function drawArrow(
 
 /** Cool→warm ramp matching the histogram bucket edges (1, 2, 5, 10 px)
  * already used for `target_hist_per_camera`. Keeps the visual scale
- * consistent across UI surfaces if a histogram view is added later. */
+ * consistent across UI surfaces. */
 export function colorForError(err: number): string {
   if (err < 1) return "#1abc9c";
   if (err < 2) return "#2ecc71";

--- a/app/src/components/FrameCanvas.tsx
+++ b/app/src/components/FrameCanvas.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  FrameKey,
+  TargetFeatureResidual,
+  ViewportTransform,
+} from "../types";
+import { IDENTITY_TRANSFORM } from "../types";
+
+interface FrameCanvasProps {
+  frame: FrameKey;
+  /** All target residuals for the loaded export; the canvas filters
+   * down to those matching `frame.{pose, camera}` before drawing. */
+  residuals: TargetFeatureResidual[];
+  /** Render-time transform applied via `ctx.setTransform`. Defaults to
+   * identity. Future commits introduce wheel zoom / drag pan against
+   * this prop. */
+  transform?: ViewportTransform;
+  /** Surfaced when the underlying image fails to decode. */
+  onError?: (msg: string) => void;
+}
+
+/** Cap on rendered arrow length so a freak diverged feature does not
+ * dominate the canvas. */
+const ARROW_LENGTH_CAP_PX = 40;
+/** Multiplier applied to the residual vector so sub-pixel errors are
+ * actually visible on a 640×480 canvas. */
+const ARROW_GAIN = 30;
+
+export function FrameCanvas({
+  frame,
+  residuals,
+  transform = IDENTITY_TRANSFORM,
+  onError,
+}: FrameCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [imgUrl, setImgUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setImgUrl(null);
+    invoke<string>("load_image", { path: frame.abs_path })
+      .then((dataUrl) => {
+        if (!cancelled) setImgUrl(dataUrl);
+      })
+      .catch((e) => {
+        if (!cancelled) onError?.(`Could not load image: ${e}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [frame.abs_path, onError]);
+
+  useEffect(() => {
+    if (!imgUrl) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const img = new Image();
+    img.onload = () => {
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      const roi = frame.roi;
+      const sx = roi?.x ?? 0;
+      const sy = roi?.y ?? 0;
+      const sw = roi?.w ?? img.naturalWidth;
+      const sh = roi?.h ?? img.naturalHeight;
+      canvas.width = sw;
+      canvas.height = sh;
+      ctx.imageSmoothingEnabled = false;
+      ctx.setTransform(
+        transform.scale,
+        0,
+        0,
+        transform.scale,
+        transform.tx,
+        transform.ty,
+      );
+      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
+      // Per ImageManifest convention, residual pixel coords are already
+      // ROI-local — the canvas was just blitted from `[sx, sx+sw) ×
+      // [sy, sy+sh)` to `(0, 0)`, so we draw residuals in canvas-pixel
+      // space directly.
+      drawResidualArrows(ctx, residuals, frame);
+    };
+    img.onerror = () => onError?.("Image failed to decode.");
+    img.src = imgUrl;
+  }, [frame, residuals, imgUrl, transform, onError]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="max-h-full max-w-full border border-border [image-rendering:pixelated]"
+    />
+  );
+}
+
+function drawResidualArrows(
+  ctx: CanvasRenderingContext2D,
+  all: TargetFeatureResidual[],
+  frame: FrameKey,
+) {
+  const arrows = all.filter(
+    (r) => r.pose === frame.pose && r.camera === frame.camera,
+  );
+  for (const r of arrows) {
+    if (!r.projected_px) continue;
+    const ox = r.observed_px[0];
+    const oy = r.observed_px[1];
+    const dx0 = r.projected_px[0] - r.observed_px[0];
+    const dy0 = r.projected_px[1] - r.observed_px[1];
+    const mag = Math.hypot(dx0, dy0);
+    if (mag < 1e-6) continue;
+    const gain = Math.min(ARROW_GAIN, ARROW_LENGTH_CAP_PX / Math.max(mag, 1e-6));
+    const dx = dx0 * gain;
+    const dy = dy0 * gain;
+    ctx.strokeStyle = colorForError(r.error_px ?? mag);
+    ctx.lineWidth = 1.5;
+    drawArrow(ctx, ox, oy, ox + dx, oy + dy);
+    ctx.fillStyle = "rgba(255,255,255,0.85)";
+    ctx.beginPath();
+    ctx.arc(ox, oy, 1.6, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawArrow(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+) {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const head = 4;
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.lineTo(
+    x2 - head * Math.cos(angle - Math.PI / 6),
+    y2 - head * Math.sin(angle - Math.PI / 6),
+  );
+  ctx.moveTo(x2, y2);
+  ctx.lineTo(
+    x2 - head * Math.cos(angle + Math.PI / 6),
+    y2 - head * Math.sin(angle + Math.PI / 6),
+  );
+  ctx.stroke();
+}
+
+/** Cool→warm ramp matching the histogram bucket edges (1, 2, 5, 10 px)
+ * already used for `target_hist_per_camera`. Keeps the visual scale
+ * consistent across UI surfaces if a histogram view is added later. */
+export function colorForError(err: number): string {
+  if (err < 1) return "#1abc9c";
+  if (err < 2) return "#2ecc71";
+  if (err < 5) return "#f1c40f";
+  if (err < 10) return "#e67e22";
+  return "#e74c3c";
+}

--- a/app/src/components/FrameCanvas.tsx
+++ b/app/src/components/FrameCanvas.tsx
@@ -12,20 +12,31 @@ import type {
   TargetFeatureResidual,
   ViewportTransform,
 } from "../types";
+import { IDENTITY_TRANSFORM } from "../types";
 
 interface FrameCanvasProps {
   frame: FrameKey;
-  /** All target residuals for the loaded export; filtered down to
+  /** Target residuals for the loaded export; filtered down to
    * `frame.{pose, camera}` before drawing. */
   residuals: TargetFeatureResidual[];
-  /** Decoded image element from `useImageData`. `null` while loading. */
+  /** Decoded image element. `null` while loading. */
   image: HTMLImageElement | null;
+  /** Controlled transform. When provided, the canvas treats it as
+   * authoritative and emits all updates via `onTransformChange`.
+   * When `undefined` the canvas keeps an internal transform — the
+   * single-pane mode used by `ResidualViewer`. Compare mode passes
+   * a shared transform from above. */
+  transform?: ViewportTransform;
+  onTransformChange?: (t: ViewportTransform) => void;
   /** Surfaced when something fails (the parent owns the error UI). */
   onError?: (msg: string) => void;
   /** Called on `mousemove` with image-pixel coordinates (ROI-local,
    * matching the residual frame). `null` when the cursor leaves the
    * image area. */
   onCursor?: (cursor: { x: number; y: number } | null) => void;
+  /** Visual ring drawn around the canvas when this pane is the
+   * keyboard-active pane in compare mode. */
+  active?: boolean;
 }
 
 /** Imperative handle the toolbar uses to drive zoom/fit. */
@@ -41,16 +52,42 @@ const SCALE_MIN = 0.25;
 const SCALE_MAX = 16;
 
 export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
-  function FrameCanvas({ frame, residuals, image, onError, onCursor }, ref) {
-    void onError; // Reserved for future canvas-internal failures.
+  function FrameCanvas(
+    {
+      frame,
+      residuals,
+      image,
+      transform: controlled,
+      onTransformChange,
+      onError,
+      onCursor,
+      active,
+    },
+    ref,
+  ) {
+    void onError;
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const [container, setContainer] = useState({ w: 0, h: 0 });
-    const [transform, setTransform] = useState<ViewportTransform>({
-      scale: 1,
-      tx: 0,
-      ty: 0,
-    });
+    const [internal, setInternal] = useState<ViewportTransform>(IDENTITY_TRANSFORM);
+    const isControlled = controlled !== undefined;
+    const transform = controlled ?? internal;
+
+    const setTransform = useCallback(
+      (next: ViewportTransform | ((prev: ViewportTransform) => ViewportTransform)) => {
+        const value =
+          typeof next === "function"
+            ? (next as (p: ViewportTransform) => ViewportTransform)(transform)
+            : next;
+        if (isControlled) {
+          onTransformChange?.(value);
+        } else {
+          setInternal(value);
+          onTransformChange?.(value);
+        }
+      },
+      [isControlled, onTransformChange, transform],
+    );
 
     const roi = frame.roi;
 
@@ -71,7 +108,7 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       const sw = roi?.w ?? image?.naturalWidth ?? 0;
       const sh = roi?.h ?? image?.naturalHeight ?? 0;
       if (sw === 0 || sh === 0 || container.w === 0 || container.h === 0) {
-        return { scale: 1, tx: 0, ty: 0 };
+        return IDENTITY_TRANSFORM;
       }
       const scale = Math.min(container.w / sw, container.h / sh);
       const tx = (container.w - scale * sw) / 2;
@@ -79,10 +116,14 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       return { scale, tx, ty };
     }, [roi, image, container]);
 
+    // Auto-fit on frame change is owned by the canvas only in
+    // uncontrolled mode. When the parent controls the transform
+    // (compare mode with linked panes), it decides when to re-fit.
     useEffect(() => {
+      if (isControlled) return;
       if (!image || container.w === 0 || container.h === 0) return;
-      setTransform(computeFit());
-    }, [frame.abs_path, image, container, computeFit]);
+      setInternal(computeFit());
+    }, [frame.abs_path, image, container, computeFit, isControlled]);
 
     useImperativeHandle(
       ref,
@@ -102,7 +143,7 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
             zoomAround(t, factor, container.w / 2, container.h / 2),
           ),
       }),
-      [computeFit, roi, image, container],
+      [computeFit, roi, image, container, setTransform],
     );
 
     const handleWheel = useCallback(
@@ -116,7 +157,7 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
         const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
         setTransform((t) => zoomAround(t, factor, cx, cy));
       },
-      [],
+      [setTransform],
     );
 
     const dragRef = useRef<{
@@ -196,7 +237,9 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
     return (
       <div
         ref={containerRef}
-        className="relative h-full w-full overflow-hidden rounded-md bg-bg-soft"
+        className={`relative h-full w-full overflow-hidden rounded-md bg-bg-soft transition-shadow ${
+          active ? "ring-1 ring-brand" : ""
+        }`}
       >
         <canvas
           ref={canvasRef}

--- a/app/src/components/Histogram.tsx
+++ b/app/src/components/Histogram.tsx
@@ -1,0 +1,60 @@
+interface HistogramProps {
+  /** Bin counts (left-to-right). The component normalises by max. */
+  bins: number[];
+  /** 0-based bin index to highlight (cursor) — `null` for none. */
+  cursorBin?: number | null;
+  /** SVG width / height in CSS px. */
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+/** Simple SVG histogram bar chart. Bars are grey-on-bg-soft; the
+ * cursor bin is recoloured to `--brand` when supplied. The component
+ * is presentational only — bin computation lives in the
+ * `useImageData` hook. */
+export function Histogram({
+  bins,
+  cursorBin,
+  width = 240,
+  height = 36,
+  className,
+}: HistogramProps) {
+  const max = bins.reduce((m, v) => Math.max(m, v), 0);
+  if (max === 0) {
+    return (
+      <svg width={width} height={height} className={className} aria-hidden>
+        <rect width={width} height={height} fill="hsl(var(--bg-soft))" />
+      </svg>
+    );
+  }
+  const barW = width / bins.length;
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-label="grayscale histogram"
+    >
+      <rect width={width} height={height} fill="hsl(var(--bg-soft))" />
+      {bins.map((v, i) => {
+        const h = (v / max) * (height - 2);
+        const x = i * barW;
+        const isCursor = cursorBin === i;
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={height - h}
+            width={Math.max(barW - 0.5, 0.5)}
+            height={h}
+            fill={
+              isCursor ? "hsl(var(--brand))" : "hsl(var(--muted-foreground) / 0.55)"
+            }
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/app/src/components/Logo.tsx
+++ b/app/src/components/Logo.tsx
@@ -1,0 +1,50 @@
+interface LogoProps {
+  /** Pixel size of the bounding square. Logo scales uniformly. */
+  size?: number;
+  className?: string;
+}
+
+/* SVG geometry extracted from the vitavision logo
+   (https://github.com/VitalyVorobyev/vitavision —
+   src/components/shared/VitavisionLogo.tsx). Rendered as a static
+   stroke-based "V" with a cyan dot pupil; no entrance animation —
+   the diagnose viewer remounts the logo on every export reload, so
+   a draw-in animation gets eye-poking fast. */
+const V_OUTER =
+  "m102.8 113.4 15.6-27.6h34.7l-40 71s-.6 1.3-3.3 4.7c-1.6 2-4.3 3-7 3q-4.2 0-7-2.9c-1.6-1.7-4-6.2-4-6.2L52.4 85.8H87z";
+const V_INNER = "m102.6 112.3 28.2-15.1-28 49.5-28-49.5Z";
+
+export function Logo({ size = 24, className }: LogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 107.9 82.9"
+      xmlns="http://www.w3.org/2000/svg"
+      shapeRendering="geometricPrecision"
+      aria-label="vitavision V mark"
+      className={className}
+    >
+      <g transform="translate(-48.8 -83.7)">
+        <path
+          d={V_OUTER}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={5.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d={V_INNER}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={5.4}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle cx={102.7} cy={112} r={11.8} fill="hsl(var(--background))" />
+        <circle cx={102.6} cy={112} r={8.1} fill="hsl(var(--brand))" />
+      </g>
+    </svg>
+  );
+}

--- a/app/src/components/PoseCameraStepper.tsx
+++ b/app/src/components/PoseCameraStepper.tsx
@@ -1,0 +1,75 @@
+interface PoseCameraStepperProps {
+  pose: number;
+  camera: number;
+  numPoses: number;
+  numCameras: number;
+  onPose: (next: number) => void;
+  onCamera: (next: number) => void;
+}
+
+/** Two stepper widgets side by side: pose (←/→) and camera (←/→).
+ * Wraps around at the boundaries. The arrow keys are also bound at
+ * the window level via `useKeyboardNav`; these buttons are the
+ * mouse-only path. */
+export function PoseCameraStepper({
+  pose,
+  camera,
+  numPoses,
+  numCameras,
+  onPose,
+  onCamera,
+}: PoseCameraStepperProps) {
+  const wrap = (i: number, n: number) => ((i % n) + n) % n;
+  return (
+    <div className="flex items-center gap-4">
+      <Stepper
+        label="pose"
+        index={pose}
+        count={numPoses}
+        onChange={(next) => onPose(wrap(next, numPoses))}
+      />
+      <Stepper
+        label="cam"
+        index={camera}
+        count={numCameras}
+        onChange={(next) => onCamera(wrap(next, numCameras))}
+      />
+    </div>
+  );
+}
+
+interface StepperProps {
+  label: string;
+  index: number;
+  count: number;
+  onChange: (next: number) => void;
+}
+
+function Stepper({ label, index, count, onChange }: StepperProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="font-mono text-[11px] text-muted-foreground">{label}</span>
+      <button
+        type="button"
+        onClick={() => onChange(index - 1)}
+        aria-label={`previous ${label}`}
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+        title={`previous ${label}`}
+      >
+        ◀
+      </button>
+      <span className="min-w-[3.5rem] text-center font-mono text-xs tabular-nums">
+        {index + 1} / {count}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(index + 1)}
+        aria-label={`next ${label}`}
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+        title={`next ${label}`}
+      >
+        ▶
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/PoseCameraStepper.tsx
+++ b/app/src/components/PoseCameraStepper.tsx
@@ -1,38 +1,47 @@
 interface PoseCameraStepperProps {
-  pose: number;
-  camera: number;
-  numPoses: number;
-  numCameras: number;
-  onPose: (next: number) => void;
-  onCamera: (next: number) => void;
+  /** 1-indexed ordinal of the current pose within the meaningful set
+   * (the manifest's available poses for the current camera, or all
+   * distinct poses if the parent treats them globally). */
+  poseOrdinal: number;
+  /** Count of meaningful poses — the denominator in `i / N`. */
+  poseTotal: number;
+  cameraOrdinal: number;
+  cameraTotal: number;
+  /** Step the pose by `delta` (typically ±1). The parent handles
+   * wraparound and ROI-aware skipping over manifest gaps. */
+  onPoseStep: (delta: number) => void;
+  onCameraStep: (delta: number) => void;
 }
 
-/** Two stepper widgets side by side: pose (←/→) and camera (←/→).
- * Wraps around at the boundaries. The arrow keys are also bound at
- * the window level via `useKeyboardNav`; these buttons are the
- * mouse-only path. */
+/** Two stepper widgets side by side: pose (◀ / ▶) and camera (◀ / ▶).
+ * The arrow keys are also bound at the window level via
+ * `useKeyboardNav`; these buttons are the mouse-only path. The
+ * stepper itself is dumb — the parent decides what "next" means
+ * (especially for sparse manifests where some `(pose, camera)`
+ * combinations don't exist). */
 export function PoseCameraStepper({
-  pose,
-  camera,
-  numPoses,
-  numCameras,
-  onPose,
-  onCamera,
+  poseOrdinal,
+  poseTotal,
+  cameraOrdinal,
+  cameraTotal,
+  onPoseStep,
+  onCameraStep,
 }: PoseCameraStepperProps) {
-  const wrap = (i: number, n: number) => ((i % n) + n) % n;
   return (
     <div className="flex items-center gap-4">
       <Stepper
         label="pose"
-        index={pose}
-        count={numPoses}
-        onChange={(next) => onPose(wrap(next, numPoses))}
+        ordinal={poseOrdinal}
+        total={poseTotal}
+        onPrev={() => onPoseStep(-1)}
+        onNext={() => onPoseStep(+1)}
       />
       <Stepper
         label="cam"
-        index={camera}
-        count={numCameras}
-        onChange={(next) => onCamera(wrap(next, numCameras))}
+        ordinal={cameraOrdinal}
+        total={cameraTotal}
+        onPrev={() => onCameraStep(-1)}
+        onNext={() => onCameraStep(+1)}
       />
     </div>
   );
@@ -40,18 +49,19 @@ export function PoseCameraStepper({
 
 interface StepperProps {
   label: string;
-  index: number;
-  count: number;
-  onChange: (next: number) => void;
+  ordinal: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
 }
 
-function Stepper({ label, index, count, onChange }: StepperProps) {
+function Stepper({ label, ordinal, total, onPrev, onNext }: StepperProps) {
   return (
     <div className="flex items-center gap-1">
       <span className="font-mono text-[11px] text-muted-foreground">{label}</span>
       <button
         type="button"
-        onClick={() => onChange(index - 1)}
+        onClick={onPrev}
         aria-label={`previous ${label}`}
         className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
         title={`previous ${label}`}
@@ -59,11 +69,11 @@ function Stepper({ label, index, count, onChange }: StepperProps) {
         ◀
       </button>
       <span className="min-w-[3.5rem] text-center font-mono text-xs tabular-nums">
-        {index + 1} / {count}
+        {ordinal} / {total}
       </span>
       <button
         type="button"
-        onClick={() => onChange(index + 1)}
+        onClick={onNext}
         aria-label={`next ${label}`}
         className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
         title={`next ${label}`}

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -1,54 +1,32 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { isTauriContext, joinPath } from "../lib/tauri";
+import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import type {
   FrameKey,
   LoadExportResult,
   PlanarExport,
   TargetFeatureResidual,
 } from "../types";
-
-// True iff the page is running inside a Tauri webview (i.e. the IPC
-// internals have been injected). When the user runs `bun run dev` and
-// loads localhost:1420 in a regular browser, this is false and any
-// `invoke` / dialog call would throw `Cannot read properties of
-// undefined (reading 'invoke')`. We guard up-front so the failure mode
-// is a readable banner instead of an opaque TypeError.
-function isTauriContext(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    "__TAURI_INTERNALS__" in window &&
-    (window as unknown as { __TAURI_INTERNALS__?: unknown })
-      .__TAURI_INTERNALS__ != null
-  );
-}
-
-// Path joining for absolute filesystem paths. Tauri exposes a path
-// utility but for v0 the manifest only ever uses POSIX-style relatives,
-// so a hand-rolled join keeps the dependency surface tiny.
-function joinPath(dir: string, ...rest: string[]): string {
-  let out = dir.replace(/[\\/]+$/, "");
-  for (const segment of rest) {
-    if (!segment) continue;
-    const sep = out.includes("\\") && !out.includes("/") ? "\\" : "/";
-    out = `${out}${sep}${segment.replace(/^[\\/]+/, "")}`;
-  }
-  return out;
-}
+import { FrameCanvas, colorForError } from "./FrameCanvas";
+import { PoseCameraStepper } from "./PoseCameraStepper";
 
 interface ExportState {
   exportPath: string;
   exportDir: string;
   data: PlanarExport;
   frames: FrameKey[];
+  /** `pose` values run [0, numPoses); `camera` values run [0, numCameras). */
+  numPoses: number;
+  numCameras: number;
 }
 
 export function ResidualViewer() {
   const [state, setState] = useState<ExportState | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [pose, setPose] = useState<number>(0);
+  const [camera, setCamera] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
-  const [imgUrl, setImgUrl] = useState<string | null>(null);
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const tauriOk = isTauriContext();
 
   const handleOpen = async () => {
@@ -94,71 +72,54 @@ export function ResidualViewer() {
         abs_path: joinPath(root, f.path),
         roi: f.roi,
       }));
+      const numPoses =
+        frames.reduce((m, f) => Math.max(m, f.pose), -1) + 1;
+      const numCameras =
+        frames.reduce((m, f) => Math.max(m, f.camera), -1) + 1;
       setState({
         exportPath: chosen,
         exportDir: result.export_dir,
         data: result.export,
         frames,
+        numPoses: Math.max(numPoses, 1),
+        numCameras: Math.max(numCameras, 1),
       });
-      setSelected(frames[0] ? frameKey(frames[0]) : null);
+      setPose(0);
+      setCamera(0);
     } catch (e) {
       setError(`Could not load export: ${e}`);
     }
   };
 
   const frame = useMemo<FrameKey | null>(() => {
-    if (!state || !selected) return null;
-    return state.frames.find((f) => frameKey(f) === selected) ?? null;
-  }, [state, selected]);
+    if (!state) return null;
+    return (
+      state.frames.find((f) => f.pose === pose && f.camera === camera) ?? null
+    );
+  }, [state, pose, camera]);
 
-  // Load the image bytes when the selection changes.
-  useEffect(() => {
-    if (!frame) {
-      setImgUrl(null);
-      return;
-    }
-    let cancelled = false;
-    setImgUrl(null);
-    invoke<string>("load_image", { path: frame.abs_path })
-      .then((dataUrl) => {
-        if (!cancelled) setImgUrl(dataUrl);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(`Could not load image: ${e}`);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [frame]);
+  const stepPose = useCallback(
+    (delta: number) => {
+      if (!state) return;
+      setPose((p) => ((p + delta) % state.numPoses + state.numPoses) % state.numPoses);
+    },
+    [state],
+  );
+  const stepCamera = useCallback(
+    (delta: number) => {
+      if (!state) return;
+      setCamera(
+        (c) => ((c + delta) % state.numCameras + state.numCameras) % state.numCameras,
+      );
+    },
+    [state],
+  );
 
-  // Draw image + arrows whenever the selection or image changes.
-  useEffect(() => {
-    if (!state || !frame || !imgUrl) return;
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const img = new Image();
-    img.onload = () => {
-      const ctx = canvas.getContext("2d");
-      if (!ctx) return;
-      const roi = frame.roi;
-      const sx = roi?.x ?? 0;
-      const sy = roi?.y ?? 0;
-      const sw = roi?.w ?? img.naturalWidth;
-      const sh = roi?.h ?? img.naturalHeight;
-      canvas.width = sw;
-      canvas.height = sh;
-      ctx.imageSmoothingEnabled = false;
-      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
-      // Per ImageManifest convention (see image_manifest.rs `# Coordinate
-      // convention`), residual pixel coords are already in the ROI-local
-      // frame, so we draw them directly onto the canvas — which we just
-      // blitted from `[sx, sx+sw) × [sy, sy+sh)` to `(0, 0)`. Subtracting
-      // `(sx, sy)` here would double-correct.
-      drawResidualArrows(ctx, state.data.per_feature_residuals.target, frame);
-    };
-    img.onerror = () => setError("Image failed to decode.");
-    img.src = imgUrl;
-  }, [state, frame, imgUrl]);
+  useKeyboardNav({
+    onPoseStep: stepPose,
+    onCameraStep: stepCamera,
+    enabled: state != null,
+  });
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
@@ -169,25 +130,23 @@ export function ResidualViewer() {
           with <code>bun run tauri dev</code> to use the file dialog.
         </div>
       )}
-      <div className="flex items-center gap-2.5">
+      <div className="flex flex-wrap items-center gap-3">
         <button onClick={handleOpen} disabled={!tauriOk}>
           Open Export…
         </button>
         {state && (
-          <select
-            value={selected ?? ""}
-            onChange={(e) => setSelected(e.target.value)}
-          >
-            {state.frames.map((f) => (
-              <option key={frameKey(f)} value={frameKey(f)}>
-                {f.label}
-              </option>
-            ))}
-          </select>
+          <PoseCameraStepper
+            pose={pose}
+            camera={camera}
+            numPoses={state.numPoses}
+            numCameras={state.numCameras}
+            onPose={setPose}
+            onCamera={setCamera}
+          />
         )}
         {state && (
-          <span className="text-xs opacity-70">
-            mean reprojection error: {state.data.mean_reproj_error.toFixed(3)} px
+          <span className="ml-auto font-mono text-xs text-muted-foreground">
+            mean reproj: {state.data.mean_reproj_error.toFixed(3)} px
           </span>
         )}
       </div>
@@ -199,15 +158,17 @@ export function ResidualViewer() {
       )}
 
       <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-md bg-bg-soft">
-        {state ? (
-          <canvas
-            ref={canvasRef}
-            className="max-h-full max-w-full border border-border [image-rendering:pixelated]"
+        {state && frame ? (
+          <FrameCanvas
+            frame={frame}
+            residuals={state.data.per_feature_residuals.target}
+            onError={setError}
           />
         ) : (
-          <div className="text-[13px] opacity-60">
+          <div className="text-[13px] text-muted-foreground">
             Open an <code>export.json</code> from a calibration run with an
-            <code> image_manifest</code>.
+            <code> image_manifest</code>. Use ← / → for pose, ↑ / ↓ for
+            camera once an export is loaded.
           </div>
         )}
       </div>
@@ -223,80 +184,6 @@ export function ResidualViewer() {
   );
 }
 
-function frameKey(f: { pose: number; camera: number }): string {
-  return `${f.pose}/${f.camera}`;
-}
-
-/** Cap on rendered arrow length so a freak diverged feature does not
- * dominate the canvas. The numeric value still reads correctly off the
- * legend if needed. */
-const ARROW_LENGTH_CAP_PX = 40;
-/** Multiplier applied to the residual vector so sub-pixel errors are
- * actually visible on a 640×480 canvas. */
-const ARROW_GAIN = 30;
-
-function drawResidualArrows(
-  ctx: CanvasRenderingContext2D,
-  all: TargetFeatureResidual[],
-  frame: FrameKey,
-) {
-  const arrows = all.filter((r) => r.pose === frame.pose && r.camera === frame.camera);
-  for (const r of arrows) {
-    if (!r.projected_px) continue;
-    const ox = r.observed_px[0];
-    const oy = r.observed_px[1];
-    const dx0 = r.projected_px[0] - r.observed_px[0];
-    const dy0 = r.projected_px[1] - r.observed_px[1];
-    const mag = Math.hypot(dx0, dy0);
-    if (mag < 1e-6) continue;
-    const gain = Math.min(ARROW_GAIN, ARROW_LENGTH_CAP_PX / Math.max(mag, 1e-6) / 1);
-    const dx = dx0 * gain;
-    const dy = dy0 * gain;
-    ctx.strokeStyle = colorForError(r.error_px ?? mag);
-    ctx.lineWidth = 1.5;
-    drawArrow(ctx, ox, oy, ox + dx, oy + dy);
-    ctx.fillStyle = "rgba(255,255,255,0.85)";
-    ctx.beginPath();
-    ctx.arc(ox, oy, 1.6, 0, Math.PI * 2);
-    ctx.fill();
-  }
-}
-
-function drawArrow(
-  ctx: CanvasRenderingContext2D,
-  x1: number,
-  y1: number,
-  x2: number,
-  y2: number,
-) {
-  const angle = Math.atan2(y2 - y1, x2 - x1);
-  const head = 4;
-  ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x2, y2);
-  ctx.lineTo(
-    x2 - head * Math.cos(angle - Math.PI / 6),
-    y2 - head * Math.sin(angle - Math.PI / 6),
-  );
-  ctx.moveTo(x2, y2);
-  ctx.lineTo(
-    x2 - head * Math.cos(angle + Math.PI / 6),
-    y2 - head * Math.sin(angle + Math.PI / 6),
-  );
-  ctx.stroke();
-}
-
-function colorForError(err: number): string {
-  // Cool→warm ramp matching the histogram bucket edges (1, 2, 5, 10 px)
-  // already used for `target_hist_per_camera`. Keeps the visual scale
-  // consistent across UI surfaces if a histogram view is added later.
-  if (err < 1) return "#1abc9c"; // teal
-  if (err < 2) return "#2ecc71"; // green
-  if (err < 5) return "#f1c40f"; // yellow
-  if (err < 10) return "#e67e22"; // orange
-  return "#e74c3c"; // red
-}
-
 function ResidualLegend({ residuals }: { residuals: TargetFeatureResidual[] }) {
   const errs = residuals
     .map((r) => r.error_px)
@@ -305,35 +192,30 @@ function ResidualLegend({ residuals }: { residuals: TargetFeatureResidual[] }) {
   const max = errs.length > 0 ? Math.max(...errs) : 0;
   const diverged = residuals.length - errs.length;
   return (
-    <div className="flex flex-wrap gap-x-3.5 gap-y-1 text-xs opacity-85">
-      <span>features: {residuals.length}</span>
-      <span>diverged: {diverged}</span>
-      <span>mean error: {mean.toFixed(3)} px</span>
-      <span>max error: {max.toFixed(3)} px</span>
-      <span>
-        legend (px):
-        <SwatchLabel color="#1abc9c" label="<1" />
-        <SwatchLabel color="#2ecc71" label="<2" />
-        <SwatchLabel color="#f1c40f" label="<5" />
-        <SwatchLabel color="#e67e22" label="<10" />
-        <SwatchLabel color="#e74c3c" label="≥10" />
-      </span>
-      <span>
-        arrows scaled ×{ARROW_GAIN} (cap {ARROW_LENGTH_CAP_PX}px) for
-        sub-pixel visibility.
+    <div className="flex flex-wrap items-center gap-x-3.5 gap-y-1 font-mono text-[11px] text-muted-foreground">
+      <span>features {residuals.length}</span>
+      <span>diverged {diverged}</span>
+      <span>mean {mean.toFixed(3)} px</span>
+      <span>max {max.toFixed(3)} px</span>
+      <span className="flex items-center gap-2">
+        <Swatch err={0.5} label="<1" />
+        <Swatch err={1.5} label="<2" />
+        <Swatch err={3} label="<5" />
+        <Swatch err={7} label="<10" />
+        <Swatch err={20} label="≥10" />
       </span>
     </div>
   );
 }
 
-function SwatchLabel({ color, label }: { color: string; label: string }) {
-  // Color is data-driven (matches the canvas error ramp), so the swatch
-  // background stays inline rather than escaping to a Tailwind arbitrary.
+function Swatch({ err, label }: { err: number; label: string }) {
+  // Color is data-driven (matches the canvas error ramp), so it stays
+  // inline; the dot is a Tailwind utility.
   return (
-    <span className="ml-1.5 inline-flex items-center gap-1">
+    <span className="inline-flex items-center gap-1">
       <span
-        className="inline-block h-2.5 w-2.5 rounded-[2px]"
-        style={{ background: color }}
+        className="inline-block h-2 w-2 rounded-[2px]"
+        style={{ background: colorForError(err) }}
       />
       {label}
     </span>

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -3,7 +3,13 @@ import { invoke } from "@tauri-apps/api/core";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { isTauriContext, joinPath } from "../lib/tauri";
 import { useKeyboardNav } from "../hooks/useKeyboardNav";
+import {
+  getPixelLum,
+  rectHistogram,
+  useImageData,
+} from "../hooks/useImageData";
 import type {
+  CursorReadout,
   FrameKey,
   LoadExportResult,
   PlanarExport,
@@ -14,7 +20,10 @@ import {
   type FrameCanvasHandle,
   colorForError,
 } from "./FrameCanvas";
+import { Histogram } from "./Histogram";
 import { PoseCameraStepper } from "./PoseCameraStepper";
+
+const HISTOGRAM_BINS = 64;
 
 interface ExportState {
   exportPath: string;
@@ -31,6 +40,7 @@ export function ResidualViewer() {
   const [pose, setPose] = useState<number>(0);
   const [camera, setCamera] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
+  const [cursor, setCursor] = useState<CursorReadout | null>(null);
   const tauriOk = isTauriContext();
   const canvasHandleRef = useRef<FrameCanvasHandle | null>(null);
 
@@ -102,6 +112,56 @@ export function ResidualViewer() {
       state.frames.find((f) => f.pose === pose && f.camera === camera) ?? null
     );
   }, [state, pose, camera]);
+
+  const imageData = useImageData(frame, setError);
+
+  // Static ROI histogram — recomputed only when the frame's image data
+  // changes, which is the cheap path. (A viewport-tracking variant
+  // can come later; for diagnostic use the static distribution is
+  // more stable to read.)
+  const roiHistogram = useMemo<number[] | null>(() => {
+    if (!imageData || !frame) return null;
+    const r = frame.roi ?? {
+      x: 0,
+      y: 0,
+      w: imageData.naturalWidth,
+      h: imageData.naturalHeight,
+    };
+    return rectHistogram(imageData, r, HISTOGRAM_BINS);
+  }, [imageData, frame]);
+
+  const cursorBin = useMemo<number | null>(() => {
+    if (!cursor || cursor.intensity == null) return null;
+    const bin = Math.floor((cursor.intensity * HISTOGRAM_BINS) / 256);
+    return Math.min(bin, HISTOGRAM_BINS - 1);
+  }, [cursor]);
+
+  // Reset cursor whenever the frame changes — the previous cursor's
+  // (x, y) no longer maps to the new image.
+  useEffect(() => {
+    setCursor(null);
+  }, [frame?.abs_path]);
+
+  const handleCursor = useCallback(
+    (c: { x: number; y: number } | null) => {
+      if (!c || !imageData) {
+        setCursor(null);
+        return;
+      }
+      const roi = frame?.roi;
+      // Translate ROI-local coords back to source-image coords for the
+      // luminance lookup; residual frame and pixel buffer differ when
+      // the manifest crops out a tile.
+      const srcX = (roi?.x ?? 0) + c.x;
+      const srcY = (roi?.y ?? 0) + c.y;
+      setCursor({
+        x: c.x,
+        y: c.y,
+        intensity: getPixelLum(imageData, srcX, srcY),
+      });
+    },
+    [imageData, frame],
+  );
 
   const stepPose = useCallback(
     (delta: number) => {
@@ -220,6 +280,8 @@ export function ResidualViewer() {
             ref={canvasHandleRef}
             frame={frame}
             residuals={state.data.per_feature_residuals.target}
+            image={imageData?.image ?? null}
+            onCursor={handleCursor}
             onError={setError}
           />
         ) : (
@@ -232,13 +294,42 @@ export function ResidualViewer() {
       </div>
 
       {state && frame && (
-        <ResidualLegend
-          residuals={state.data.per_feature_residuals.target.filter(
-            (r) => r.pose === frame.pose && r.camera === frame.camera,
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <ResidualLegend
+            residuals={state.data.per_feature_residuals.target.filter(
+              (r) => r.pose === frame.pose && r.camera === frame.camera,
+            )}
+          />
+          {roiHistogram && (
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                histogram
+              </span>
+              <Histogram bins={roiHistogram} cursorBin={cursorBin} />
+            </div>
           )}
-        />
+          <CursorChip cursor={cursor} />
+        </div>
       )}
     </section>
+  );
+}
+
+function CursorChip({ cursor }: { cursor: CursorReadout | null }) {
+  return (
+    <span className="inline-flex min-w-[12rem] items-center gap-2 rounded-md border border-border bg-surface px-2 py-1 font-mono text-[11px] text-muted-foreground">
+      <span className="uppercase tracking-wider">cursor</span>
+      {cursor ? (
+        <span className="text-foreground tabular-nums">
+          ({cursor.x.toFixed(0)}, {cursor.y.toFixed(0)})
+          {cursor.intensity != null
+            ? ` · I=${cursor.intensity}`
+            : ""}
+        </span>
+      ) : (
+        <span>—</span>
+      )}
+    </span>
   );
 }
 

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -163,7 +163,7 @@ export function ResidualViewer() {
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
       {!tauriOk && (
-        <div className="rounded-md border border-[var(--warn-border)] bg-[var(--warn-bg)] p-2.5 text-[13px] text-[var(--warn-fg)]">
+        <div className="rounded-md border-l-2 border-brand bg-brand/[0.06] p-2.5 text-[13px] text-foreground">
           Tauri runtime not detected — you appear to be running plain Vite
           (<code>bun run dev</code>) in a browser. Launch the desktop app
           with <code>bun run tauri dev</code> to use the file dialog.
@@ -193,16 +193,16 @@ export function ResidualViewer() {
       </div>
 
       {error && (
-        <div className="rounded-md border border-[var(--error-border)] bg-[var(--error-bg)] p-2.5 text-[13px] text-[var(--error-fg)]">
+        <div className="rounded-md border-l-2 border-destructive bg-destructive/[0.08] p-2.5 text-[13px] text-foreground">
           {error}
         </div>
       )}
 
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-md bg-[var(--panel-bg)]">
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-md bg-bg-soft">
         {state ? (
           <canvas
             ref={canvasRef}
-            className="max-h-full max-w-full shadow-[0_1px_4px_rgba(0,0,0,0.2)] [image-rendering:pixelated]"
+            className="max-h-full max-w-full border border-border [image-rendering:pixelated]"
           />
         ) : (
           <div className="text-[13px] opacity-60">

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -149,7 +149,12 @@ export function ResidualViewer() {
       canvas.height = sh;
       ctx.imageSmoothingEnabled = false;
       ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
-      drawResidualArrows(ctx, state.data.per_feature_residuals.target, frame, sx, sy);
+      // Per ImageManifest convention (see image_manifest.rs `# Coordinate
+      // convention`), residual pixel coords are already in the ROI-local
+      // frame, so we draw them directly onto the canvas — which we just
+      // blitted from `[sx, sx+sw) × [sy, sy+sh)` to `(0, 0)`. Subtracting
+      // `(sx, sy)` here would double-correct.
+      drawResidualArrows(ctx, state.data.per_feature_residuals.target, frame);
     };
     img.onerror = () => setError("Image failed to decode.");
     img.src = imgUrl;
@@ -234,14 +239,12 @@ function drawResidualArrows(
   ctx: CanvasRenderingContext2D,
   all: TargetFeatureResidual[],
   frame: FrameKey,
-  roiX: number,
-  roiY: number,
 ) {
   const arrows = all.filter((r) => r.pose === frame.pose && r.camera === frame.camera);
   for (const r of arrows) {
     if (!r.projected_px) continue;
-    const ox = r.observed_px[0] - roiX;
-    const oy = r.observed_px[1] - roiY;
+    const ox = r.observed_px[0];
+    const oy = r.observed_px[1];
     const dx0 = r.projected_px[0] - r.observed_px[0];
     const dy0 = r.projected_px[1] - r.observed_px[1];
     const mag = Math.hypot(dx0, dy0);

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -34,9 +34,33 @@ interface ExportState {
   exportDir: string;
   data: PlanarExport;
   frames: FrameKey[];
-  /** `pose` values run [0, numPoses); `camera` values run [0, numCameras). */
-  numPoses: number;
-  numCameras: number;
+  /** Sorted distinct pose values present in the manifest. */
+  poseValues: number[];
+  /** Sorted distinct camera values present in the manifest. */
+  cameraValues: number[];
+  /** For each camera, the sorted list of poses that have a frame. */
+  posesByCamera: Map<number, number[]>;
+  /** For each pose, the sorted list of cameras that have a frame. */
+  camerasByPose: Map<number, number[]>;
+}
+
+/** Wrap-around index lookup over a sorted array; returns the value
+ * at position `(idx(current) + delta) mod arr.length`, with a
+ * fallback to the first/last element when `current` is missing. */
+function nextInWrap(
+  arr: number[],
+  current: number,
+  delta: number,
+): number {
+  if (arr.length === 0) return current;
+  const idx = arr.indexOf(current);
+  if (idx < 0) {
+    // Current value is no longer in the available set; jump to the
+    // nearest neighbour in the step direction.
+    return delta >= 0 ? arr[0] : arr[arr.length - 1];
+  }
+  const n = arr.length;
+  return arr[((idx + delta) % n + n) % n];
 }
 
 export function ResidualViewer() {
@@ -97,22 +121,64 @@ export function ResidualViewer() {
         abs_path: joinPath(root, f.path),
         roi: f.roi,
       }));
-      const numPoses =
-        frames.reduce((m, f) => Math.max(m, f.pose), -1) + 1;
-      const numCameras =
-        frames.reduce((m, f) => Math.max(m, f.camera), -1) + 1;
+      if (frames.length === 0) {
+        setError(
+          "This export's image_manifest is empty. v0 needs at least one " +
+            "(pose, camera) frame to render.",
+        );
+        return;
+      }
+      // Build availability indices off the actual manifest entries —
+      // a manifest may be sparse (detector failures, partial captures),
+      // so we must NOT navigate over a dense `[0..max]` Cartesian grid.
+      const poseSet = new Set<number>();
+      const cameraSet = new Set<number>();
+      const posesByCameraSet = new Map<number, Set<number>>();
+      const camerasByPoseSet = new Map<number, Set<number>>();
+      for (const f of frames) {
+        poseSet.add(f.pose);
+        cameraSet.add(f.camera);
+        if (!posesByCameraSet.has(f.camera)) {
+          posesByCameraSet.set(f.camera, new Set());
+        }
+        posesByCameraSet.get(f.camera)!.add(f.pose);
+        if (!camerasByPoseSet.has(f.pose)) {
+          camerasByPoseSet.set(f.pose, new Set());
+        }
+        camerasByPoseSet.get(f.pose)!.add(f.camera);
+      }
+      const sortNum = (s: Set<number>) => [...s].sort((a, b) => a - b);
+      const poseValues = sortNum(poseSet);
+      const cameraValues = sortNum(cameraSet);
+      const posesByCamera = new Map(
+        [...posesByCameraSet].map(([k, v]) => [k, sortNum(v)]),
+      );
+      const camerasByPose = new Map(
+        [...camerasByPoseSet].map(([k, v]) => [k, sortNum(v)]),
+      );
+
+      const first = frames[0];
+      // Default right pane to the next manifest entry that differs from
+      // the first; falls back to the first if it's the only frame so the
+      // compare branch can still mount.
+      const second =
+        frames.find((f) => f.pose !== first.pose || f.camera !== first.camera) ??
+        first;
+
       setState({
         exportPath: chosen,
         exportDir: result.export_dir,
         data: result.export,
         frames,
-        numPoses: Math.max(numPoses, 1),
-        numCameras: Math.max(numCameras, 1),
+        poseValues,
+        cameraValues,
+        posesByCamera,
+        camerasByPose,
       });
-      setPose(0);
-      setCamera(0);
-      setPoseRight(0);
-      setCameraRight(Math.min(1, Math.max(numCameras - 1, 0)));
+      setPose(first.pose);
+      setCamera(first.camera);
+      setPoseRight(second.pose);
+      setCameraRight(second.camera);
       setCompare(false);
       setActivePane("left");
     } catch (e) {
@@ -189,28 +255,31 @@ export function ResidualViewer() {
   const stepPose = useCallback(
     (delta: number) => {
       if (!state) return;
-      const apply = (p: number) =>
-        ((p + delta) % state.numPoses + state.numPoses) % state.numPoses;
-      if (compare && activePane === "right") {
-        setPoseRight(apply);
-      } else {
-        setPose(apply);
-      }
+      const isRight = compare && activePane === "right";
+      const cam = isRight ? cameraRight : camera;
+      // Walk the poses that actually exist for the current camera.
+      // Falling back to the global pose set keeps stepping useful
+      // when the active camera has no frames (e.g. just-loaded state).
+      const poses = state.posesByCamera.get(cam) ?? state.poseValues;
+      const cur = isRight ? poseRight : pose;
+      const next = nextInWrap(poses, cur, delta);
+      if (isRight) setPoseRight(next);
+      else setPose(next);
     },
-    [state, compare, activePane],
+    [state, compare, activePane, camera, cameraRight, pose, poseRight],
   );
   const stepCamera = useCallback(
     (delta: number) => {
       if (!state) return;
-      const apply = (c: number) =>
-        ((c + delta) % state.numCameras + state.numCameras) % state.numCameras;
-      if (compare && activePane === "right") {
-        setCameraRight(apply);
-      } else {
-        setCamera(apply);
-      }
+      const isRight = compare && activePane === "right";
+      const p = isRight ? poseRight : pose;
+      const cams = state.camerasByPose.get(p) ?? state.cameraValues;
+      const cur = isRight ? cameraRight : camera;
+      const next = nextInWrap(cams, cur, delta);
+      if (isRight) setCameraRight(next);
+      else setCamera(next);
     },
-    [state, compare, activePane],
+    [state, compare, activePane, pose, poseRight, camera, cameraRight],
   );
 
   useKeyboardNav({
@@ -293,18 +362,20 @@ export function ResidualViewer() {
         </button>
         {state && (
           <PoseCameraStepper
-            pose={compare && activePane === "right" ? poseRight : pose}
-            camera={compare && activePane === "right" ? cameraRight : camera}
-            numPoses={state.numPoses}
-            numCameras={state.numCameras}
-            onPose={(next) =>
-              compare && activePane === "right" ? setPoseRight(next) : setPose(next)
+            poseOrdinal={
+              state.poseValues.indexOf(
+                compare && activePane === "right" ? poseRight : pose,
+              ) + 1
             }
-            onCamera={(next) =>
-              compare && activePane === "right"
-                ? setCameraRight(next)
-                : setCamera(next)
+            poseTotal={state.poseValues.length}
+            cameraOrdinal={
+              state.cameraValues.indexOf(
+                compare && activePane === "right" ? cameraRight : camera,
+              ) + 1
             }
+            cameraTotal={state.cameraValues.length}
+            onPoseStep={stepPose}
+            onCameraStep={stepCamera}
           />
         )}
         {state && (

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { isTauriContext, joinPath } from "../lib/tauri";
@@ -9,7 +9,11 @@ import type {
   PlanarExport,
   TargetFeatureResidual,
 } from "../types";
-import { FrameCanvas, colorForError } from "./FrameCanvas";
+import {
+  FrameCanvas,
+  type FrameCanvasHandle,
+  colorForError,
+} from "./FrameCanvas";
 import { PoseCameraStepper } from "./PoseCameraStepper";
 
 interface ExportState {
@@ -28,6 +32,7 @@ export function ResidualViewer() {
   const [camera, setCamera] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
   const tauriOk = isTauriContext();
+  const canvasHandleRef = useRef<FrameCanvasHandle | null>(null);
 
   const handleOpen = async () => {
     setError(null);
@@ -121,6 +126,50 @@ export function ResidualViewer() {
     enabled: state != null,
   });
 
+  // Single-key shortcuts for zoom controls. Bound at the window level
+  // so they work without needing the canvas to be focused; ignored
+  // when an editable element has focus.
+  useEffect(() => {
+    if (!state) return;
+    const handler = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null;
+      if (
+        tgt &&
+        (tgt.tagName === "INPUT" ||
+          tgt.tagName === "SELECT" ||
+          tgt.tagName === "TEXTAREA" ||
+          tgt.isContentEditable)
+      ) {
+        return;
+      }
+      const handle = canvasHandleRef.current;
+      if (!handle) return;
+      switch (e.key) {
+        case "f":
+        case "F":
+          handle.fit();
+          e.preventDefault();
+          break;
+        case "1":
+          handle.reset1to1();
+          e.preventDefault();
+          break;
+        case "+":
+        case "=":
+          handle.zoomBy(1.25);
+          e.preventDefault();
+          break;
+        case "-":
+        case "_":
+          handle.zoomBy(1 / 1.25);
+          e.preventDefault();
+          break;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [state]);
+
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
       {!tauriOk && (
@@ -145,6 +194,14 @@ export function ResidualViewer() {
           />
         )}
         {state && (
+          <ZoomControls
+            onFit={() => canvasHandleRef.current?.fit()}
+            onOneToOne={() => canvasHandleRef.current?.reset1to1()}
+            onZoomIn={() => canvasHandleRef.current?.zoomBy(1.25)}
+            onZoomOut={() => canvasHandleRef.current?.zoomBy(1 / 1.25)}
+          />
+        )}
+        {state && (
           <span className="ml-auto font-mono text-xs text-muted-foreground">
             mean reproj: {state.data.mean_reproj_error.toFixed(3)} px
           </span>
@@ -157,15 +214,16 @@ export function ResidualViewer() {
         </div>
       )}
 
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-md bg-bg-soft">
+      <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-md bg-bg-soft">
         {state && frame ? (
           <FrameCanvas
+            ref={canvasHandleRef}
             frame={frame}
             residuals={state.data.per_feature_residuals.target}
             onError={setError}
           />
         ) : (
-          <div className="text-[13px] text-muted-foreground">
+          <div className="m-auto text-[13px] text-muted-foreground">
             Open an <code>export.json</code> from a calibration run with an
             <code> image_manifest</code>. Use ← / → for pose, ↑ / ↓ for
             camera once an export is loaded.
@@ -204,6 +262,59 @@ function ResidualLegend({ residuals }: { residuals: TargetFeatureResidual[] }) {
         <Swatch err={7} label="<10" />
         <Swatch err={20} label="≥10" />
       </span>
+    </div>
+  );
+}
+
+interface ZoomControlsProps {
+  onFit: () => void;
+  onOneToOne: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+}
+
+function ZoomControls({
+  onFit,
+  onOneToOne,
+  onZoomIn,
+  onZoomOut,
+}: ZoomControlsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onZoomOut}
+        title="Zoom out (−)"
+        aria-label="Zoom out"
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+      >
+        −
+      </button>
+      <button
+        type="button"
+        onClick={onZoomIn}
+        title="Zoom in (+)"
+        aria-label="Zoom in"
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+      >
+        +
+      </button>
+      <button
+        type="button"
+        onClick={onFit}
+        title="Fit (f)"
+        className="h-7 px-2 font-mono text-[11px]"
+      >
+        Fit
+      </button>
+      <button
+        type="button"
+        onClick={onOneToOne}
+        title="1:1 (1)"
+        className="h-7 px-2 font-mono text-[11px]"
+      >
+        1:1
+      </button>
     </div>
   );
 }

--- a/app/src/components/ResidualViewer.tsx
+++ b/app/src/components/ResidualViewer.tsx
@@ -16,6 +16,10 @@ import type {
   TargetFeatureResidual,
 } from "../types";
 import {
+  CompareViewer,
+  type CompareViewerHandle,
+} from "./CompareViewer";
+import {
   FrameCanvas,
   type FrameCanvasHandle,
   colorForError,
@@ -39,10 +43,16 @@ export function ResidualViewer() {
   const [state, setState] = useState<ExportState | null>(null);
   const [pose, setPose] = useState<number>(0);
   const [camera, setCamera] = useState<number>(0);
+  const [poseRight, setPoseRight] = useState<number>(0);
+  const [cameraRight, setCameraRight] = useState<number>(1);
+  const [compare, setCompare] = useState<boolean>(false);
+  const [linked, setLinked] = useState<boolean>(true);
+  const [activePane, setActivePane] = useState<"left" | "right">("left");
   const [error, setError] = useState<string | null>(null);
   const [cursor, setCursor] = useState<CursorReadout | null>(null);
   const tauriOk = isTauriContext();
   const canvasHandleRef = useRef<FrameCanvasHandle | null>(null);
+  const compareHandleRef = useRef<CompareViewerHandle | null>(null);
 
   const handleOpen = async () => {
     setError(null);
@@ -101,6 +111,10 @@ export function ResidualViewer() {
       });
       setPose(0);
       setCamera(0);
+      setPoseRight(0);
+      setCameraRight(Math.min(1, Math.max(numCameras - 1, 0)));
+      setCompare(false);
+      setActivePane("left");
     } catch (e) {
       setError(`Could not load export: ${e}`);
     }
@@ -112,6 +126,15 @@ export function ResidualViewer() {
       state.frames.find((f) => f.pose === pose && f.camera === camera) ?? null
     );
   }, [state, pose, camera]);
+
+  const rightFrame = useMemo<FrameKey | null>(() => {
+    if (!state) return null;
+    return (
+      state.frames.find(
+        (f) => f.pose === poseRight && f.camera === cameraRight,
+      ) ?? null
+    );
+  }, [state, poseRight, cameraRight]);
 
   const imageData = useImageData(frame, setError);
 
@@ -166,18 +189,28 @@ export function ResidualViewer() {
   const stepPose = useCallback(
     (delta: number) => {
       if (!state) return;
-      setPose((p) => ((p + delta) % state.numPoses + state.numPoses) % state.numPoses);
+      const apply = (p: number) =>
+        ((p + delta) % state.numPoses + state.numPoses) % state.numPoses;
+      if (compare && activePane === "right") {
+        setPoseRight(apply);
+      } else {
+        setPose(apply);
+      }
     },
-    [state],
+    [state, compare, activePane],
   );
   const stepCamera = useCallback(
     (delta: number) => {
       if (!state) return;
-      setCamera(
-        (c) => ((c + delta) % state.numCameras + state.numCameras) % state.numCameras,
-      );
+      const apply = (c: number) =>
+        ((c + delta) % state.numCameras + state.numCameras) % state.numCameras;
+      if (compare && activePane === "right") {
+        setCameraRight(apply);
+      } else {
+        setCamera(apply);
+      }
     },
-    [state],
+    [state, compare, activePane],
   );
 
   useKeyboardNav({
@@ -202,33 +235,48 @@ export function ResidualViewer() {
       ) {
         return;
       }
-      const handle = canvasHandleRef.current;
-      if (!handle) return;
+      const fit = () =>
+        compare ? compareHandleRef.current?.fitActive() : canvasHandleRef.current?.fit();
+      const oneToOne = () =>
+        compare
+          ? compareHandleRef.current?.reset1to1Active()
+          : canvasHandleRef.current?.reset1to1();
+      const zoom = (factor: number) =>
+        compare
+          ? compareHandleRef.current?.zoomActiveBy(factor)
+          : canvasHandleRef.current?.zoomBy(factor);
       switch (e.key) {
         case "f":
         case "F":
-          handle.fit();
+          fit();
           e.preventDefault();
           break;
         case "1":
-          handle.reset1to1();
+          oneToOne();
           e.preventDefault();
           break;
         case "+":
         case "=":
-          handle.zoomBy(1.25);
+          zoom(1.25);
           e.preventDefault();
           break;
         case "-":
         case "_":
-          handle.zoomBy(1 / 1.25);
+          zoom(1 / 1.25);
           e.preventDefault();
+          break;
+        case "l":
+        case "L":
+          if (compare) {
+            setLinked((v) => !v);
+            e.preventDefault();
+          }
           break;
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [state]);
+  }, [state, compare]);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
@@ -245,21 +293,67 @@ export function ResidualViewer() {
         </button>
         {state && (
           <PoseCameraStepper
-            pose={pose}
-            camera={camera}
+            pose={compare && activePane === "right" ? poseRight : pose}
+            camera={compare && activePane === "right" ? cameraRight : camera}
             numPoses={state.numPoses}
             numCameras={state.numCameras}
-            onPose={setPose}
-            onCamera={setCamera}
+            onPose={(next) =>
+              compare && activePane === "right" ? setPoseRight(next) : setPose(next)
+            }
+            onCamera={(next) =>
+              compare && activePane === "right"
+                ? setCameraRight(next)
+                : setCamera(next)
+            }
           />
         )}
         {state && (
           <ZoomControls
-            onFit={() => canvasHandleRef.current?.fit()}
-            onOneToOne={() => canvasHandleRef.current?.reset1to1()}
-            onZoomIn={() => canvasHandleRef.current?.zoomBy(1.25)}
-            onZoomOut={() => canvasHandleRef.current?.zoomBy(1 / 1.25)}
+            onFit={() =>
+              compare
+                ? compareHandleRef.current?.fitActive()
+                : canvasHandleRef.current?.fit()
+            }
+            onOneToOne={() =>
+              compare
+                ? compareHandleRef.current?.reset1to1Active()
+                : canvasHandleRef.current?.reset1to1()
+            }
+            onZoomIn={() =>
+              compare
+                ? compareHandleRef.current?.zoomActiveBy(1.25)
+                : canvasHandleRef.current?.zoomBy(1.25)
+            }
+            onZoomOut={() =>
+              compare
+                ? compareHandleRef.current?.zoomActiveBy(1 / 1.25)
+                : canvasHandleRef.current?.zoomBy(1 / 1.25)
+            }
           />
+        )}
+        {state && (
+          <button
+            type="button"
+            onClick={() => setCompare((v) => !v)}
+            className={`h-7 px-2 font-mono text-[11px] ${
+              compare ? "border-brand text-brand" : ""
+            }`}
+            title="Toggle compare mode"
+          >
+            {compare ? "Compare ✓" : "Compare"}
+          </button>
+        )}
+        {state && compare && (
+          <button
+            type="button"
+            onClick={() => setLinked((v) => !v)}
+            className={`h-7 px-2 font-mono text-[11px] ${
+              linked ? "border-brand text-brand" : ""
+            }`}
+            title="Toggle linked viewport (L)"
+          >
+            {linked ? "Linked" : "Unlinked"}
+          </button>
         )}
         {state && (
           <span className="ml-auto font-mono text-xs text-muted-foreground">
@@ -274,8 +368,20 @@ export function ResidualViewer() {
         </div>
       )}
 
-      <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-md bg-bg-soft">
-        {state && frame ? (
+      <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-md bg-bg-soft p-2">
+        {state && frame && compare && rightFrame ? (
+          <CompareViewer
+            leftFrame={frame}
+            rightFrame={rightFrame}
+            residuals={state.data.per_feature_residuals.target}
+            activePane={activePane}
+            onActivePane={setActivePane}
+            linked={linked}
+            onCursorChange={setCursor}
+            onError={setError}
+            innerRef={compareHandleRef}
+          />
+        ) : state && frame ? (
           <FrameCanvas
             ref={canvasHandleRef}
             frame={frame}
@@ -288,7 +394,7 @@ export function ResidualViewer() {
           <div className="m-auto text-[13px] text-muted-foreground">
             Open an <code>export.json</code> from a calibration run with an
             <code> image_manifest</code>. Use ← / → for pose, ↑ / ↓ for
-            camera once an export is loaded.
+            camera; toggle Compare to view two frames side by side.
           </div>
         )}
       </div>

--- a/app/src/hooks/useImageData.ts
+++ b/app/src/hooks/useImageData.ts
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { FrameKey } from "../types";
+
+export interface ImageData {
+  /** The decoded HTMLImageElement, ready for `ctx.drawImage`. */
+  image: HTMLImageElement;
+  /** Width / height of the original PNG in pixels. */
+  naturalWidth: number;
+  naturalHeight: number;
+  /** Per-pixel luminance for the full image, row-major
+   * (`y * naturalWidth + x`). 8-bit. We store luminance only — that's
+   * what the histogram + cursor readout need, and one byte per pixel
+   * keeps memory at reasonable bounds (8 MB for a 4320×540 strip). */
+  luminance: Uint8Array;
+}
+
+/** Loads a frame's PNG via the Tauri `load_image` command and decodes
+ * its luminance buffer once, so both `FrameCanvas` (drawing) and
+ * `ResidualViewer` (cursor readout + histogram) can share the same
+ * decode without the IPC roundtrip happening twice. */
+export function useImageData(
+  frame: FrameKey | null,
+  onError?: (msg: string) => void,
+): ImageData | null {
+  const [data, setData] = useState<ImageData | null>(null);
+
+  useEffect(() => {
+    if (!frame) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+    setData(null);
+    invoke<string>("load_image", { path: frame.abs_path })
+      .then((dataUrl) => {
+        if (cancelled) return;
+        const img = new Image();
+        img.onload = () => {
+          if (cancelled) return;
+          try {
+            const luminance = decodeLuminance(img);
+            setData({
+              image: img,
+              naturalWidth: img.naturalWidth,
+              naturalHeight: img.naturalHeight,
+              luminance,
+            });
+          } catch (e) {
+            onError?.(`Pixel decode failed: ${e}`);
+          }
+        };
+        img.onerror = () => {
+          if (!cancelled) onError?.("Image failed to decode.");
+        };
+        img.src = dataUrl;
+      })
+      .catch((e) => {
+        if (!cancelled) onError?.(`Could not load image: ${e}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [frame?.abs_path, onError]);
+
+  return data;
+}
+
+/** Pull luminance out of an HTMLImageElement by drawing it into an
+ * OffscreenCanvas (or a hidden 2D canvas for older runtimes) and
+ * extracting RGBA. We compute Rec. 601 luma and discard the rest. */
+type Canvas2D = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
+
+function decodeLuminance(img: HTMLImageElement): Uint8Array {
+  const w = img.naturalWidth;
+  const h = img.naturalHeight;
+  const ctx = acquireContext(w, h);
+  if (!ctx) throw new Error("could not acquire 2D context");
+  ctx.drawImage(img, 0, 0);
+  const rgba = ctx.getImageData(0, 0, w, h).data;
+  const lum = new Uint8Array(w * h);
+  for (let i = 0, j = 0; i < rgba.length; i += 4, j++) {
+    // Rec. 601 luma — close enough for diagnostic readout.
+    lum[j] = (0.299 * rgba[i] + 0.587 * rgba[i + 1] + 0.114 * rgba[i + 2]) | 0;
+  }
+  return lum;
+}
+
+function acquireContext(w: number, h: number): Canvas2D | null {
+  if (typeof OffscreenCanvas !== "undefined") {
+    return new OffscreenCanvas(w, h).getContext(
+      "2d",
+    ) as OffscreenCanvasRenderingContext2D | null;
+  }
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  return c.getContext("2d");
+}
+
+/** Read the luminance at integer image coords, or null if out of bounds. */
+export function getPixelLum(data: ImageData, x: number, y: number): number | null {
+  const xi = x | 0;
+  const yi = y | 0;
+  if (xi < 0 || yi < 0 || xi >= data.naturalWidth || yi >= data.naturalHeight) {
+    return null;
+  }
+  return data.luminance[yi * data.naturalWidth + xi];
+}
+
+/** Compute a fixed-bin histogram over a sub-rectangle of the image. */
+export function rectHistogram(
+  data: ImageData,
+  rect: { x: number; y: number; w: number; h: number },
+  binCount: number,
+): number[] {
+  const bins = new Array<number>(binCount).fill(0);
+  const w = data.naturalWidth;
+  const h = data.naturalHeight;
+  const x0 = Math.max(0, Math.floor(rect.x));
+  const y0 = Math.max(0, Math.floor(rect.y));
+  const x1 = Math.min(w, Math.ceil(rect.x + rect.w));
+  const y1 = Math.min(h, Math.ceil(rect.y + rect.h));
+  if (x1 <= x0 || y1 <= y0) return bins;
+  const scale = binCount / 256;
+  const lum = data.luminance;
+  for (let y = y0; y < y1; y++) {
+    const row = y * w;
+    for (let x = x0; x < x1; x++) {
+      const v = lum[row + x];
+      let bin = (v * scale) | 0;
+      if (bin >= binCount) bin = binCount - 1;
+      bins[bin]++;
+    }
+  }
+  return bins;
+}

--- a/app/src/hooks/useKeyboardNav.ts
+++ b/app/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+
+interface KeyboardNavOptions {
+  /** Called on ArrowLeft / ArrowRight (signed step). No-op when an
+   * editable control has focus. */
+  onPoseStep?: (delta: number) => void;
+  /** Called on ArrowUp / ArrowDown (signed step). No-op when an
+   * editable control has focus. */
+  onCameraStep?: (delta: number) => void;
+  /** When false, listeners are not registered. */
+  enabled?: boolean;
+}
+
+/** Window-scoped arrow-key navigation. Ignores the keystroke when an
+ * `<input>` / `<select>` / `<textarea>` (or anything `contenteditable`)
+ * has focus, so typing into a search field still works. */
+export function useKeyboardNav(opts: KeyboardNavOptions): void {
+  const { onPoseStep, onCameraStep, enabled = true } = opts;
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null;
+      if (tgt) {
+        const tag = tgt.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "SELECT" ||
+          tag === "TEXTAREA" ||
+          tgt.isContentEditable
+        ) {
+          return;
+        }
+      }
+      switch (e.key) {
+        case "ArrowLeft":
+          onPoseStep?.(-1);
+          e.preventDefault();
+          break;
+        case "ArrowRight":
+          onPoseStep?.(+1);
+          e.preventDefault();
+          break;
+        case "ArrowUp":
+          onCameraStep?.(-1);
+          e.preventDefault();
+          break;
+        case "ArrowDown":
+          onCameraStep?.(+1);
+          e.preventDefault();
+          break;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onPoseStep, onCameraStep, enabled]);
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,73 +1,144 @@
 @import "tailwindcss";
 
-/* Light/dark color tokens consumed via Tailwind's `var()` arbitrary values
-   (e.g. `bg-[var(--page-bg)]`). We keep the palette here rather than in a
-   `@theme` block so dark mode follows the OS preference automatically; a
-   `@theme` switch would require explicit class toggling. */
-:root {
-  --page-bg: #f6f8fa;
-  --page-fg: #1f2328;
-  --panel-bg: rgba(127, 127, 127, 0.08);
-  --warn-border: #d4a72c;
-  --warn-bg: #fff7d6;
-  --warn-fg: #5a4400;
-  --error-border: #c0392b;
-  --error-bg: #fdecea;
-  --error-fg: #7d2118;
-  color-scheme: light dark;
+/* Class-based dark mode: Tailwind's `dark:` variant matches when an
+   ancestor (typically <html>) carries the `.dark` class. Toggle from
+   main.tsx; persist user override in localStorage. */
+@custom-variant dark (&:is(.dark *));
+
+/* Design tokens — adapted from the vitavision website
+   (https://github.com/VitalyVorobyev/vitavision src/index.css). Trimmed
+   to what the diagnose viewer actually consumes (no article/horizon
+   tokens). Colours are HSL triplets so `hsl(var(--name))` works in
+   Tailwind arbitrary values and CSS alike. */
+@theme {
+  --color-background: hsl(var(--background));
+  --color-bg-soft: hsl(var(--bg-soft));
+  --color-surface: hsl(var(--surface));
+  --color-surface-hi: hsl(var(--surface-hi));
+  --color-foreground: hsl(var(--foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-border: hsl(var(--border));
+  --color-border-strong: hsl(var(--border-strong));
+  --color-accent: hsl(var(--accent));
+  --color-accent-soft: hsl(var(--accent-soft));
+  --color-brand: hsl(var(--brand));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+
+  --font-sans: Inter, system-ui, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+
+  /* Tighter than Tailwind defaults — "engineered" feel matches vitavision. */
+  --radius-sm: 0.125rem;
+  --radius-md: 0.25rem;
+  --radius-lg: 0.375rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --page-bg: #0d1117;
-    --page-fg: #e6edf3;
-    --panel-bg: rgba(255, 255, 255, 0.05);
-    --warn-border: #d4a72c;
-    --warn-bg: #3a2f00;
-    --warn-fg: #ffe589;
-    --error-border: #c0392b;
-    --error-bg: #3a1414;
-    --error-fg: #ffb3a8;
+@layer base {
+  *,
+  ::after,
+  ::before {
+    border-color: var(--color-border);
   }
-}
 
-html,
-body,
-#root {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  width: 100%;
-  font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  color: var(--page-fg);
-  background: var(--page-bg);
-}
+  :root {
+    /* Light mode — "Technical Journal" */
+    --background: 210 40% 98%;
+    --bg-soft: 210 40% 96%;
+    --surface: 0 0% 100%;
+    --surface-hi: 214 32% 91%;
+    --foreground: 215 25% 27%;
+    --muted: 210 40% 96%;
+    --muted-foreground: 215 16% 47%;
+    --border: 214 32% 91%;
+    --border-strong: 214 32% 80%;
+    --accent: 215 19% 35%;
+    --accent-soft: 214 32% 91%;
+    --brand: 191 75% 55%;
+    --destructive: 0 72% 45%;
+    --destructive-foreground: 0 0% 100%;
+    color-scheme: light;
+  }
 
-button {
-  font: inherit;
-  padding: 0.4em 0.9em;
-  border-radius: 6px;
-  border: 1px solid currentColor;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-}
+  .dark {
+    /* Dark mode — "Observatory" */
+    --background: 222 47% 11%;
+    --bg-soft: 222 40% 13%;
+    --surface: 217 33% 17%;
+    --surface-hi: 217 33% 21%;
+    --foreground: 210 40% 96%;
+    --muted: 217 33% 17%;
+    --muted-foreground: 215 20% 65%;
+    --border: 215 25% 27%;
+    --border-strong: 222 18% 28%;
+    --accent: 215 20% 65%;
+    --accent-soft: 217 33% 17%;
+    --brand: 191 75% 55%;
+    --destructive: 0 70% 65%;
+    --destructive-foreground: 222 47% 11%;
+    color-scheme: dark;
+  }
 
-button:hover:not(:disabled) {
-  background: rgba(127, 127, 127, 0.12);
-}
+  html,
+  body,
+  #root {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    background: var(--color-background);
+    color: var(--color-foreground);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    font-feature-settings: "rlig" 1, "calt" 1;
+  }
 
-button:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
+  ::selection {
+    background: hsl(var(--accent) / 0.18);
+  }
 
-select {
-  font: inherit;
-  padding: 0.3em 0.5em;
-  border-radius: 6px;
-  border: 1px solid currentColor;
-  background: transparent;
-  color: inherit;
+  button {
+    font: inherit;
+    padding: 0.4em 0.9em;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-foreground);
+    cursor: pointer;
+    transition:
+      background 120ms ease,
+      border-color 120ms ease,
+      color 120ms ease;
+  }
+
+  button:hover:not(:disabled) {
+    background: var(--color-surface-hi);
+    border-color: var(--color-border-strong);
+  }
+
+  button:disabled {
+    opacity: 0.45;
+    cursor: default;
+  }
+
+  button:focus-visible {
+    outline: 1px solid var(--color-brand);
+    outline-offset: 1px;
+  }
+
+  select {
+    font: inherit;
+    padding: 0.3em 0.5em;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-foreground);
+  }
+
+  code,
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+  }
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1,0 +1,28 @@
+/** True iff the page is running inside a Tauri webview (i.e. the IPC
+ * internals have been injected). When the user runs `bun run dev` and
+ * loads localhost:1420 in a regular browser, this is false and any
+ * `invoke` / dialog call would throw `Cannot read properties of
+ * undefined (reading 'invoke')`. We guard up-front so the failure mode
+ * is a readable banner instead of an opaque TypeError. */
+export function isTauriContext(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in window &&
+    (window as unknown as { __TAURI_INTERNALS__?: unknown })
+      .__TAURI_INTERNALS__ != null
+  );
+}
+
+/** Path joining for absolute filesystem paths. Tauri exposes a path
+ * utility but for our manifest needs (POSIX-style relatives appended
+ * to absolute roots) a hand-rolled join keeps the dependency surface
+ * tiny. */
+export function joinPath(dir: string, ...rest: string[]): string {
+  let out = dir.replace(/[\\/]+$/, "");
+  for (const segment of rest) {
+    if (!segment) continue;
+    const sep = out.includes("\\") && !out.includes("/") ? "\\" : "/";
+    out = `${out}${sep}${segment.replace(/^[\\/]+/, "")}`;
+  }
+  return out;
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,7 +1,23 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/600.css";
 import { App } from "./App";
 import "./index.css";
+
+// Apply the persisted theme (or the OS preference when there is no
+// override) before React mounts so the first paint is correctly
+// themed and we don't flash light-on-dark / dark-on-light.
+const stored = localStorage.getItem("calib-theme");
+const prefersDark =
+  typeof matchMedia === "function" &&
+  matchMedia("(prefers-color-scheme: dark)").matches;
+const dark = stored ? stored === "dark" : prefersDark;
+document.documentElement.classList.toggle("dark", dark);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -63,3 +63,25 @@ export interface FrameKey {
   abs_path: string;
   roi?: PixelRect;
 }
+
+/** Viewport transform applied to the canvas before drawing the image
+ * + residuals. `scale` is the zoom factor; `(tx, ty)` is the
+ * translation in canvas pixels. Identity is `{ scale: 1, tx: 0, ty: 0 }`.
+ * Wheel zoom anchors at the cursor; reset on frame change. */
+export interface ViewportTransform {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+
+export const IDENTITY_TRANSFORM: ViewportTransform = { scale: 1, tx: 0, ty: 0 };
+
+/** Cursor readout emitted by FrameCanvas on mouse move. Coordinates
+ * are in image-pixel space (the ROI-local frame the residuals live
+ * in); `intensity` is luminance ∈ [0, 255] when the underlying pixel
+ * is decodable, or null at the canvas's edge / outside the image. */
+export interface CursorReadout {
+  x: number;
+  y: number;
+  intensity: number | null;
+}

--- a/crates/vision-calibration-core/src/types/image_manifest.rs
+++ b/crates/vision-calibration-core/src/types/image_manifest.rs
@@ -25,6 +25,21 @@
 //! tiled-image format: multiple `FrameRef`s point at the same `path` with
 //! disjoint ROIs.
 //!
+//! # Coordinate convention
+//!
+//! `observed_px` and `projected_px` in any [`PerFeatureResiduals`] entry
+//! that refers to a frame are in **the camera's own pixel frame** — i.e.
+//! the frame the camera intrinsics were calibrated against. With
+//! `roi = None` that is the full source image; with `roi = Some(_)` it is
+//! the ROI-local frame, with origin at the ROI's top-left corner.
+//!
+//! ROI is therefore a **render-time crop hint**, never a coordinate
+//! transform: a viewer that renders the per-camera tile by blitting the
+//! ROI rectangle onto a fresh canvas at `(0, 0)` can plot residual
+//! coordinates directly, without subtracting `roi.x` / `roi.y`. Doing so
+//! would double-correct and push residuals off-canvas — see the bug fix
+//! that introduced this convention.
+//!
 //! [`PerFeatureResiduals`]: crate::PerFeatureResiduals
 //! [`TargetFeatureResidual`]: crate::TargetFeatureResidual
 //! [`LaserFeatureResidual`]: crate::LaserFeatureResidual
@@ -58,6 +73,14 @@ pub struct FrameRef {
     pub path: PathBuf,
     /// Sub-image rectangle in pixel coordinates. `None` means the entire
     /// image is this `(pose, camera)`. Used for tiled multi-camera frames.
+    ///
+    /// **Coordinate convention:** see the module-level `# Coordinate
+    /// convention` block. ROI is a render-time crop hint only —
+    /// per-feature residuals are already in the ROI-local pixel frame
+    /// (i.e. the camera's own image frame, since intrinsics were
+    /// calibrated against the cropped tile), so a viewer must not
+    /// subtract `(x, y)` from `observed_px` / `projected_px` when
+    /// drawing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub roi: Option<PixelRect>,
 }

--- a/crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs
@@ -41,8 +41,8 @@ use vision_calibration::{
     session::CalibrationSession,
 };
 use vision_calibration_core::{
-    BrownConrady5, CameraFixMask, CorrespondenceView, DistortionFixMask, FxFyCxCySkew, Pt2,
-    RigDataset, RigView, RigViewObs, ScheimpflugParams,
+    BrownConrady5, CameraFixMask, CorrespondenceView, DistortionFixMask, FrameRef, FxFyCxCySkew,
+    ImageManifest, PixelRect, Pt2, RigDataset, RigView, RigViewObs, ScheimpflugParams,
 };
 use vision_calibration_examples_private::{
     PoseEntry, detect_laser, detect_target, load_gray, load_poses, split_horizontal,
@@ -265,7 +265,19 @@ fn main() -> Result<()> {
         t0.elapsed()
     );
 
-    let rig_export = rig_session.export()?;
+    let mut rig_export = rig_session.export()?;
+    // ADR 0014 / B0.5: ship an `image_manifest` so the diagnose viewer can
+    // pull per-tile pixels straight from the source PNGs. Each pose stores
+    // a single 4320×540 strip; emit one `FrameRef` per (pose, camera) using
+    // ROI to slice the camera's 720×540 tile out of that strip.
+    rig_export.image_manifest = Some(build_image_manifest(&poses, tile_w, tile_h));
+    let export_path = data_dir.join("export.json");
+    std::fs::write(
+        &export_path,
+        serde_json::to_string_pretty(&rig_export).context("serialize rig export")?,
+    )
+    .with_context(|| format!("write {}", export_path.display()))?;
+    println!("  wrote {}", export_path.display());
     println!(
         "  mean reproj error:   {:.4} px",
         rig_export.mean_reproj_error
@@ -756,6 +768,37 @@ fn print_robot_delta_summary(label: &str, deltas: Option<&[[f64; 6]]>) {
         max_rot.to_degrees(),
         max_trans
     );
+}
+
+/// Build the [`ImageManifest`] that ships with `export.json` so the
+/// diagnose viewer (Track B) can locate the per-camera tile for every
+/// `(pose, camera)` slot. The puzzle 130×130 rig stores all six camera
+/// views of a pose as a single horizontal strip; each `FrameRef` points
+/// at that strip with an ROI carving out a 720×540 tile. `root` is `.`
+/// because we write `export.json` alongside the source PNGs (the
+/// `privatedata/` directory is `*`-gitignored, so this is private to
+/// the developer).
+fn build_image_manifest(poses: &[PoseEntry], tile_w: u32, tile_h: u32) -> ImageManifest {
+    let mut frames = Vec::with_capacity(poses.len() * NUM_CAMERAS);
+    for (pose_idx, pose) in poses.iter().enumerate() {
+        for cam_idx in 0..NUM_CAMERAS {
+            frames.push(FrameRef {
+                pose: pose_idx,
+                camera: cam_idx,
+                path: PathBuf::from(&pose.target_image),
+                roi: Some(PixelRect {
+                    x: (cam_idx as u32) * tile_w,
+                    y: 0,
+                    w: tile_w,
+                    h: tile_h,
+                }),
+            });
+        }
+    }
+    ImageManifest {
+        root: PathBuf::from("."),
+        frames,
+    }
 }
 
 fn build_datasets(data_dir: &Path, poses: &[PoseEntry]) -> Result<DetectedDatasets> {

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -6,8 +6,8 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    Camera, FeatureResidualHistogram, Iso3, PerFeatureResiduals, Pinhole, PinholeCamera,
-    ScheimpflugParams, build_feature_histogram, compute_rig_target_residuals,
+    Camera, FeatureResidualHistogram, ImageManifest, Iso3, PerFeatureResiduals, Pinhole,
+    PinholeCamera, ScheimpflugParams, build_feature_histogram, compute_rig_target_residuals,
 };
 use vision_calibration_optim::{
     HandEyeEstimate as PinholeHandEyeEstimate, HandEyeMode,
@@ -322,6 +322,16 @@ pub struct RigHandeyeExport {
     /// then composed with `cam_se3_rig` for projection.
     #[serde(default)]
     pub per_feature_residuals: PerFeatureResiduals,
+
+    /// Optional image manifest (ADR 0014, viewer-side contract). When
+    /// populated, downstream viewers (the diagnose UI) can locate the source
+    /// image for each `(pose, camera)` slot. Tiled multi-camera frames
+    /// (e.g. 6× 720×540 horizontal strips on the puzzle 130×130 rig) point
+    /// multiple `FrameRef`s at the same `path` with disjoint ROIs. `None`
+    /// means "no images shipped"; the calibration pipeline never reads
+    /// this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_manifest: Option<ImageManifest>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -553,6 +563,10 @@ impl ProblemType for RigHandeyeProblem {
                 target_hist_per_camera: Some(target_hist_per_camera),
                 laser_hist_per_camera: None,
             },
+            // Manifest is populated by callers that also wrote images for
+            // the dataset (e.g. the puzzle 130×130 example); the pipeline
+            // itself never has image paths to fill in.
+            image_manifest: None,
         })
     }
 }
@@ -781,5 +795,90 @@ mod tests {
         assert!(export.gripper_se3_target.is_some());
         assert!(export.gripper_se3_rig.is_none());
         assert!(export.base_se3_target.is_none());
+    }
+
+    #[test]
+    fn export_image_manifest_defaults_absent_from_wire() {
+        // ADR 0014: when the pipeline emits an export the manifest is
+        // None and `skip_serializing_if` keeps the legacy JSON byte-stable.
+        let output = make_dummy_output();
+        let config = RigHandeyeConfig::default();
+        let dummy_view = RigView {
+            meta: RobotPoseMeta {
+                base_se3_gripper: Iso3::identity(),
+            },
+            obs: RigViewObs {
+                cameras: vec![Some(
+                    CorrespondenceView::new(
+                        vec![Pt3::new(0.0, 0.0, 0.0); 4],
+                        vec![Pt2::new(0.0, 0.0); 4],
+                    )
+                    .unwrap(),
+                )],
+            },
+        };
+        let dummy_input = RigDataset::new(vec![dummy_view], 1).unwrap();
+        let export = RigHandeyeProblem::export(&dummy_input, &output, &config).unwrap();
+        assert!(export.image_manifest.is_none());
+
+        let json = serde_json::to_string(&export).unwrap();
+        assert!(
+            !json.contains("image_manifest"),
+            "absent manifest must not appear on the wire"
+        );
+        let restored: RigHandeyeExport = serde_json::from_str(&json).unwrap();
+        assert!(restored.image_manifest.is_none());
+    }
+
+    #[test]
+    fn export_image_manifest_roundtrip_with_tiled_roi() {
+        // The puzzle 130×130 rig writes a single 4320×540 PNG per pose
+        // and references each of its six 720×540 camera tiles via ROI;
+        // mirror that shape in the test to lock the wire format.
+        use vision_calibration_core::{FrameRef, ImageManifest, PixelRect};
+
+        let output = make_dummy_output();
+        let config = RigHandeyeConfig::default();
+        let dummy_view = RigView {
+            meta: RobotPoseMeta {
+                base_se3_gripper: Iso3::identity(),
+            },
+            obs: RigViewObs {
+                cameras: vec![Some(
+                    CorrespondenceView::new(
+                        vec![Pt3::new(0.0, 0.0, 0.0); 4],
+                        vec![Pt2::new(0.0, 0.0); 4],
+                    )
+                    .unwrap(),
+                )],
+            },
+        };
+        let dummy_input = RigDataset::new(vec![dummy_view], 1).unwrap();
+        let mut export = RigHandeyeProblem::export(&dummy_input, &output, &config).unwrap();
+        export.image_manifest = Some(ImageManifest {
+            root: std::path::PathBuf::from("."),
+            frames: (0..6)
+                .map(|cam| FrameRef {
+                    pose: 0,
+                    camera: cam,
+                    path: std::path::PathBuf::from("target_0.png"),
+                    roi: Some(PixelRect {
+                        x: (cam as u32) * 720,
+                        y: 0,
+                        w: 720,
+                        h: 540,
+                    }),
+                })
+                .collect(),
+        });
+
+        let json = serde_json::to_string(&export).unwrap();
+        let restored: RigHandeyeExport = serde_json::from_str(&json).unwrap();
+        let manifest = restored
+            .image_manifest
+            .expect("manifest survives roundtrip");
+        assert_eq!(manifest.frames.len(), 6);
+        assert_eq!(manifest.frames[0].camera, 0);
+        assert_eq!(manifest.frames[5].roi.unwrap().x, 5 * 720);
     }
 }

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -835,6 +835,11 @@ mod tests {
         // The puzzle 130×130 rig writes a single 4320×540 PNG per pose
         // and references each of its six 720×540 camera tiles via ROI;
         // mirror that shape in the test to lock the wire format.
+        //
+        // Note: per the `image_manifest` coordinate convention, residual
+        // pixel coords are *ROI-local* — the ROI is a render-time crop
+        // hint only. This test pins the wire format; the convention
+        // itself is exercised by the viewer (see app/src/components).
         use vision_calibration_core::{FrameRef, ImageManifest, PixelRect};
 
         let output = make_dummy_output();


### PR DESCRIPTION
Stacks B0.5 (rig `image_manifest` + puzzle acceptance) and B0.6 (the viewer UX + visual-language overhaul) into one PR per the agreed plan. Eight commits, ordered for review.

## Summary

- **viewer cam ≥1 overlay bug fix.** `observed_px` / `projected_px` are documented as ROI-local on `FrameRef`; the viewer drops the ROI subtraction it was double-correcting with. Arrows now land on detected corners across all six tiles of the puzzle 130×130 export.
- **vitavision visual language.** HSL palette + Inter / Geist Mono fonts + tight 4px/6px radii + class-based light + dark mode (no `next-themes` dep). Logo is a static V mark + cyan dot pupil ported from `vitavision/src/components/shared/VitavisionLogo.tsx`, alongside `calibration-rs · diagnose` wordmark and a sun/moon theme toggle.
- **Navigation.** Single `pose i · cam j` dropdown gone; replaced by two ◀/▶ steppers + window-scoped ←/→ (pose) and ↑/↓ (camera) keys with wraparound. Editable elements still capture their own keystrokes.
- **Zoom + pan.** Cursor-anchored wheel zoom (clamped to `[0.25, 16]`), drag-to-pan, toolbar `−`/`+`/Fit/1:1 buttons + matching `f`/`1`/`+`/`−` shortcuts. Auto-fit on frame change in single-pane mode.
- **Pixel readout + histogram.** Per-frame Rec.601 luminance buffer (one decode pass shared by overlay + histogram + cursor); 64-bin grayscale histogram of the ROI; cursor chip showing `(x, y) · I=NNN` with the matching histogram bin highlighted in `--brand`.
- **Side-by-side compare mode.** New `CompareViewer` renders two frames; linked transform by default (`L` toggles). The active pane (Tab to swap) gets a cyan ring and is the target of the stepper / zoom shortcuts. Per-pane cursor readout flows back into the same chip.
- **B0.5 stays in this PR (its base).** `RigHandeyeExport` gains `Option<ImageManifest>`; the puzzle `examples-private` populator now writes `privatedata/130x130_puzzle/export.json` with one `FrameRef` per `(pose, camera)` slot pointing at the right tile via ROI.

## Bundle and dep cost

| Add | Size |
|---|---|
| `@fontsource/inter` (4 weights, latin + latin-ext) | ~32 KB woff2 / weight |
| `@fontsource/geist-mono` (2 weights) | ~25 KB woff2 / weight |
| (no JS deps added) | 0 |

Final viewer bundle: 211 KB JS / 67 KB gzip; 29 KB CSS / 5.5 KB gzip.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` green
- [x] `cargo doc --workspace --no-deps` clean
- [x] `cd app && bun run build` green
- [ ] `bun run tauri dev` → open `target/fixtures/planar_synthetic_with_images/export.json`: arrows still land on the 9×6 corners, mean ≈ 0.226 px
- [ ] Open `privatedata/130x130_puzzle/export.json`: step through cams 0–5 for pose 0; arrows land on detected corners in every tile (cam ≥1 fix)
- [ ] ←/→ cycles poses 0→19→0; ↑/↓ cycles cams 0→5→0 with wraparound
- [ ] Wheel-zoom anchors at cursor; pan via drag works; `f` fits, `1` is 1:1, `+`/`−` zoom, banner / disabled state still appear when launched as plain Vite
- [ ] Hover over a known white square → I≈240; black square → I≈30; histogram cursor bin highlights cyan
- [ ] Toggle Compare; pick `(pose 5, cam 0)` left and `(pose 5, cam 3)` right; linked zoom keeps both at the same image-pixel; press `L` and zoom one side independently
- [ ] Sun/moon toggle persists across reload; theme respects OS preference on a fresh `localStorage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)