### PR TITLE
B2: epipolar workspace + compute_epipolar_overlay command

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -254,12 +254,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "nalgebra",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "vision-calibration",
+ "vision-calibration-core",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -29,7 +29,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 anyhow = "1"
+nalgebra = { version = "0.34", features = ["serde-serialize"] }
 vision-calibration = { path = "../../crates/vision-calibration" }
+vision-calibration-core = { path = "../../crates/vision-calibration-core" }
 
 [features]
 # Avoid touching the embed_plist build hooks unless explicitly running

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -9,11 +9,15 @@
 use base64::Engine;
 use serde::Serialize;
 use std::path::PathBuf;
+use tauri::State;
+
+use crate::epipolar::{self, EpipolarOverlay};
+use crate::export_cache::ExportCache;
 
 /// Successful response for [`load_export`].
 #[derive(Serialize)]
 pub struct LoadExportResult {
-    /// Raw parsed export JSON. The frontend treats this as `PlanarExport`
+    /// Raw parsed export JSON. The frontend treats this as `AnyExport`
     /// (subset interface) and ignores fields it does not render.
     pub export: serde_json::Value,
     /// Absolute path to the directory containing `export.json`. The
@@ -23,9 +27,14 @@ pub struct LoadExportResult {
     pub export_dir: String,
 }
 
-/// Read and parse a calibration export JSON file.
+/// Read and parse a calibration export JSON file. Also populates the
+/// [`ExportCache`] so [`compute_epipolar_overlay`] can reuse the parsed
+/// JSON without going back to disk.
 #[tauri::command]
-pub async fn load_export(path: String) -> Result<LoadExportResult, String> {
+pub async fn load_export(
+    path: String,
+    cache: State<'_, ExportCache>,
+) -> Result<LoadExportResult, String> {
     let p = PathBuf::from(&path);
     let parent = p
         .parent()
@@ -39,6 +48,9 @@ pub async fn load_export(path: String) -> Result<LoadExportResult, String> {
         .map_err(|e| format!("canonicalize {}: {e}", parent.display()))?
         .to_string_lossy()
         .into_owned();
+
+    cache.set(path.clone(), export.clone());
+
     Ok(LoadExportResult { export, export_dir })
 }
 
@@ -51,6 +63,27 @@ pub async fn load_image(path: String) -> Result<String, String> {
     let mime = mime_for(&path);
     let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
     Ok(format!("data:{mime};base64,{b64}"))
+}
+
+/// Compute the epipolar polyline + epipole for a click in pane A.
+///
+/// Reads the most recently loaded export from [`ExportCache`] (no disk
+/// I/O), backprojects `point_px` through cam-A's full distortion +
+/// (optional) Scheimpflug chain, transforms the resulting ray into
+/// cam-B's frame via the rig extrinsics, and projects 64 logarithmically
+/// spaced depth samples through cam-B's full chain. The returned line
+/// is in distorted pane-B pixel coordinates and can be rendered as an
+/// SVG `<polyline>` directly.
+#[tauri::command]
+pub async fn compute_epipolar_overlay(
+    cam_a: usize,
+    cam_b: usize,
+    point_px: [f64; 2],
+    cache: State<'_, ExportCache>,
+) -> Result<EpipolarOverlay, String> {
+    cache
+        .read(|cached| epipolar::compute_overlay(&cached.value, cam_a, cam_b, point_px))
+        .ok_or_else(|| "no export loaded yet".to_string())?
 }
 
 fn mime_for(path: &str) -> &'static str {

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -27,14 +27,14 @@ pub struct LoadExportResult {
     pub export_dir: String,
 }
 
-/// Read and parse a calibration export JSON file. Also populates the
-/// [`ExportCache`] so [`compute_epipolar_overlay`] can reuse the parsed
-/// JSON without going back to disk.
+/// Read and parse a calibration export JSON file. Does NOT cache the
+/// result — the frontend validates the export (e.g. requires
+/// `image_manifest`) before the user can interact with it, and a
+/// rejected export must not displace the cache the previous session is
+/// still using. The frontend calls [`set_active_export`] explicitly
+/// once it accepts the file.
 #[tauri::command]
-pub async fn load_export(
-    path: String,
-    cache: State<'_, ExportCache>,
-) -> Result<LoadExportResult, String> {
+pub async fn load_export(path: String) -> Result<LoadExportResult, String> {
     let p = PathBuf::from(&path);
     let parent = p
         .parent()
@@ -49,9 +49,24 @@ pub async fn load_export(
         .to_string_lossy()
         .into_owned();
 
-    cache.set(path.clone(), export.clone());
-
     Ok(LoadExportResult { export, export_dir })
+}
+
+/// Commit the export the frontend has accepted as the active dataset.
+///
+/// Called by the frontend after [`load_export`] returned and the
+/// frontend's validation (image_manifest required, frames non-empty,
+/// …) passed. Writes `path` + the parsed `export` into the
+/// [`ExportCache`] so subsequent math commands operate on exactly the
+/// dataset the user is looking at.
+#[tauri::command]
+pub async fn set_active_export(
+    path: String,
+    export: serde_json::Value,
+    cache: State<'_, ExportCache>,
+) -> Result<(), String> {
+    cache.set(path, export);
+    Ok(())
 }
 
 /// Read an image file and return it as a `data:` URL the webview can use

--- a/app/src-tauri/src/epipolar.rs
+++ b/app/src-tauri/src/epipolar.rs
@@ -17,10 +17,13 @@ use vision_calibration::core::{
 };
 use vision_calibration_core::CameraModel;
 
-/// Number of depth samples along the ray. 64 is enough that even when
-/// the polyline crosses the far plane at a high angle the rendered SVG
-/// looks smooth.
-const DEPTH_SAMPLES: usize = 64;
+/// Number of depth samples along the ray. 256 keeps the rendered SVG
+/// smooth even when only a short subset of samples lands inside the
+/// pane-B image (which is where the engineer actually reads the
+/// epipolar curve). 64 was enough for the in-test scenario but left a
+/// visibly piecewise polyline on real datasets where most samples
+/// project outside the image and only a handful land within bounds.
+const DEPTH_SAMPLES: usize = 256;
 /// Min/max depths along the back-projected ray (meters). Logarithmic
 /// spacing inside this window. Picked to comfortably cover the puzzle
 /// 130×130 working volume and shorter benchtop calibrations.

--- a/app/src-tauri/src/epipolar.rs
+++ b/app/src-tauri/src/epipolar.rs
@@ -1,0 +1,287 @@
+//! Server-side epipolar overlay: given a clicked pixel in pane A, return
+//! the polyline of its epipolar line in pane B (in distorted pane-B
+//! pixel coordinates) plus the optional epipole.
+//!
+//! Math lives here, not in the React frontend, so distortion +
+//! Scheimpflug projection use the canonical [`vision_calibration::core`]
+//! camera models. Drift between Rust and a re-implemented TS projection
+//! would be the worst possible bug class for a diagnostic tool — every
+//! "is the calibration wrong or is the viz wrong" moment becomes a
+//! science fair.
+
+use nalgebra::{Point2, Point3, Vector3};
+use serde::Serialize;
+use vision_calibration::core::{
+    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams, Iso3,
+    ProjectionParams, ScheimpflugParams, SensorParams,
+};
+use vision_calibration_core::CameraModel;
+
+/// Number of depth samples along the ray. 64 is enough that even when
+/// the polyline crosses the far plane at a high angle the rendered SVG
+/// looks smooth.
+const DEPTH_SAMPLES: usize = 64;
+/// Min/max depths along the back-projected ray (meters). Logarithmic
+/// spacing inside this window. Picked to comfortably cover the puzzle
+/// 130×130 working volume and shorter benchtop calibrations.
+const DEPTH_MIN_M: f64 = 0.05;
+const DEPTH_MAX_M: f64 = 5.0;
+
+/// Result of a single epipolar overlay computation.
+#[derive(Debug, Clone, Serialize)]
+pub struct EpipolarOverlay {
+    /// Pane-B distorted pixel coordinates of each depth sample that
+    /// projected successfully. `[]` when the ray never crosses pane B's
+    /// image plane in front of cam B.
+    pub line_b: Vec<[f64; 2]>,
+    /// Pane-B pixel coordinate of cam A's optical center. `None` when
+    /// the cameras are arranged so the epipole is at infinity (or
+    /// behind cam B).
+    pub epipole_b: Option<[f64; 2]>,
+    /// Number of depth samples whose projection diverged (point behind
+    /// cam B, distortion fixed-point failure, …). For diagnostic UI.
+    pub samples_clipped: usize,
+}
+
+/// Compute the overlay for a click at `point_px` on cam-A.
+///
+/// `export` is the most-recently-loaded calibration export JSON, expected
+/// to carry `cameras: Vec<PinholeCamera-shaped>`, optional
+/// `sensors: Vec<ScheimpflugParams>`, and `cam_se3_rig: Vec<Iso3>` — this
+/// is true for `RigExtrinsicsExport`, `RigHandeyeExport`, and
+/// `RigLaserlineDeviceExport`.
+pub fn compute_overlay(
+    export: &serde_json::Value,
+    cam_a: usize,
+    cam_b: usize,
+    point_px: [f64; 2],
+) -> Result<EpipolarOverlay, String> {
+    let cameras = export
+        .get("cameras")
+        .and_then(|v| v.as_array())
+        .ok_or("export has no `cameras` array (rig exports only)")?;
+    let cam_se3_rig: Vec<Iso3> = serde_json::from_value(
+        export
+            .get("cam_se3_rig")
+            .ok_or("export has no `cam_se3_rig`")?
+            .clone(),
+    )
+    .map_err(|e| format!("cam_se3_rig decode: {e}"))?;
+    let sensors = parse_sensors(export)?;
+
+    let n = cameras.len();
+    if cam_a >= n || cam_b >= n {
+        return Err(format!(
+            "camera index out of range (cam_a={cam_a}, cam_b={cam_b}, num_cameras={n})"
+        ));
+    }
+    if cam_se3_rig.len() != n {
+        return Err(format!(
+            "cam_se3_rig length {} does not match cameras length {n}",
+            cam_se3_rig.len()
+        ));
+    }
+
+    let sensor_for =
+        |idx: usize| -> Option<&ScheimpflugParams> { sensors.as_ref()?.get(idx)?.as_ref() };
+    let cam_a_model = build_camera(&cameras[cam_a], sensor_for(cam_a))?;
+    let cam_b_model = build_camera(&cameras[cam_b], sensor_for(cam_b))?;
+
+    // Ray in cam-A frame from the clicked pixel. `Camera::backproject_pixel`
+    // returns the point on the z = 1 plane, so scaling by `depth` gives a
+    // 3D point at that depth without re-undistorting.
+    let ray_a = cam_a_model.backproject_pixel(&Point2::new(point_px[0], point_px[1]));
+
+    // T_B_A composes the rig→cam transforms: T_B_A = T_B_R · T_R_A.
+    // cam_se3_rig[i] is T_C_R (rig→camera); inverting cam_a gives T_A_R
+    // → T_R_A; combined with T_C_R for cam_b yields T_B_A.
+    let t_b_a = cam_se3_rig[cam_b] * cam_se3_rig[cam_a].inverse();
+
+    let mut line_b = Vec::with_capacity(DEPTH_SAMPLES);
+    let mut samples_clipped = 0usize;
+    for d in log_depths() {
+        let p_a = Point3::from(ray_a.point * d);
+        let p_b = t_b_a * p_a;
+        match cam_b_model.project_point_c(&p_b.coords) {
+            Some(px) => line_b.push([px.x, px.y]),
+            None => samples_clipped += 1,
+        }
+    }
+
+    // Epipole = projection of cam-A's optical center (origin in A frame)
+    // into cam B. None when behind cam B (parallel-cam configuration in
+    // particular puts the epipole at infinity).
+    let origin_b = t_b_a * Point3::<f64>::origin();
+    let epipole_b = cam_b_model
+        .project_point_c(&origin_b.coords)
+        .map(|p| [p.x, p.y]);
+
+    Ok(EpipolarOverlay {
+        line_b,
+        epipole_b,
+        samples_clipped,
+    })
+}
+
+/// Logarithmically-spaced depths from `DEPTH_MIN_M` to `DEPTH_MAX_M`.
+fn log_depths() -> impl Iterator<Item = f64> {
+    let ratio = DEPTH_MAX_M / DEPTH_MIN_M;
+    (0..DEPTH_SAMPLES).map(move |i| {
+        let t = i as f64 / (DEPTH_SAMPLES - 1) as f64;
+        DEPTH_MIN_M * ratio.powf(t)
+    })
+}
+
+/// Build a runtime camera from one entry of the export's `cameras` array
+/// + optional Scheimpflug sensor params from the parallel `sensors` array.
+fn build_camera(
+    camera_json: &serde_json::Value,
+    sensor: Option<&ScheimpflugParams>,
+) -> Result<CameraModel, String> {
+    let k: FxFyCxCySkew<f64> = serde_json::from_value(
+        camera_json
+            .get("k")
+            .ok_or("camera entry has no `k` field")?
+            .clone(),
+    )
+    .map_err(|e| format!("camera.k decode: {e}"))?;
+    let dist: BrownConrady5<f64> = serde_json::from_value(
+        camera_json
+            .get("dist")
+            .ok_or("camera entry has no `dist` field")?
+            .clone(),
+    )
+    .map_err(|e| format!("camera.dist decode: {e}"))?;
+
+    let sensor_params = match sensor {
+        None => SensorParams::Identity,
+        Some(s) => SensorParams::Scheimpflug { params: *s },
+    };
+
+    let params = CameraParams {
+        projection: ProjectionParams::Pinhole,
+        distortion: DistortionParams::BrownConrady5 { params: dist },
+        sensor: sensor_params,
+        intrinsics: IntrinsicsParams::FxFyCxCySkew { params: k },
+    };
+    Ok(params.build())
+}
+
+/// Parse the optional `sensors` array. None when the export is a pinhole
+/// rig; Some(_) when Scheimpflug. Each entry is `null` for pinhole
+/// cameras inside a mixed rig (none today, but future-proof).
+fn parse_sensors(
+    export: &serde_json::Value,
+) -> Result<Option<Vec<Option<ScheimpflugParams>>>, String> {
+    let Some(arr) = export.get("sensors") else {
+        return Ok(None);
+    };
+    if arr.is_null() {
+        return Ok(None);
+    }
+    let arr = arr
+        .as_array()
+        .ok_or("`sensors` is neither null nor an array")?;
+    let mut out = Vec::with_capacity(arr.len());
+    for entry in arr {
+        if entry.is_null() {
+            out.push(None);
+        } else {
+            let s: ScheimpflugParams = serde_json::from_value(entry.clone())
+                .map_err(|e| format!("sensors[..] decode: {e}"))?;
+            out.push(Some(s));
+        }
+    }
+    Ok(Some(out))
+}
+
+/// Vector3 alias to keep imports tidy if/when the algorithm grows beyond
+/// the current single-call shape.
+#[allow(dead_code)]
+type V3 = Vector3<f64>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vision_calibration::core::{BrownConrady5 as BC5, FxFyCxCySkew as K, make_pinhole_camera};
+
+    /// Synthetic 2-camera pinhole rig: project a known 3D point through
+    /// cam A, ask for the overlay, assert pane-B's projected_pixel of
+    /// the same 3D point lies within 0.5 px of *some* polyline sample.
+    /// Tight bound because the depth sweep is dense (64 log samples).
+    #[test]
+    fn overlay_polyline_passes_through_corresponding_pixel_pinhole() {
+        let k = K {
+            fx: 800.0,
+            fy: 800.0,
+            cx: 320.0,
+            cy: 240.0,
+            skew: 0.0,
+        };
+        let cam_a = make_pinhole_camera(k, BC5::default());
+        let cam_b = make_pinhole_camera(k, BC5::default());
+        // T_C_R: identity for cam A, +0.2 m baseline along X for cam B
+        // (cam B is to the right of cam A in rig frame).
+        let t_a_r = Iso3::identity();
+        let t_b_r = Iso3::from_parts(
+            nalgebra::Translation3::new(0.2, 0.0, 0.0),
+            nalgebra::UnitQuaternion::identity(),
+        );
+        // 3D point in rig frame, ~1 m in front of both cameras.
+        let p_r = Point3::new(0.0, 0.0, 1.0);
+        let p_a = t_a_r * p_r;
+        let p_b = t_b_r * p_r;
+        let pixel_a = cam_a.project_point_c(&p_a.coords).unwrap();
+        let pixel_b = cam_b.project_point_c(&p_b.coords).unwrap();
+
+        // Hand-build the export-shaped JSON the production code reads.
+        let export = serde_json::json!({
+            "cameras": [serde_json::to_value(&cam_a).unwrap(), serde_json::to_value(&cam_b).unwrap()],
+            "cam_se3_rig": [t_a_r, t_b_r],
+        });
+
+        let overlay = compute_overlay(&export, 0, 1, [pixel_a.x, pixel_a.y]).unwrap();
+        assert!(!overlay.line_b.is_empty(), "polyline must have samples");
+
+        let dist_min = overlay
+            .line_b
+            .iter()
+            .map(|p| {
+                let dx = p[0] - pixel_b.x;
+                let dy = p[1] - pixel_b.y;
+                (dx * dx + dy * dy).sqrt()
+            })
+            .fold(f64::INFINITY, f64::min);
+        assert!(
+            dist_min < 0.5,
+            "polyline closest sample {dist_min:.4} px away from \
+             corresponding pane-B projection (pixel_b={pixel_b:?})"
+        );
+    }
+
+    #[test]
+    fn overlay_rejects_out_of_range_camera() {
+        let k = K {
+            fx: 800.0,
+            fy: 800.0,
+            cx: 320.0,
+            cy: 240.0,
+            skew: 0.0,
+        };
+        let cam = make_pinhole_camera(k, BC5::default());
+        let export = serde_json::json!({
+            "cameras": [serde_json::to_value(&cam).unwrap()],
+            "cam_se3_rig": [Iso3::identity()],
+        });
+        let err = compute_overlay(&export, 0, 5, [100.0, 100.0]).unwrap_err();
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+
+    #[test]
+    fn log_depth_endpoints_match_constants() {
+        let depths: Vec<f64> = log_depths().collect();
+        assert_eq!(depths.len(), DEPTH_SAMPLES);
+        assert!((depths[0] - DEPTH_MIN_M).abs() < 1e-12);
+        assert!((depths[DEPTH_SAMPLES - 1] - DEPTH_MAX_M).abs() < 1e-9);
+    }
+}

--- a/app/src-tauri/src/export_cache.rs
+++ b/app/src-tauri/src/export_cache.rs
@@ -1,0 +1,49 @@
+//! Most-recently-loaded export cache.
+//!
+//! `compute_epipolar_overlay` is invoked once per click in the epipolar
+//! workspace; re-reading and re-parsing the export JSON on every call
+//! would be wasteful. We hold the most recent `(path, json)` pair in a
+//! `tauri::State<ExportCache>` singleton, populated by `load_export` and
+//! invalidated when a new export is loaded.
+
+use std::sync::Mutex;
+
+/// Snapshot of a loaded export. The JSON is kept as raw `Value` so the
+/// command can pull whatever fields it needs (cameras, sensors,
+/// cam_se3_rig, …) without committing the cache to a particular shape.
+#[derive(Debug, Clone)]
+pub struct CachedExport {
+    /// Absolute path the export was loaded from. Kept around so future
+    /// commands can disambiguate stale caches after a reload — read by
+    /// debug logs but not yet by command code.
+    #[allow(dead_code)]
+    pub path: String,
+    /// Parsed export JSON.
+    pub value: serde_json::Value,
+}
+
+/// Tauri-managed state holding the latest cached export.
+#[derive(Default)]
+pub struct ExportCache {
+    inner: Mutex<Option<CachedExport>>,
+}
+
+impl ExportCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the cached export.
+    pub fn set(&self, path: String, value: serde_json::Value) {
+        let mut guard = self.inner.lock().expect("export cache mutex poisoned");
+        *guard = Some(CachedExport { path, value });
+    }
+
+    /// Run `f` against the cached export under the lock. Returns `None`
+    /// when no export has been loaded yet. Cloning the `serde_json::Value`
+    /// inside `f` is fine — it's a few-KB to a few-hundred-KB document.
+    pub fn read<R>(&self, f: impl FnOnce(&CachedExport) -> R) -> Option<R> {
+        let guard = self.inner.lock().expect("export cache mutex poisoned");
+        guard.as_ref().map(f)
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
         .manage(ExportCache::new())
         .invoke_handler(tauri::generate_handler![
             commands::load_export,
+            commands::set_active_export,
             commands::load_image,
             commands::compute_epipolar_overlay,
         ])

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,29 +1,35 @@
-//! Tauri 2 backend for the calibration-rs diagnose viewer (B0).
+//! Tauri 2 backend for the calibration-rs diagnose viewer.
 //!
-//! See `app/README.md` and `docs/adrs/0014-tauri-desktop-app.md` for the
-//! v0 scope. The backend exposes exactly two commands:
+//! Commands exposed to the React frontend:
 //!
 //! - [`commands::load_export`] — read + parse an `export.json` produced
 //!   by the calibration library, return its parsed contents and the
 //!   absolute directory it lives in (so the frontend can resolve the
-//!   image manifest's relative paths).
-//! - [`commands::load_image`] — read a PNG file from disk, return a
-//!   `data:` URL the webview can drop into a `<canvas>` via
-//!   `Image()`.
-//!
-//! No long-lived state, no calibration mutation, no IPC events — the
-//! viewer is a one-way passive consumer of an export bundle.
+//!   image manifest's relative paths). Also caches the parsed JSON for
+//!   downstream math commands.
+//! - [`commands::load_image`] — read an image file from disk, return a
+//!   `data:` URL the webview can drop into a `<canvas>` via `Image()`.
+//! - [`commands::compute_epipolar_overlay`] — server-side epipolar line
+//!   computation through the canonical camera models in
+//!   `vision_calibration_core`. See ADR 0014 for the architecture
+//!   rationale (no TS-side projection).
 
 mod commands;
+mod epipolar;
+mod export_cache;
 
-/// Entry point invoked from `main.rs`. Wires up the dialog plugin and
-/// the two viewer commands and starts the Tauri runtime.
+use export_cache::ExportCache;
+
+/// Entry point invoked from `main.rs`. Wires up the dialog plugin, the
+/// shared export cache, and the viewer + math commands.
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .manage(ExportCache::new())
         .invoke_handler(tauri::generate_handler![
             commands::load_export,
             commands::load_image,
+            commands::compute_epipolar_overlay,
         ])
         .run(tauri::generate_context!())
         .expect("failed to launch calibration-diagnose");

--- a/app/src/components/FrameCanvas.tsx
+++ b/app/src/components/FrameCanvas.tsx
@@ -34,10 +34,19 @@ interface FrameCanvasProps {
    * matching the residual frame). `null` when the cursor leaves the
    * image area. */
   onCursor?: (cursor: { x: number; y: number } | null) => void;
+  /** Called on a discrete left-click (mousedown → mouseup with little
+   * cursor movement, distinguishing it from a pan-drag) at the given
+   * image-pixel coordinates. Used by the epipolar workspace to pick a
+   * pane-A pixel for the overlay request. */
+  onPick?: (pixel: { x: number; y: number }) => void;
   /** Visual ring drawn around the canvas when this pane is the
    * keyboard-active pane in compare mode. */
   active?: boolean;
 }
+
+/** Pixel-distance threshold below which a mousedown→mouseup pair is a
+ * click (firing `onPick`) and above which it's a pan-drag. */
+const CLICK_DRAG_THRESHOLD_PX = 4;
 
 /** Imperative handle the toolbar uses to drive zoom/fit. */
 export interface FrameCanvasHandle {
@@ -61,6 +70,7 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       onTransformChange,
       onError,
       onCursor,
+      onPick,
       active,
     },
     ref,
@@ -200,8 +210,28 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
         }));
       }
     };
-    const handleMouseUp = () => {
+    const handleMouseUp = (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const d = dragRef.current;
       dragRef.current = null;
+      // Distinguish click from pan-drag by total cursor movement.
+      // Below the threshold we treat it as a pick; above it the user
+      // was dragging and shouldn't accidentally select a feature.
+      if (!d || !onPick) return;
+      const dx = e.clientX - d.startX;
+      const dy = e.clientY - d.startY;
+      if (Math.hypot(dx, dy) > CLICK_DRAG_THRESHOLD_PX) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      const ix = (cx - transform.tx) / transform.scale;
+      const iy = (cy - transform.ty) / transform.scale;
+      const sw = roi?.w ?? image?.naturalWidth ?? 0;
+      const sh = roi?.h ?? image?.naturalHeight ?? 0;
+      if (ix >= 0 && iy >= 0 && ix < sw && iy < sh) {
+        onPick({ x: ix, y: iy });
+      }
     };
     const handleMouseLeave = () => {
       dragRef.current = null;

--- a/app/src/components/PoseCameraStepper.tsx
+++ b/app/src/components/PoseCameraStepper.tsx
@@ -1,85 +1,97 @@
+import { PoseStepper } from "./PoseStepper";
+
 interface PoseCameraStepperProps {
-  /** 1-indexed ordinal of the current pose within the meaningful set
-   * (the manifest's available poses for the current camera, or all
-   * distinct poses if the parent treats them globally). */
-  poseOrdinal: number;
-  /** Count of meaningful poses — the denominator in `i / N`. */
-  poseTotal: number;
-  cameraOrdinal: number;
-  cameraTotal: number;
-  /** Step the pose by `delta` (typically ±1). The parent handles
-   * wraparound and ROI-aware skipping over manifest gaps. */
-  onPoseStep: (delta: number) => void;
-  onCameraStep: (delta: number) => void;
+  poseValues: number[];
+  selectedPose: number;
+  onSelectPose: (next: number) => void;
+  cameraValues: number[];
+  selectedCamera: number;
+  onSelectCamera: (next: number) => void;
 }
 
-/** Two stepper widgets side by side: pose (◀ / ▶) and camera (◀ / ▶).
- * The arrow keys are also bound at the window level via
- * `useKeyboardNav`; these buttons are the mouse-only path. The
- * stepper itself is dumb — the parent decides what "next" means
- * (especially for sparse manifests where some `(pose, camera)`
- * combinations don't exist). */
+/** Pose + camera selectors side by side. Pose has a typeable value
+ * (handy for sparse manifests where stepping is slow); camera is a
+ * compact stepper because rigs rarely have more than a handful. */
 export function PoseCameraStepper({
-  poseOrdinal,
-  poseTotal,
-  cameraOrdinal,
-  cameraTotal,
-  onPoseStep,
-  onCameraStep,
+  poseValues,
+  selectedPose,
+  onSelectPose,
+  cameraValues,
+  selectedCamera,
+  onSelectCamera,
 }: PoseCameraStepperProps) {
   return (
     <div className="flex items-center gap-4">
-      <Stepper
-        label="pose"
-        ordinal={poseOrdinal}
-        total={poseTotal}
-        onPrev={() => onPoseStep(-1)}
-        onNext={() => onPoseStep(+1)}
+      <PoseStepper
+        poseValues={poseValues}
+        selectedPose={selectedPose}
+        onSelectPose={onSelectPose}
       />
-      <Stepper
-        label="cam"
-        ordinal={cameraOrdinal}
-        total={cameraTotal}
-        onPrev={() => onCameraStep(-1)}
-        onNext={() => onCameraStep(+1)}
+      <CameraStepper
+        cameraValues={cameraValues}
+        selectedCamera={selectedCamera}
+        onSelectCamera={onSelectCamera}
       />
     </div>
   );
 }
 
-interface StepperProps {
-  label: string;
-  ordinal: number;
-  total: number;
-  onPrev: () => void;
-  onNext: () => void;
+interface CameraStepperProps {
+  cameraValues: number[];
+  selectedCamera: number;
+  onSelectCamera: (next: number) => void;
 }
 
-function Stepper({ label, ordinal, total, onPrev, onNext }: StepperProps) {
+function CameraStepper({
+  cameraValues,
+  selectedCamera,
+  onSelectCamera,
+}: CameraStepperProps) {
+  const stepBy = (delta: number) => {
+    if (cameraValues.length === 0) return;
+    const idx = cameraValues.indexOf(selectedCamera);
+    if (idx < 0) {
+      onSelectCamera(cameraValues[delta >= 0 ? 0 : cameraValues.length - 1]);
+      return;
+    }
+    const n = cameraValues.length;
+    onSelectCamera(cameraValues[(((idx + delta) % n) + n) % n]);
+  };
+
+  const idx = cameraValues.indexOf(selectedCamera);
+  const ordinalLabel =
+    idx >= 0 ? `${idx + 1}/${cameraValues.length}` : `?/${cameraValues.length}`;
+
   return (
     <div className="flex items-center gap-1">
-      <span className="font-mono text-[11px] text-muted-foreground">{label}</span>
+      <span className="font-mono text-[11px] text-muted-foreground">cam</span>
       <button
         type="button"
-        onClick={onPrev}
-        aria-label={`previous ${label}`}
+        onClick={() => stepBy(-1)}
+        aria-label="previous camera"
         className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
-        title={`previous ${label}`}
+        title="previous camera"
       >
         ◀
       </button>
-      <span className="min-w-[3.5rem] text-center font-mono text-xs tabular-nums">
-        {ordinal} / {total}
+      <span className="min-w-[1.5rem] text-center font-mono text-xs tabular-nums">
+        {selectedCamera}
       </span>
       <button
         type="button"
-        onClick={onNext}
-        aria-label={`next ${label}`}
+        onClick={() => stepBy(+1)}
+        aria-label="next camera"
         className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
-        title={`next ${label}`}
+        title="next camera"
       >
         ▶
       </button>
+      <span
+        className="font-mono text-[10px] tabular-nums text-muted-foreground"
+        title={`${idx + 1} of ${cameraValues.length} cameras`}
+      >
+        {ordinalLabel}
+      </span>
     </div>
   );
 }

--- a/app/src/components/PoseStepper.tsx
+++ b/app/src/components/PoseStepper.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from "react";
+
+interface PoseStepperProps {
+  /** All valid pose values (from manifest / export). Sorted ascending. */
+  poseValues: number[];
+  /** Currently selected pose. */
+  selectedPose: number;
+  /** Called with the next valid pose value. The component snaps a
+   * typed value to the nearest entry in `poseValues`; this callback
+   * always receives a member of that list (or the unchanged
+   * `selectedPose` if the typed text was unparseable). */
+  onSelectPose: (next: number) => void;
+  /** Optional label override; default "pose". */
+  label?: string;
+}
+
+/** Pose selector with a typeable value. Combines step arrows (one
+ * pose at a time, wrapping) with a small text input so engineers can
+ * jump straight to "pose 47" instead of clicking the arrow 47 times.
+ *
+ * Typed values snap to the nearest member of `poseValues` on commit
+ * (Enter / blur) — convenient when the manifest is sparse and a
+ * raw typed integer might not exist. Invalid text reverts. */
+export function PoseStepper({
+  poseValues,
+  selectedPose,
+  onSelectPose,
+  label = "pose",
+}: PoseStepperProps) {
+  const [draft, setDraft] = useState<string>(() => String(selectedPose));
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Keep the visible text in sync with the canonical selection
+  // whenever the parent moves it (arrow keys, click on a frustum,
+  // wrap-around step). Avoid clobbering the user's typing while the
+  // input is focused.
+  useEffect(() => {
+    if (document.activeElement === inputRef.current) return;
+    setDraft(String(selectedPose));
+  }, [selectedPose]);
+
+  const stepBy = (delta: number) => {
+    if (poseValues.length === 0) return;
+    const idx = poseValues.indexOf(selectedPose);
+    if (idx < 0) {
+      onSelectPose(poseValues[delta >= 0 ? 0 : poseValues.length - 1]);
+      return;
+    }
+    const n = poseValues.length;
+    const next = poseValues[(((idx + delta) % n) + n) % n];
+    onSelectPose(next);
+  };
+
+  const commit = () => {
+    const parsed = Number.parseInt(draft, 10);
+    if (Number.isNaN(parsed) || poseValues.length === 0) {
+      setDraft(String(selectedPose));
+      return;
+    }
+    // Snap to nearest valid pose. Sparse manifests routinely have gaps
+    // (poses 0, 2, 5, …) so an exact match isn't guaranteed.
+    let best = poseValues[0];
+    let bestDist = Math.abs(best - parsed);
+    for (const v of poseValues) {
+      const d = Math.abs(v - parsed);
+      if (d < bestDist) {
+        best = v;
+        bestDist = d;
+      }
+    }
+    setDraft(String(best));
+    if (best !== selectedPose) onSelectPose(best);
+  };
+
+  const idx = poseValues.indexOf(selectedPose);
+  const ordinalLabel =
+    idx >= 0 ? `${idx + 1}/${poseValues.length}` : `?/${poseValues.length}`;
+
+  return (
+    <div className="flex items-center gap-1">
+      <span className="font-mono text-[11px] text-muted-foreground">{label}</span>
+      <button
+        type="button"
+        onClick={() => stepBy(-1)}
+        aria-label={`previous ${label}`}
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+        title={`previous ${label}`}
+      >
+        ◀
+      </button>
+      <input
+        ref={inputRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            commit();
+            inputRef.current?.blur();
+          } else if (e.key === "Escape") {
+            setDraft(String(selectedPose));
+            inputRef.current?.blur();
+          }
+        }}
+        inputMode="numeric"
+        className="h-7 w-14 rounded-md border border-border bg-surface px-1 text-center font-mono text-xs tabular-nums text-foreground"
+        aria-label={`${label} value`}
+      />
+      <button
+        type="button"
+        onClick={() => stepBy(+1)}
+        aria-label={`next ${label}`}
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+        title={`next ${label}`}
+      >
+        ▶
+      </button>
+      <span
+        className="font-mono text-[10px] tabular-nums text-muted-foreground"
+        title={`${idx + 1} of ${poseValues.length} poses`}
+      >
+        {ordinalLabel}
+      </span>
+    </div>
+  );
+}

--- a/app/src/lib/se3.ts
+++ b/app/src/lib/se3.ts
@@ -1,5 +1,11 @@
-import { Matrix4, Quaternion, Vector3 } from "three";
+import { Euler, Matrix4, Quaternion, Vector3 } from "three";
 import type { Iso3Wire } from "../store/types";
+
+const RAD2DEG = 180 / Math.PI;
+export const IDENTITY_ISO3: Iso3Wire = {
+  rotation: [0, 0, 0, 1],
+  translation: [0, 0, 0],
+};
 
 /** Build a Three.js Matrix4 from the on-wire `Iso3` shape.
  *
@@ -55,4 +61,72 @@ export function cameraPositionInRig(camSe3Rig: Iso3Wire): [number, number, numbe
   const qInv = new Quaternion(-qx, -qy, -qz, qw);
   const tNeg = new Vector3(-tx, -ty, -tz).applyQuaternion(qInv);
   return [tNeg.x, tNeg.y, tNeg.z];
+}
+
+/** SE(3) inverse in wire format. Same math as `iso3InverseFromWire`
+ * but stays in `Iso3Wire` so it can be composed with the other
+ * pose-readout helpers without a Matrix4 round-trip. */
+export function iso3InverseWire(iso: Iso3Wire): Iso3Wire {
+  const [qx, qy, qz, qw] = iso.rotation;
+  const [tx, ty, tz] = iso.translation;
+  const qInv = new Quaternion(-qx, -qy, -qz, qw);
+  const tNeg = new Vector3(-tx, -ty, -tz).applyQuaternion(qInv);
+  return {
+    rotation: [qInv.x, qInv.y, qInv.z, qInv.w],
+    translation: [tNeg.x, tNeg.y, tNeg.z],
+  };
+}
+
+/** Euclidean magnitude of the translation, in the same units as the
+ * input (meters for our wire format). Used for "distance" readouts in
+ * the 3D viewer pose panels. */
+export function iso3DistanceM(iso: Iso3Wire): number {
+  const [tx, ty, tz] = iso.translation;
+  return Math.hypot(tx, ty, tz);
+}
+
+/** Convert the rotation to ZYX Euler angles in degrees.
+ *
+ * Three.js's `Euler.setFromQuaternion` with order `"XYZ"` returns the
+ * angles such that `R = Rx(x) * Ry(y) * Rz(z)`. For a board pose the
+ * X / Y components are the pitch / yaw the engineer reads as "is the
+ * board tilted left, is it tilted up"; Z is roll. */
+export function iso3EulerXYZDeg(iso: Iso3Wire): {
+  x: number;
+  y: number;
+  z: number;
+} {
+  const [qx, qy, qz, qw] = iso.rotation;
+  const q = new Quaternion(qx, qy, qz, qw);
+  const e = new Euler().setFromQuaternion(q, "XYZ");
+  return { x: e.x * RAD2DEG, y: e.y * RAD2DEG, z: e.z * RAD2DEG };
+}
+
+/** Magnitude of the axis-angle representation of the rotation, in
+ * degrees. A single number summarising "how rotated is this pose". */
+export function iso3RotationAngleDeg(iso: Iso3Wire): number {
+  const qw = Math.min(1, Math.max(-1, iso.rotation[3]));
+  return 2 * Math.acos(qw) * RAD2DEG;
+}
+
+/** Compose `cam_se3_rig[ref]` with `cam_se3_rig[sel]^-1` to get the
+ * pose of the selected camera expressed in the reference camera's
+ * frame: translation tells you where the selected camera sits relative
+ * to the reference, rotation tells you how its axes are oriented. */
+export function relativeCameraPose(
+  refCamSe3Rig: Iso3Wire,
+  selCamSe3Rig: Iso3Wire,
+): Iso3Wire {
+  return iso3Compose(refCamSe3Rig, iso3InverseWire(selCamSe3Rig));
+}
+
+/** Compose `cam_se3_rig[cam] · rig_se3_target[pose]` to get the
+ * target's pose in the camera's frame. The translation is the
+ * camera→target vector (length = distance to board); the rotation is
+ * the board's orientation in the camera. */
+export function targetInCameraPose(
+  camSe3Rig: Iso3Wire,
+  rigSe3Target: Iso3Wire,
+): Iso3Wire {
+  return iso3Compose(camSe3Rig, rigSe3Target);
 }

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -93,6 +93,10 @@ export const useStore = create<AppState>()(
       const data = result.export;
       const manifest = data.image_manifest;
       if (!manifest) {
+        // Reject the file. We deliberately do NOT promote it to the
+        // backend export cache — `compute_epipolar_overlay` (and any
+        // future math command) must keep operating against the
+        // previous accepted export until the user picks a valid one.
         set({
           loadError:
             "This export has no image_manifest field. v0 requires the manifest to render the source images alongside the residuals.",
@@ -149,6 +153,18 @@ export const useStore = create<AppState>()(
         frames.find(
           (f) => f.pose !== first.pose || f.camera !== first.camera,
         ) ?? first;
+
+      // Promote the validated export into the backend cache *before*
+      // updating the frontend state, so `compute_epipolar_overlay` and
+      // any future math command sees the same dataset the user is
+      // about to interact with. If the commit fails the frontend
+      // surfaces the error and stays on the previous export.
+      try {
+        await invoke("set_active_export", { path, export: data });
+      } catch (e) {
+        set({ loadError: `Could not commit export to backend cache: ${e}` });
+        return;
+      }
 
       set({
         exportPath: path,

--- a/app/src/workspaces/DiagnoseWorkspace/index.tsx
+++ b/app/src/workspaces/DiagnoseWorkspace/index.tsx
@@ -33,6 +33,8 @@ export function DiagnoseWorkspace() {
   const cameraB = useStore((s) => s.cameraB);
   const stepPose = useStore((s) => s.stepPose);
   const stepCamera = useStore((s) => s.stepCamera);
+  const setSelectedPose = useStore((s) => s.setSelectedPose);
+  const setCamera = useStore((s) => s.setCamera);
 
   // Diagnose-specific UI state stays local — these affordances don't
   // exist in the other workspaces.
@@ -187,17 +189,12 @@ export function DiagnoseWorkspace() {
       <div className="flex flex-wrap items-center gap-3">
         {data && (
           <PoseCameraStepper
-            poseOrdinal={
-              poseValues.indexOf(which === "B" ? selectedPoseB : selectedPose) +
-              1
-            }
-            poseTotal={poseValues.length}
-            cameraOrdinal={
-              cameraValues.indexOf(which === "B" ? cameraB : cameraA) + 1
-            }
-            cameraTotal={cameraValues.length}
-            onPoseStep={onPoseStep}
-            onCameraStep={onCameraStep}
+            poseValues={poseValues}
+            selectedPose={which === "B" ? selectedPoseB : selectedPose}
+            onSelectPose={(next) => setSelectedPose(next, which)}
+            cameraValues={cameraValues}
+            selectedCamera={which === "B" ? cameraB : cameraA}
+            onSelectCamera={(next) => setCamera(next, which)}
           />
         )}
         {data && (
@@ -293,20 +290,23 @@ export function DiagnoseWorkspace() {
       </div>
 
       {data && frame && (
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        // Reserve a stable height so the panel doesn't shimmy when the
+        // histogram briefly drops out during a frame switch (imageData
+        // unloads → roiHistogram becomes null until the next decode).
+        // The histogram block always mounts; its bins go empty during
+        // the gap and re-fill once decode lands.
+        <div className="flex min-h-[3.25rem] flex-wrap items-center gap-x-4 gap-y-2">
           <ResidualLegend
             residuals={data.per_feature_residuals.target.filter(
               (r) => r.pose === frame.pose && r.camera === frame.camera,
             )}
           />
-          {roiHistogram && (
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                histogram
-              </span>
-              <Histogram bins={roiHistogram} cursorBin={cursorBin} />
-            </div>
-          )}
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+              histogram
+            </span>
+            <Histogram bins={roiHistogram ?? []} cursorBin={cursorBin} />
+          </div>
           <CursorChip cursor={cursor} />
         </div>
       )}

--- a/app/src/workspaces/EpipolarWorkspace/EpipolarOverlay.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/EpipolarOverlay.tsx
@@ -26,6 +26,10 @@ interface EpipolarOverlayProps {
   markers?: OverlayPoint[];
   /** Optional label drawn at the top-left of the overlay. */
   caption?: string;
+  /** Optional pixel-anchored text annotation drawn near `px` (canvas
+   * pixel space, fixed on-screen size). Used to flag the picked
+   * feature's residual distance to the epipolar polyline. */
+  annotation?: { px: [number, number]; text: string; color: string };
 }
 
 /** SVG layer drawn over a FrameCanvas. The SVG fills the canvas's
@@ -39,6 +43,7 @@ export function EpipolarOverlay({
   polylineColor = "currentColor",
   markers,
   caption,
+  annotation,
 }: EpipolarOverlayProps) {
   return (
     <svg
@@ -91,6 +96,26 @@ export function EpipolarOverlay({
           {caption}
         </text>
       )}
+      {annotation && (() => {
+        const cx = annotation.px[0] * transform.scale + transform.tx;
+        const cy = annotation.px[1] * transform.scale + transform.ty;
+        // Offset upward-right of the anchor so the label clears the
+        // crosshair drawn at the same pixel.
+        return (
+          <text
+            x={cx + 10}
+            y={cy - 8}
+            fontFamily="var(--font-mono, monospace)"
+            fontSize={11}
+            fill={annotation.color}
+            stroke="hsl(var(--bg-soft))"
+            strokeWidth={3}
+            paintOrder="stroke"
+          >
+            {annotation.text}
+          </text>
+        );
+      })()}
     </svg>
   );
 }

--- a/app/src/workspaces/EpipolarWorkspace/EpipolarOverlay.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/EpipolarOverlay.tsx
@@ -1,0 +1,96 @@
+import type { ViewportTransform } from "../../types";
+
+export interface OverlayPoint {
+  /** Pixel coordinates in the canvas's image-pixel frame (ROI-local). */
+  px: [number, number];
+  /** Visual color (typically token-derived). */
+  color: string;
+  /** Optional radius in CSS pixels; defaults to 6. */
+  size?: number;
+  /** When true, render as a filled dot rather than a crosshair. */
+  dot?: boolean;
+}
+
+interface EpipolarOverlayProps {
+  /** Viewport transform of the underlying FrameCanvas. The polyline is
+   * drawn in image-pixel space so it follows zoom/pan; crosshairs are
+   * drawn in canvas-pixel space so they stay a fixed on-screen size
+   * regardless of zoom. */
+  transform: ViewportTransform;
+  /** Polyline in image-pixel coordinates. Renders inside the scaled
+   * group so the line scales with the image. */
+  polyline?: [number, number][];
+  /** Polyline stroke color. */
+  polylineColor?: string;
+  /** Crosshair markers (selected feature, hover ghost, tie-line dots). */
+  markers?: OverlayPoint[];
+  /** Optional label drawn at the top-left of the overlay. */
+  caption?: string;
+}
+
+/** SVG layer drawn over a FrameCanvas. The SVG fills the canvas's
+ * container; an inner group is transformed by the viewport so the
+ * polyline lines up with the underlying image, while crosshairs and
+ * dots are drawn in the outer canvas-pixel space so they keep a stable
+ * on-screen size as the user zooms. */
+export function EpipolarOverlay({
+  transform,
+  polyline,
+  polylineColor = "currentColor",
+  markers,
+  caption,
+}: EpipolarOverlayProps) {
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0 h-full w-full"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {polyline && polyline.length > 1 && (
+        <g
+          transform={`translate(${transform.tx} ${transform.ty}) scale(${transform.scale})`}
+        >
+          <polyline
+            points={polyline.map((p) => `${p[0]},${p[1]}`).join(" ")}
+            fill="none"
+            stroke={polylineColor}
+            strokeWidth={1 / transform.scale}
+            strokeLinejoin="round"
+          />
+        </g>
+      )}
+      {markers?.map((m, i) => {
+        const cx = m.px[0] * transform.scale + transform.tx;
+        const cy = m.px[1] * transform.scale + transform.ty;
+        const size = m.size ?? 6;
+        return m.dot ? (
+          <circle
+            key={i}
+            cx={cx}
+            cy={cy}
+            r={size * 0.35}
+            fill={m.color}
+            opacity={0.75}
+          />
+        ) : (
+          <g key={i} stroke={m.color} strokeWidth={1.4}>
+            <line x1={cx - size} y1={cy} x2={cx + size} y2={cy} />
+            <line x1={cx} y1={cy - size} x2={cx} y2={cy + size} />
+            <circle cx={cx} cy={cy} r={size * 0.6} fill="none" />
+          </g>
+        );
+      })}
+      {caption && (
+        <text
+          x={8}
+          y={16}
+          fontFamily="var(--font-mono, monospace)"
+          fontSize={11}
+          fill="currentColor"
+          opacity={0.7}
+        >
+          {caption}
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/app/src/workspaces/EpipolarWorkspace/index.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/index.tsx
@@ -1,59 +1,478 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { FrameCanvas } from "../../components/FrameCanvas";
+import { useImageData } from "../../hooks/useImageData";
 import { useStore } from "../../store";
 import { exportKindLabel } from "../../store/exportShape";
+import type { FrameKey, TargetFeatureResidual, ViewportTransform } from "../../types";
+import { IDENTITY_TRANSFORM } from "../../types";
+import { EpipolarOverlay, type OverlayPoint } from "./EpipolarOverlay";
 
-/** Placeholder for B2's epipolar-line workspace. Two FrameCanvas panes
- * + click-to-overlay epipolar lines computed server-side via a Tauri
- * command (`compute_epipolar_overlay`). */
+interface EpipolarOverlayResult {
+  line_b: [number, number][];
+  epipole_b: [number, number] | null;
+  samples_clipped: number;
+}
+
+/** Pixel-radius around the click within which we snap the selected
+ * feature index; otherwise the click is a free pixel pick (no
+ * corresponding pane-B ghost). */
+const FEATURE_SNAP_PX = 6;
+
 export function EpipolarWorkspace() {
   const data = useStore((s) => s.data);
   const kind = useStore((s) => s.kind);
+  const frames = useStore((s) => s.frames);
+  const cameraValues = useStore((s) => s.cameraValues);
+  const poseValues = useStore((s) => s.poseValues);
+  const camerasByPose = useStore((s) => s.camerasByPose);
+  const selectedPose = useStore((s) => s.selectedPose);
+  const cameraA = useStore((s) => s.cameraA);
+  const cameraB = useStore((s) => s.cameraB);
+  const setSelectedPose = useStore((s) => s.setSelectedPose);
+  const setCamera = useStore((s) => s.setCamera);
+
+  const [transformA, setTransformA] = useState<ViewportTransform>(
+    IDENTITY_TRANSFORM,
+  );
+  const [transformB, setTransformB] = useState<ViewportTransform>(
+    IDENTITY_TRANSFORM,
+  );
+  const [picked, setPicked] = useState<{ px: [number, number]; feature: number | null } | null>(
+    null,
+  );
+  const [overlay, setOverlay] = useState<EpipolarOverlayResult | null>(null);
+  const [overlayError, setOverlayError] = useState<string | null>(null);
+  const [showTieLines, setShowTieLines] = useState(false);
 
   if (!data || !kind) {
     return (
-      <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-border bg-bg-soft">
-        <p className="max-w-[28rem] p-6 text-center text-[13px] text-muted-foreground">
-          Load a rig export to inspect epipolar geometry between cameras.
-          B2 will let you click a feature in pane A and see the matching
-          epipolar line in pane B.
-        </p>
-      </div>
+      <Empty body="Load a rig export to inspect epipolar geometry between cameras." />
     );
   }
 
   const isRig =
-    kind === "rig_extrinsics" ||
-    kind === "rig_handeye" ||
-    kind === "rig_laserline_device";
+    Array.isArray(data.cameras) &&
+    Array.isArray(data.cam_se3_rig) &&
+    data.cameras.length >= 2;
+  if (!isRig) {
+    return (
+      <Empty
+        body={`Epipolar geometry only applies to rig exports (rig_extrinsics, rig_handeye, rig_laserline_device). The current export is ${exportKindLabel(
+          kind,
+        )}.`}
+      />
+    );
+  }
 
+  return (
+    <EpipolarBody
+      data={data}
+      kind={kind}
+      frames={frames}
+      poseValues={poseValues}
+      cameraValues={cameraValues}
+      camerasByPose={camerasByPose}
+      selectedPose={selectedPose}
+      cameraA={cameraA}
+      cameraB={cameraB}
+      setSelectedPose={setSelectedPose}
+      setCamera={setCamera}
+      transformA={transformA}
+      transformB={transformB}
+      setTransformA={setTransformA}
+      setTransformB={setTransformB}
+      picked={picked}
+      setPicked={setPicked}
+      overlay={overlay}
+      setOverlay={setOverlay}
+      overlayError={overlayError}
+      setOverlayError={setOverlayError}
+      showTieLines={showTieLines}
+      setShowTieLines={setShowTieLines}
+    />
+  );
+}
+
+interface BodyProps {
+  data: NonNullable<ReturnType<typeof useStore.getState>["data"]>;
+  kind: NonNullable<ReturnType<typeof useStore.getState>["kind"]>;
+  frames: FrameKey[];
+  poseValues: number[];
+  cameraValues: number[];
+  camerasByPose: Map<number, number[]>;
+  selectedPose: number;
+  cameraA: number;
+  cameraB: number;
+  setSelectedPose: (pose: number, which?: "A" | "B") => void;
+  setCamera: (camera: number, which?: "A" | "B") => void;
+  transformA: ViewportTransform;
+  transformB: ViewportTransform;
+  setTransformA: (t: ViewportTransform) => void;
+  setTransformB: (t: ViewportTransform) => void;
+  picked: { px: [number, number]; feature: number | null } | null;
+  setPicked: (p: { px: [number, number]; feature: number | null } | null) => void;
+  overlay: EpipolarOverlayResult | null;
+  setOverlay: (o: EpipolarOverlayResult | null) => void;
+  overlayError: string | null;
+  setOverlayError: (msg: string | null) => void;
+  showTieLines: boolean;
+  setShowTieLines: (v: boolean | ((prev: boolean) => boolean)) => void;
+}
+
+function EpipolarBody(props: BodyProps) {
+  const {
+    data,
+    kind,
+    frames,
+    poseValues,
+    cameraValues,
+    camerasByPose,
+    selectedPose,
+    cameraA,
+    cameraB,
+    setSelectedPose,
+    setCamera,
+    transformA,
+    transformB,
+    setTransformA,
+    setTransformB,
+    picked,
+    setPicked,
+    overlay,
+    setOverlay,
+    overlayError,
+    setOverlayError,
+    showTieLines,
+    setShowTieLines,
+  } = props;
+
+  const frameA = useMemo<FrameKey | null>(
+    () =>
+      frames.find((f) => f.pose === selectedPose && f.camera === cameraA) ??
+      null,
+    [frames, selectedPose, cameraA],
+  );
+  const frameB = useMemo<FrameKey | null>(
+    () =>
+      frames.find((f) => f.pose === selectedPose && f.camera === cameraB) ??
+      null,
+    [frames, selectedPose, cameraB],
+  );
+
+  // Bucket the residuals once per (pose) so the overlays / tie-lines
+  // don't re-scan the full residual array on every render.
+  const residualsForPose = useMemo<TargetFeatureResidual[]>(
+    () =>
+      data.per_feature_residuals.target.filter((r) => r.pose === selectedPose),
+    [data, selectedPose],
+  );
+  const residualsA = useMemo(
+    () => residualsForPose.filter((r) => r.camera === cameraA),
+    [residualsForPose, cameraA],
+  );
+  const residualsB = useMemo(
+    () => residualsForPose.filter((r) => r.camera === cameraB),
+    [residualsForPose, cameraB],
+  );
+
+  // Reset the picked overlay whenever the user changes the working
+  // tuple (pose / cam-A / cam-B). Stale polylines from a previous
+  // configuration are misleading.
+  useEffect(() => {
+    setPicked(null);
+    setOverlay(null);
+    setOverlayError(null);
+  }, [selectedPose, cameraA, cameraB, setPicked, setOverlay, setOverlayError]);
+
+  const camerasInPose = camerasByPose.get(selectedPose) ?? cameraValues;
+
+  const handlePickA = useCallback(
+    async (pixel: { x: number; y: number }) => {
+      const px: [number, number] = [pixel.x, pixel.y];
+      // Snap to the nearest residual feature in cam A within
+      // FEATURE_SNAP_PX so the workspace can ghost the matching feature
+      // in pane B; outside that radius the click is a free pixel pick
+      // and no ghost is shown.
+      let feature: number | null = null;
+      let bestDist = FEATURE_SNAP_PX;
+      for (const r of residualsA) {
+        const dx = r.observed_px[0] - px[0];
+        const dy = r.observed_px[1] - px[1];
+        const d = Math.hypot(dx, dy);
+        if (d < bestDist) {
+          bestDist = d;
+          feature = r.feature;
+        }
+      }
+      setPicked({ px, feature });
+      setOverlayError(null);
+      try {
+        const result = await invoke<EpipolarOverlayResult>(
+          "compute_epipolar_overlay",
+          { camA: cameraA, camB: cameraB, pointPx: px },
+        );
+        setOverlay(result);
+      } catch (e) {
+        setOverlay(null);
+        setOverlayError(`epipolar overlay failed: ${e}`);
+      }
+    },
+    [cameraA, cameraB, residualsA, setOverlay, setOverlayError, setPicked],
+  );
+
+  const ghostInB = useMemo<TargetFeatureResidual | null>(() => {
+    if (!picked || picked.feature == null) return null;
+    return residualsB.find((r) => r.feature === picked.feature) ?? null;
+  }, [picked, residualsB]);
+
+  const tieMarkersA = useMemo<OverlayPoint[]>(() => {
+    if (!showTieLines) return [];
+    return residualsA.map((r) => ({
+      px: r.observed_px,
+      color: "var(--color-muted-foreground, #888)",
+      dot: true,
+      size: 4,
+    }));
+  }, [showTieLines, residualsA]);
+
+  const tieMarkersB = useMemo<OverlayPoint[]>(() => {
+    if (!showTieLines) return [];
+    return residualsB.map((r) => ({
+      px: r.observed_px,
+      color: "var(--color-muted-foreground, #888)",
+      dot: true,
+      size: 4,
+    }));
+  }, [showTieLines, residualsB]);
+
+  const markersA: OverlayPoint[] = [
+    ...tieMarkersA,
+    ...(picked
+      ? [
+          {
+            px: picked.px,
+            color: "var(--color-brand, #1abc9c)",
+            size: 8,
+          } satisfies OverlayPoint,
+        ]
+      : []),
+  ];
+  const markersB: OverlayPoint[] = [
+    ...tieMarkersB,
+    ...(ghostInB
+      ? [
+          {
+            px: ghostInB.observed_px,
+            color: "var(--color-brand, #1abc9c)",
+            size: 8,
+          } satisfies OverlayPoint,
+        ]
+      : []),
+    ...(overlay?.epipole_b
+      ? [
+          {
+            px: overlay.epipole_b,
+            color: "var(--color-destructive, #e74c3c)",
+            size: 7,
+          } satisfies OverlayPoint,
+        ]
+      : []),
+  ];
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-2.5">
+      <div className="flex flex-wrap items-center gap-3">
+        <Selector
+          label="pose"
+          value={selectedPose}
+          options={poseValues}
+          onChange={(v) => setSelectedPose(v, "A")}
+        />
+        <Selector
+          label="cam A"
+          value={cameraA}
+          options={camerasInPose}
+          onChange={(v) => setCamera(v, "A")}
+        />
+        <Selector
+          label="cam B"
+          value={cameraB}
+          options={camerasInPose}
+          onChange={(v) => setCamera(v, "B")}
+        />
+        <button
+          type="button"
+          onClick={() => setShowTieLines((v) => !v)}
+          className={`h-7 px-2 font-mono text-[11px] ${
+            showTieLines ? "border-brand text-brand" : ""
+          }`}
+          title="Render every feature observation as a faint dot in both panes"
+        >
+          {showTieLines ? "Tie-points ✓" : "Tie-points"}
+        </button>
+        <span className="ml-auto font-mono text-[11px] text-muted-foreground">
+          {exportKindLabel(kind)}
+        </span>
+      </div>
+
+      {overlayError && (
+        <div className="rounded-md border-l-2 border-destructive bg-destructive/[0.08] p-2.5 text-[13px] text-foreground">
+          {overlayError}
+        </div>
+      )}
+
+      <div className="grid min-h-0 flex-1 grid-cols-2 gap-2 overflow-hidden rounded-md bg-bg-soft p-2">
+        <Pane
+          frame={frameA}
+          residuals={residualsForPose}
+          transform={transformA}
+          onTransformChange={setTransformA}
+          onPick={handlePickA}
+          markers={markersA}
+          caption={frameA ? `pane A · cam ${cameraA} · click to pick` : undefined}
+        />
+        <Pane
+          frame={frameB}
+          residuals={residualsForPose}
+          transform={transformB}
+          onTransformChange={setTransformB}
+          polyline={overlay?.line_b}
+          polylineColor="var(--color-brand, #1abc9c)"
+          markers={markersB}
+          caption={frameB ? `pane B · cam ${cameraB}` : undefined}
+        />
+      </div>
+
+      {!cameraValues.includes(cameraB) && (
+        <div className="rounded-md border-l-2 border-brand bg-brand/[0.06] p-2 text-[12px] text-foreground">
+          Pane-B camera {cameraB} is not in this export.
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface PaneProps {
+  frame: FrameKey | null;
+  residuals: TargetFeatureResidual[];
+  transform: ViewportTransform;
+  onTransformChange: (t: ViewportTransform) => void;
+  onPick?: (pixel: { x: number; y: number }) => void;
+  polyline?: [number, number][];
+  polylineColor?: string;
+  markers?: OverlayPoint[];
+  caption?: string;
+}
+
+function Pane({
+  frame,
+  residuals,
+  transform,
+  onTransformChange,
+  onPick,
+  polyline,
+  polylineColor,
+  markers,
+  caption,
+}: PaneProps) {
+  if (!frame) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-md border border-dashed border-border text-[12px] text-muted-foreground">
+        no frame for this (pose, camera)
+      </div>
+    );
+  }
+  return (
+    <PaneInner
+      key={frame.abs_path}
+      frame={frame}
+      residuals={residuals}
+      transform={transform}
+      onTransformChange={onTransformChange}
+      onPick={onPick}
+      polyline={polyline}
+      polylineColor={polylineColor}
+      markers={markers}
+      caption={caption}
+    />
+  );
+}
+
+function PaneInner({
+  frame,
+  residuals,
+  transform,
+  onTransformChange,
+  onPick,
+  polyline,
+  polylineColor,
+  markers,
+  caption,
+}: PaneProps & { frame: FrameKey }) {
+  const image = useImageData(frame);
+  return (
+    <div className="relative flex h-full flex-col">
+      <div className="relative flex-1 overflow-hidden">
+        <FrameCanvas
+          frame={frame}
+          residuals={residuals}
+          image={image?.image ?? null}
+          transform={transform}
+          onTransformChange={onTransformChange}
+          onPick={onPick}
+        />
+        <EpipolarOverlay
+          transform={transform}
+          polyline={polyline}
+          polylineColor={polylineColor}
+          markers={markers}
+          caption={caption}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Selector({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  options: number[];
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+      <span className="uppercase tracking-wider">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-7 rounded-md border border-border bg-surface px-1 text-foreground"
+      >
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function Empty({ body }: { body: string }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
       <header className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold tracking-tight">
-          Epipolar geometry
-        </h2>
-        <span className="font-mono text-[11px] text-muted-foreground">
-          {exportKindLabel(kind)}
-        </span>
+        <h2 className="text-sm font-semibold tracking-tight">Epipolar geometry</h2>
       </header>
       <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-border bg-bg-soft">
-        <div className="max-w-[36rem] p-6 text-center">
-          <h3 className="mb-2 text-sm font-semibold">
-            Two-pane epipolar view lands in B2
-          </h3>
-          <p className="text-[12px] text-muted-foreground">
-            Pick pose + cam A + cam B; click a feature in pane A; a Tauri
-            command computes the epipolar line through the rig's relative
-            extrinsics and distortion-aware projection, then renders it as
-            an SVG polyline over pane B.
-          </p>
-          {!isRig && (
-            <p className="mt-4 rounded-md border-l-2 border-brand bg-brand/[0.06] p-2.5 text-left text-[11px] text-foreground">
-              The current export is single-camera ({exportKindLabel(kind)}).
-              Epipolar geometry only applies to rig exports
-              (rig_extrinsics, rig_handeye, rig_laserline_device).
-            </p>
-          )}
-        </div>
+        <p className="max-w-[28rem] p-6 text-center text-[13px] text-muted-foreground">
+          {body}
+        </p>
       </div>
     </div>
   );

--- a/app/src/workspaces/EpipolarWorkspace/index.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/index.tsx
@@ -1,12 +1,35 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FrameCanvas } from "../../components/FrameCanvas";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  FrameCanvas,
+  type FrameCanvasHandle,
+} from "../../components/FrameCanvas";
+import { PoseStepper } from "../../components/PoseStepper";
 import { useImageData } from "../../hooks/useImageData";
+import {
+  iso3DistanceM,
+  iso3EulerXYZDeg,
+  iso3RotationAngleDeg,
+  relativeCameraPose,
+} from "../../lib/se3";
 import { useStore } from "../../store";
 import { exportKindLabel } from "../../store/exportShape";
-import type { FrameKey, TargetFeatureResidual, ViewportTransform } from "../../types";
+import type {
+  FrameKey,
+  TargetFeatureResidual,
+  ViewportTransform,
+} from "../../types";
 import { IDENTITY_TRANSFORM } from "../../types";
-import { EpipolarOverlay, type OverlayPoint } from "./EpipolarOverlay";
+import {
+  EpipolarOverlay,
+  type OverlayPoint,
+} from "./EpipolarOverlay";
 
 interface EpipolarOverlayResult {
   line_b: [number, number][];
@@ -14,17 +37,16 @@ interface EpipolarOverlayResult {
   samples_clipped: number;
 }
 
-/** Pixel-radius around the click within which we snap the selected
- * feature index; otherwise the click is a free pixel pick (no
- * corresponding pane-B ghost). */
-const FEATURE_SNAP_PX = 6;
+/** Pixel-radius around the click within which we snap to the nearest
+ * residual feature. Outside this radius the click is a free pixel
+ * pick (no corresponding pane-B ghost is drawn). */
+const FEATURE_SNAP_PX = 8;
 
 export function EpipolarWorkspace() {
   const data = useStore((s) => s.data);
   const kind = useStore((s) => s.kind);
   const frames = useStore((s) => s.frames);
   const cameraValues = useStore((s) => s.cameraValues);
-  const poseValues = useStore((s) => s.poseValues);
   const camerasByPose = useStore((s) => s.camerasByPose);
   const selectedPose = useStore((s) => s.selectedPose);
   const cameraA = useStore((s) => s.cameraA);
@@ -32,18 +54,25 @@ export function EpipolarWorkspace() {
   const setSelectedPose = useStore((s) => s.setSelectedPose);
   const setCamera = useStore((s) => s.setCamera);
 
-  const [transformA, setTransformA] = useState<ViewportTransform>(
+  const [linked, setLinked] = useState<boolean>(false);
+  const [showFeatures, setShowFeatures] = useState<boolean>(true);
+  const [showTieLines, setShowTieLines] = useState<boolean>(false);
+
+  const [transformA, setTransformA] = useState<ViewportTransform>(IDENTITY_TRANSFORM);
+  const [transformB, setTransformB] = useState<ViewportTransform>(IDENTITY_TRANSFORM);
+  const [linkedTransform, setLinkedTransform] = useState<ViewportTransform>(
     IDENTITY_TRANSFORM,
   );
-  const [transformB, setTransformB] = useState<ViewportTransform>(
-    IDENTITY_TRANSFORM,
-  );
-  const [picked, setPicked] = useState<{ px: [number, number]; feature: number | null } | null>(
-    null,
-  );
+
+  const [picked, setPicked] = useState<{
+    px: [number, number];
+    feature: number | null;
+  } | null>(null);
   const [overlay, setOverlay] = useState<EpipolarOverlayResult | null>(null);
   const [overlayError, setOverlayError] = useState<string | null>(null);
-  const [showTieLines, setShowTieLines] = useState(false);
+
+  const handleARef = useRef<FrameCanvasHandle | null>(null);
+  const handleBRef = useRef<FrameCanvasHandle | null>(null);
 
   if (!data || !kind) {
     return (
@@ -70,7 +99,6 @@ export function EpipolarWorkspace() {
       data={data}
       kind={kind}
       frames={frames}
-      poseValues={poseValues}
       cameraValues={cameraValues}
       camerasByPose={camerasByPose}
       selectedPose={selectedPose}
@@ -78,18 +106,26 @@ export function EpipolarWorkspace() {
       cameraB={cameraB}
       setSelectedPose={setSelectedPose}
       setCamera={setCamera}
+      linked={linked}
+      setLinked={setLinked}
+      showFeatures={showFeatures}
+      setShowFeatures={setShowFeatures}
+      showTieLines={showTieLines}
+      setShowTieLines={setShowTieLines}
       transformA={transformA}
       transformB={transformB}
+      linkedTransform={linkedTransform}
       setTransformA={setTransformA}
       setTransformB={setTransformB}
+      setLinkedTransform={setLinkedTransform}
       picked={picked}
       setPicked={setPicked}
       overlay={overlay}
       setOverlay={setOverlay}
       overlayError={overlayError}
       setOverlayError={setOverlayError}
-      showTieLines={showTieLines}
-      setShowTieLines={setShowTieLines}
+      handleARef={handleARef}
+      handleBRef={handleBRef}
     />
   );
 }
@@ -98,7 +134,6 @@ interface BodyProps {
   data: NonNullable<ReturnType<typeof useStore.getState>["data"]>;
   kind: NonNullable<ReturnType<typeof useStore.getState>["kind"]>;
   frames: FrameKey[];
-  poseValues: number[];
   cameraValues: number[];
   camerasByPose: Map<number, number[]>;
   selectedPose: number;
@@ -106,18 +141,26 @@ interface BodyProps {
   cameraB: number;
   setSelectedPose: (pose: number, which?: "A" | "B") => void;
   setCamera: (camera: number, which?: "A" | "B") => void;
+  linked: boolean;
+  setLinked: (v: boolean | ((prev: boolean) => boolean)) => void;
+  showFeatures: boolean;
+  setShowFeatures: (v: boolean | ((prev: boolean) => boolean)) => void;
+  showTieLines: boolean;
+  setShowTieLines: (v: boolean | ((prev: boolean) => boolean)) => void;
   transformA: ViewportTransform;
   transformB: ViewportTransform;
+  linkedTransform: ViewportTransform;
   setTransformA: (t: ViewportTransform) => void;
   setTransformB: (t: ViewportTransform) => void;
+  setLinkedTransform: (t: ViewportTransform) => void;
   picked: { px: [number, number]; feature: number | null } | null;
   setPicked: (p: { px: [number, number]; feature: number | null } | null) => void;
   overlay: EpipolarOverlayResult | null;
   setOverlay: (o: EpipolarOverlayResult | null) => void;
   overlayError: string | null;
   setOverlayError: (msg: string | null) => void;
-  showTieLines: boolean;
-  setShowTieLines: (v: boolean | ((prev: boolean) => boolean)) => void;
+  handleARef: React.MutableRefObject<FrameCanvasHandle | null>;
+  handleBRef: React.MutableRefObject<FrameCanvasHandle | null>;
 }
 
 function EpipolarBody(props: BodyProps) {
@@ -125,7 +168,6 @@ function EpipolarBody(props: BodyProps) {
     data,
     kind,
     frames,
-    poseValues,
     cameraValues,
     camerasByPose,
     selectedPose,
@@ -133,19 +175,33 @@ function EpipolarBody(props: BodyProps) {
     cameraB,
     setSelectedPose,
     setCamera,
+    linked,
+    setLinked,
+    showFeatures,
+    setShowFeatures,
+    showTieLines,
+    setShowTieLines,
     transformA,
     transformB,
+    linkedTransform,
     setTransformA,
     setTransformB,
+    setLinkedTransform,
     picked,
     setPicked,
     overlay,
     setOverlay,
     overlayError,
     setOverlayError,
-    showTieLines,
-    setShowTieLines,
+    handleARef,
+    handleBRef,
   } = props;
+
+  const numPoses = data.rig_se3_target?.length ?? 0;
+  const poseIndices = useMemo(
+    () => Array.from({ length: numPoses }, (_, i) => i),
+    [numPoses],
+  );
 
   const frameA = useMemo<FrameKey | null>(
     () =>
@@ -160,8 +216,8 @@ function EpipolarBody(props: BodyProps) {
     [frames, selectedPose, cameraB],
   );
 
-  // Bucket the residuals once per (pose) so the overlays / tie-lines
-  // don't re-scan the full residual array on every render.
+  // Bucket residuals by (camera) for the active pose so the overlay /
+  // tie-points / snap logic doesn't re-scan the full residual array.
   const residualsForPose = useMemo<TargetFeatureResidual[]>(
     () =>
       data.per_feature_residuals.target.filter((r) => r.pose === selectedPose),
@@ -176,16 +232,11 @@ function EpipolarBody(props: BodyProps) {
     [residualsForPose, cameraB],
   );
 
-  // Monotonic request id so out-of-order responses don't overwrite a
-  // newer overlay. Bumped on every pick AND on every working-tuple
-  // change; only the response whose id matches `latestRequestIdRef`
-  // when it returns is allowed to set state.
   const latestRequestIdRef = useRef(0);
 
-  // Reset the picked overlay whenever the user changes the working
-  // tuple (pose / cam-A / cam-B). Stale polylines from a previous
-  // configuration are misleading. Bump the request id so any in-flight
-  // response from the previous tuple is silently dropped on arrival.
+  // Reset the overlay whenever the working tuple changes; bump the
+  // request id so any in-flight response from the previous tuple is
+  // dropped on arrival.
   useEffect(() => {
     latestRequestIdRef.current += 1;
     setPicked(null);
@@ -198,12 +249,9 @@ function EpipolarBody(props: BodyProps) {
   const handlePickA = useCallback(
     async (pixel: { x: number; y: number }) => {
       const px: [number, number] = [pixel.x, pixel.y];
-      // Snap to the nearest residual feature in cam A within
-      // FEATURE_SNAP_PX so the workspace can ghost the matching feature
-      // in pane B; outside that radius the click is a free pixel pick
-      // and no ghost is shown.
       let feature: number | null = null;
       let bestDist = FEATURE_SNAP_PX;
+      let snappedPx: [number, number] = px;
       for (const r of residualsA) {
         const dx = r.observed_px[0] - px[0];
         const dy = r.observed_px[1] - px[1];
@@ -211,19 +259,17 @@ function EpipolarBody(props: BodyProps) {
         if (d < bestDist) {
           bestDist = d;
           feature = r.feature;
+          snappedPx = [r.observed_px[0], r.observed_px[1]];
         }
       }
-      setPicked({ px, feature });
+      setPicked({ px: snappedPx, feature });
       setOverlayError(null);
-      // Capture a monotonic id so we can drop this response if a newer
-      // pick / pose change happens before it returns. Without this an
-      // old response can race ahead and overwrite the latest overlay.
       latestRequestIdRef.current += 1;
       const myRequestId = latestRequestIdRef.current;
       try {
         const result = await invoke<EpipolarOverlayResult>(
           "compute_epipolar_overlay",
-          { camA: cameraA, camB: cameraB, pointPx: px },
+          { camA: cameraA, camB: cameraB, pointPx: snappedPx },
         );
         if (myRequestId !== latestRequestIdRef.current) return;
         setOverlay(result);
@@ -240,6 +286,41 @@ function EpipolarBody(props: BodyProps) {
     if (!picked || picked.feature == null) return null;
     return residualsB.find((r) => r.feature === picked.feature) ?? null;
   }, [picked, residualsB]);
+
+  // Polyline clipped strictly to pane-B's image bounds. The Rust side
+  // sweeps depths from 0.05 m to 5 m, which is wider than any real
+  // dataset's working volume — most samples land outside the image
+  // and pull the polyline into a long curve (distortion gets visually
+  // amplified far from the principal point). Only the in-image
+  // portion is what the engineer actually reads, so we drop the rest
+  // and keep only the longest contiguous in-image run to avoid a
+  // straight bridge across an out-of-image gap.
+  const clippedPolyline = useMemo<[number, number][] | undefined>(() => {
+    if (!overlay || overlay.line_b.length < 2) return undefined;
+    if (!frameB) return overlay.line_b;
+    const w = frameB.roi?.w ?? 0;
+    const h = frameB.roi?.h ?? 0;
+    if (w === 0 || h === 0) return overlay.line_b;
+    return longestInImageRun(overlay.line_b, w, h);
+  }, [overlay, frameB]);
+
+  // Distance from the corresponding pane-B feature to the polyline in
+  // pixels — the calibration's epipolar residual for the picked
+  // feature pair. Surfaced as an annotation next to the cam-B
+  // crosshair so the engineer can read it without leaving the workspace.
+  const ghostDistancePx = useMemo<number | null>(() => {
+    if (!ghostInB || !overlay || overlay.line_b.length < 2) return null;
+    return distanceToPolyline(ghostInB.observed_px, overlay.line_b);
+  }, [ghostInB, overlay]);
+
+  // Camera relative pose (cam B as seen from cam A). Read here so the
+  // info strip shows it alongside the overlay status.
+  const relativePose = useMemo(() => {
+    const cs = data.cam_se3_rig;
+    if (!cs || cs.length <= cameraA || cs.length <= cameraB) return null;
+    if (cameraA === cameraB) return null;
+    return relativeCameraPose(cs[cameraA], cs[cameraB]);
+  }, [data, cameraA, cameraB]);
 
   const tieMarkersA = useMemo<OverlayPoint[]>(() => {
     if (!showTieLines) return [];
@@ -261,7 +342,27 @@ function EpipolarBody(props: BodyProps) {
     }));
   }, [showTieLines, residualsB]);
 
+  const featureMarkersA = useMemo<OverlayPoint[]>(() => {
+    if (!showFeatures) return [];
+    return residualsA.map((r) => ({
+      px: r.observed_px,
+      color: "var(--color-accent, #888)",
+      dot: true,
+      size: 6,
+    }));
+  }, [showFeatures, residualsA]);
+  const featureMarkersB = useMemo<OverlayPoint[]>(() => {
+    if (!showFeatures) return [];
+    return residualsB.map((r) => ({
+      px: r.observed_px,
+      color: "var(--color-accent, #888)",
+      dot: true,
+      size: 6,
+    }));
+  }, [showFeatures, residualsB]);
+
   const markersA: OverlayPoint[] = [
+    ...featureMarkersA,
     ...tieMarkersA,
     ...(picked
       ? [
@@ -274,6 +375,7 @@ function EpipolarBody(props: BodyProps) {
       : []),
   ];
   const markersB: OverlayPoint[] = [
+    ...featureMarkersB,
     ...tieMarkersB,
     ...(ghostInB
       ? [
@@ -295,15 +397,33 @@ function EpipolarBody(props: BodyProps) {
       : []),
   ];
 
+  // Linked-mode shares one transform between both panes; flipping into
+  // linked mode forces a fresh fit so the two start aligned.
+  useEffect(() => {
+    if (linked) handleARef.current?.fit();
+  }, [linked, handleARef]);
+
+  const drivePane = (which: "A" | "B", action: (h: FrameCanvasHandle) => void) => {
+    if (linked) {
+      // Either ref drives the linked transform.
+      const h = handleARef.current ?? handleBRef.current;
+      if (h) action(h);
+      return;
+    }
+    const h = which === "A" ? handleARef.current : handleBRef.current;
+    if (h) action(h);
+  };
+
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
       <div className="flex flex-wrap items-center gap-3">
-        <Selector
-          label="pose"
-          value={selectedPose}
-          options={poseValues}
-          onChange={(v) => setSelectedPose(v, "A")}
-        />
+        {numPoses > 0 && (
+          <PoseStepper
+            poseValues={poseIndices}
+            selectedPose={selectedPose}
+            onSelectPose={(next) => setSelectedPose(next, "A")}
+          />
+        )}
         <Selector
           label="cam A"
           value={cameraA}
@@ -316,20 +436,54 @@ function EpipolarBody(props: BodyProps) {
           options={camerasInPose}
           onChange={(v) => setCamera(v, "B")}
         />
-        <button
-          type="button"
+        <ZoomBar
+          onFit={() =>
+            drivePane("A", (h) => h.fit())
+          }
+          onOneToOne={() =>
+            drivePane("A", (h) => h.reset1to1())
+          }
+          onZoomIn={() =>
+            drivePane("A", (h) => h.zoomBy(1.25))
+          }
+          onZoomOut={() =>
+            drivePane("A", (h) => h.zoomBy(1 / 1.25))
+          }
+        />
+        <Toggle
+          active={linked}
+          onClick={() => setLinked((v) => !v)}
+          label="Linked"
+          activeLabel="Linked ✓"
+          title="Share zoom + pan between both panes (common AOI)"
+        />
+        <Toggle
+          active={showFeatures}
+          onClick={() => setShowFeatures((v) => !v)}
+          label="Features"
+          activeLabel="Features ✓"
+          title="Show every detected feature as a clickable dot"
+        />
+        <Toggle
+          active={showTieLines}
           onClick={() => setShowTieLines((v) => !v)}
-          className={`h-7 px-2 font-mono text-[11px] ${
-            showTieLines ? "border-brand text-brand" : ""
-          }`}
-          title="Render every feature observation as a faint dot in both panes"
-        >
-          {showTieLines ? "Tie-points ✓" : "Tie-points"}
-        </button>
+          label="Tie-points"
+          activeLabel="Tie-points ✓"
+          title="Render every observed feature as a faint dot (both panes)"
+        />
         <span className="ml-auto font-mono text-[11px] text-muted-foreground">
           {exportKindLabel(kind)}
         </span>
       </div>
+
+      <RelativePoseStrip
+        relativePose={relativePose}
+        cameraA={cameraA}
+        cameraB={cameraB}
+        ghostDistancePx={ghostDistancePx}
+        pickedFeature={picked?.feature ?? null}
+        samplesClipped={overlay?.samples_clipped ?? null}
+      />
 
       {overlayError && (
         <div className="rounded-md border-l-2 border-destructive bg-destructive/[0.08] p-2.5 text-[13px] text-foreground">
@@ -341,31 +495,111 @@ function EpipolarBody(props: BodyProps) {
         <Pane
           frame={frameA}
           residuals={residualsForPose}
-          transform={transformA}
-          onTransformChange={setTransformA}
+          transform={linked ? linkedTransform : transformA}
+          onTransformChange={linked ? setLinkedTransform : setTransformA}
           onPick={handlePickA}
           markers={markersA}
-          caption={frameA ? `pane A · cam ${cameraA} · click to pick` : undefined}
+          caption={frameA ? `pane A · cam ${cameraA}${showFeatures ? " · click feature or anywhere" : " · click to pick"}` : undefined}
+          handleRef={handleARef}
         />
         <Pane
           frame={frameB}
           residuals={residualsForPose}
-          transform={transformB}
-          onTransformChange={setTransformB}
-          polyline={overlay?.line_b}
+          transform={linked ? linkedTransform : transformB}
+          onTransformChange={linked ? setLinkedTransform : setTransformB}
+          polyline={clippedPolyline}
           polylineColor="var(--color-brand, #1abc9c)"
           markers={markersB}
           caption={frameB ? `pane B · cam ${cameraB}` : undefined}
+          handleRef={handleBRef}
+          annotation={
+            ghostInB && ghostDistancePx != null
+              ? {
+                  px: ghostInB.observed_px,
+                  text: `Δ ${ghostDistancePx.toFixed(2)} px`,
+                  color:
+                    ghostDistancePx < 1
+                      ? "var(--color-brand, #1abc9c)"
+                      : ghostDistancePx < 5
+                        ? "var(--color-foreground, #888)"
+                        : "var(--color-destructive, #e74c3c)",
+                }
+              : undefined
+          }
         />
       </div>
-
-      {!cameraValues.includes(cameraB) && (
-        <div className="rounded-md border-l-2 border-brand bg-brand/[0.06] p-2 text-[12px] text-foreground">
-          Pane-B camera {cameraB} is not in this export.
-        </div>
-      )}
     </section>
   );
+}
+
+/** Return the longest contiguous run of polyline points that fall
+ * inside `[0, w] × [0, h]`. The Rust side densely samples depths along
+ * the back-projected ray; only some samples project inside pane B's
+ * image. Filtering kept-in-bounds points and re-stitching them into
+ * one polyline draws a "straight bridge" across out-of-image gaps,
+ * which looks like a curve. Picking the single longest in-image run
+ * sidesteps that. */
+function longestInImageRun(
+  pts: [number, number][],
+  w: number,
+  h: number,
+): [number, number][] {
+  let bestStart = 0;
+  let bestLen = 0;
+  let curStart = -1;
+  let curLen = 0;
+  const flush = (i: number) => {
+    if (curLen > bestLen) {
+      bestLen = curLen;
+      bestStart = curStart;
+    }
+    curStart = i;
+    curLen = 0;
+  };
+  for (let i = 0; i < pts.length; i++) {
+    const [x, y] = pts[i];
+    if (x >= 0 && x <= w && y >= 0 && y <= h) {
+      if (curStart < 0) curStart = i;
+      curLen += 1;
+    } else if (curLen > 0) {
+      flush(i + 1);
+    }
+  }
+  if (curLen > bestLen) {
+    bestLen = curLen;
+    bestStart = curStart;
+  }
+  return bestLen > 0 ? pts.slice(bestStart, bestStart + bestLen) : [];
+}
+
+function distanceToPolyline(
+  point: [number, number],
+  polyline: [number, number][],
+): number {
+  let best = Infinity;
+  for (let i = 0; i < polyline.length - 1; i++) {
+    const d = distanceToSegment(point, polyline[i], polyline[i + 1]);
+    if (d < best) best = d;
+  }
+  return best;
+}
+
+function distanceToSegment(
+  p: [number, number],
+  a: [number, number],
+  b: [number, number],
+): number {
+  const abx = b[0] - a[0];
+  const aby = b[1] - a[1];
+  const lenSq = abx * abx + aby * aby;
+  if (lenSq === 0) return Math.hypot(p[0] - a[0], p[1] - a[1]);
+  const t = Math.max(
+    0,
+    Math.min(1, ((p[0] - a[0]) * abx + (p[1] - a[1]) * aby) / lenSq),
+  );
+  const cx = a[0] + t * abx;
+  const cy = a[1] + t * aby;
+  return Math.hypot(p[0] - cx, p[1] - cy);
 }
 
 interface PaneProps {
@@ -378,6 +612,8 @@ interface PaneProps {
   polylineColor?: string;
   markers?: OverlayPoint[];
   caption?: string;
+  handleRef: React.MutableRefObject<FrameCanvasHandle | null>;
+  annotation?: { px: [number, number]; text: string; color: string };
 }
 
 function Pane({
@@ -390,6 +626,8 @@ function Pane({
   polylineColor,
   markers,
   caption,
+  handleRef,
+  annotation,
 }: PaneProps) {
   if (!frame) {
     return (
@@ -410,6 +648,8 @@ function Pane({
       polylineColor={polylineColor}
       markers={markers}
       caption={caption}
+      handleRef={handleRef}
+      annotation={annotation}
     />
   );
 }
@@ -424,12 +664,15 @@ function PaneInner({
   polylineColor,
   markers,
   caption,
+  handleRef,
+  annotation,
 }: PaneProps & { frame: FrameKey }) {
   const image = useImageData(frame);
   return (
     <div className="relative flex h-full flex-col">
       <div className="relative flex-1 overflow-hidden">
         <FrameCanvas
+          ref={handleRef}
           frame={frame}
           residuals={residuals}
           image={image?.image ?? null}
@@ -443,8 +686,151 @@ function PaneInner({
           polylineColor={polylineColor}
           markers={markers}
           caption={caption}
+          annotation={annotation}
         />
       </div>
+    </div>
+  );
+}
+
+interface ZoomBarProps {
+  onFit: () => void;
+  onOneToOne: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+}
+
+function ZoomBar({ onFit, onOneToOne, onZoomIn, onZoomOut }: ZoomBarProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onZoomOut}
+        title="Zoom out"
+        aria-label="Zoom out"
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+      >
+        −
+      </button>
+      <button
+        type="button"
+        onClick={onZoomIn}
+        title="Zoom in"
+        aria-label="Zoom in"
+        className="grid h-7 w-7 place-items-center !p-0 font-mono text-xs"
+      >
+        +
+      </button>
+      <button
+        type="button"
+        onClick={onFit}
+        title="Fit"
+        className="h-7 px-2 font-mono text-[11px]"
+      >
+        Fit
+      </button>
+      <button
+        type="button"
+        onClick={onOneToOne}
+        title="1:1"
+        className="h-7 px-2 font-mono text-[11px]"
+      >
+        1:1
+      </button>
+    </div>
+  );
+}
+
+interface ToggleProps {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  activeLabel?: string;
+  title?: string;
+}
+
+function Toggle({ active, onClick, label, activeLabel, title }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`h-7 px-2 font-mono text-[11px] ${
+        active ? "border-brand text-brand" : ""
+      }`}
+      title={title}
+    >
+      {active ? (activeLabel ?? `${label} ✓`) : label}
+    </button>
+  );
+}
+
+interface RelativePoseStripProps {
+  relativePose: ReturnType<typeof relativeCameraPose> | null;
+  cameraA: number;
+  cameraB: number;
+  ghostDistancePx: number | null;
+  pickedFeature: number | null;
+  samplesClipped: number | null;
+}
+
+function RelativePoseStrip({
+  relativePose,
+  cameraA,
+  cameraB,
+  ghostDistancePx,
+  pickedFeature,
+  samplesClipped,
+}: RelativePoseStripProps) {
+  if (!relativePose) {
+    return (
+      <div className="font-mono text-[11px] text-muted-foreground">
+        cam {cameraA} ↔ cam {cameraB}: pick two distinct cameras for relative pose
+      </div>
+    );
+  }
+  const dist = iso3DistanceM(relativePose);
+  const euler = iso3EulerXYZDeg(relativePose);
+  const angle = iso3RotationAngleDeg(relativePose);
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-[11px] text-muted-foreground">
+      <span>
+        cam {cameraA} ⇒ cam {cameraB}:
+      </span>
+      <span>
+        baseline <span className="text-foreground tabular-nums">{(dist * 1000).toFixed(1)} mm</span>
+      </span>
+      <span>
+        rot <span className="text-foreground tabular-nums">{angle.toFixed(2)}°</span>
+        <span className="ml-1">
+          ({euler.x.toFixed(1)}, {euler.y.toFixed(1)}, {euler.z.toFixed(1)})°
+        </span>
+      </span>
+      {pickedFeature != null && (
+        <span>
+          feature <span className="text-foreground tabular-nums">#{pickedFeature}</span>
+        </span>
+      )}
+      {ghostDistancePx != null && (
+        <span>
+          ghost Δ
+          <span
+            className={`ml-1 tabular-nums ${
+              ghostDistancePx < 1
+                ? "text-brand"
+                : ghostDistancePx < 5
+                  ? "text-foreground"
+                  : "text-destructive"
+            }`}
+          >
+            {ghostDistancePx.toFixed(2)} px
+          </span>
+        </span>
+      )}
+      {samplesClipped != null && samplesClipped > 0 && (
+        <span title="number of depth samples whose projection diverged">
+          clipped <span className="text-foreground tabular-nums">{samplesClipped}</span>
+        </span>
+      )}
     </div>
   );
 }
@@ -482,7 +868,9 @@ function Empty({ body }: { body: string }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
       <header className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold tracking-tight">Epipolar geometry</h2>
+        <h2 className="text-sm font-semibold tracking-tight">
+          Epipolar geometry
+        </h2>
       </header>
       <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-border bg-bg-soft">
         <p className="max-w-[28rem] p-6 text-center text-[13px] text-muted-foreground">

--- a/app/src/workspaces/EpipolarWorkspace/index.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/index.tsx
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FrameCanvas } from "../../components/FrameCanvas";
 import { useImageData } from "../../hooks/useImageData";
 import { useStore } from "../../store";
@@ -176,10 +176,18 @@ function EpipolarBody(props: BodyProps) {
     [residualsForPose, cameraB],
   );
 
+  // Monotonic request id so out-of-order responses don't overwrite a
+  // newer overlay. Bumped on every pick AND on every working-tuple
+  // change; only the response whose id matches `latestRequestIdRef`
+  // when it returns is allowed to set state.
+  const latestRequestIdRef = useRef(0);
+
   // Reset the picked overlay whenever the user changes the working
   // tuple (pose / cam-A / cam-B). Stale polylines from a previous
-  // configuration are misleading.
+  // configuration are misleading. Bump the request id so any in-flight
+  // response from the previous tuple is silently dropped on arrival.
   useEffect(() => {
+    latestRequestIdRef.current += 1;
     setPicked(null);
     setOverlay(null);
     setOverlayError(null);
@@ -207,13 +215,20 @@ function EpipolarBody(props: BodyProps) {
       }
       setPicked({ px, feature });
       setOverlayError(null);
+      // Capture a monotonic id so we can drop this response if a newer
+      // pick / pose change happens before it returns. Without this an
+      // old response can race ahead and overwrite the latest overlay.
+      latestRequestIdRef.current += 1;
+      const myRequestId = latestRequestIdRef.current;
       try {
         const result = await invoke<EpipolarOverlayResult>(
           "compute_epipolar_overlay",
           { camA: cameraA, camB: cameraB, pointPx: px },
         );
+        if (myRequestId !== latestRequestIdRef.current) return;
         setOverlay(result);
       } catch (e) {
+        if (myRequestId !== latestRequestIdRef.current) return;
         setOverlay(null);
         setOverlayError(`epipolar overlay failed: ${e}`);
       }

--- a/app/src/workspaces/Viewer3DWorkspace/index.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/index.tsx
@@ -1,35 +1,32 @@
 import { useMemo, useState } from "react";
+import { PoseStepper } from "../../components/PoseStepper";
+import {
+  iso3DistanceM,
+  iso3EulerXYZDeg,
+  iso3RotationAngleDeg,
+  relativeCameraPose,
+  targetInCameraPose,
+} from "../../lib/se3";
 import { useStore } from "../../store";
 import { exportKindLabel } from "../../store/exportShape";
+import type { Iso3Wire, PinholeCameraWire } from "../../store/types";
 import type { FrameKey } from "../../types";
 import { Scene } from "./Scene";
 
-/** Build a per-camera (width, height) map from the manifest's ROI
- * entries. For tiled rigs (puzzle 130×130: one 4320×540 PNG per pose
- * with six 720×540 ROIs) this gives every frustum its real sensor
- * dimensions; for single-image-per-camera shapes the ROI is absent and
- * the camera falls back to the workspace default. */
-function cameraDimensionsFromFrames(
-  frames: FrameKey[],
-): Map<number, { width: number; height: number }> {
-  const dims = new Map<number, { width: number; height: number }>();
-  for (const f of frames) {
-    if (dims.has(f.camera)) continue;
-    if (f.roi) dims.set(f.camera, { width: f.roi.w, height: f.roi.h });
-  }
-  return dims;
-}
-
-/** B1.2 — 3D rig scene. Renders the rig origin, per-camera frustums,
- * and the active pose's target board. Click a frustum to select that
- * camera across all workspaces; click a board to select that pose. */
+/** B1.2 + B2.4 — 3D rig scene + side panel that breaks down the
+ * selected camera's intrinsics, the camera→target extrinsic for the
+ * active pose, and the selected camera's pose relative to a chosen
+ * reference camera (default cam 0). Click a frustum to pick a camera;
+ * click a board to pick a pose. */
 export function Viewer3DWorkspace() {
   const data = useStore((s) => s.data);
   const kind = useStore((s) => s.kind);
   const frames = useStore((s) => s.frames);
   const cameraA = useStore((s) => s.cameraA);
   const selectedPose = useStore((s) => s.selectedPose);
+  const setSelectedPose = useStore((s) => s.setSelectedPose);
   const [showAllPoses, setShowAllPoses] = useState(false);
+  const [referenceCamera, setReferenceCamera] = useState<number>(0);
 
   const cameraDimensions = useMemo(
     () => cameraDimensionsFromFrames(frames),
@@ -37,14 +34,19 @@ export function Viewer3DWorkspace() {
   );
 
   if (!data || !kind) {
-    return <Empty body="Load a rig export to see cameras and target poses in 3D." />;
+    return (
+      <Empty body="Load a rig export to see cameras and target poses in 3D." />
+    );
   }
 
+  const camerasArr = data.cameras;
+  const camSe3Rig = data.cam_se3_rig;
+  const rigSe3Target = data.rig_se3_target;
   const isRig =
-    Array.isArray(data.cameras) &&
-    Array.isArray(data.cam_se3_rig) &&
-    Array.isArray(data.rig_se3_target) &&
-    data.cameras.length > 0;
+    Array.isArray(camerasArr) &&
+    Array.isArray(camSe3Rig) &&
+    Array.isArray(rigSe3Target) &&
+    camerasArr.length > 0;
 
   if (!isRig) {
     return (
@@ -56,14 +58,40 @@ export function Viewer3DWorkspace() {
     );
   }
 
-  const numCameras = data.cameras?.length ?? 0;
-  const numPoses = data.rig_se3_target?.length ?? 0;
+  const numCameras = camerasArr.length;
+  const numPoses = rigSe3Target.length;
+  const cameraIndices = Array.from({ length: numCameras }, (_, i) => i);
+  const poseIndices = Array.from({ length: numPoses }, (_, i) => i);
+
+  // Bound the picked indices to what the export actually has so an
+  // older selection from a previous export doesn't render an out-of-
+  // range readout.
+  const safeCameraA = cameraA < numCameras ? cameraA : 0;
+  const safeRefCamera = referenceCamera < numCameras ? referenceCamera : 0;
+  const safePose = selectedPose < numPoses ? selectedPose : 0;
+
+  const selectedCameraData = camerasArr[safeCameraA];
+  const selectedCamSe3Rig = camSe3Rig[safeCameraA];
+  const referenceCamSe3Rig = camSe3Rig[safeRefCamera];
+  const targetPose = rigSe3Target[safePose];
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
-      <header className="flex items-center justify-between">
+      <header className="flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-sm font-semibold tracking-tight">3D viewer</h2>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          {numPoses > 0 && (
+            <PoseStepper
+              poseValues={poseIndices}
+              selectedPose={safePose}
+              onSelectPose={(next) => setSelectedPose(next, "A")}
+            />
+          )}
+          <RefCameraSelect
+            cameraIndices={cameraIndices}
+            value={safeRefCamera}
+            onChange={setReferenceCamera}
+          />
           <button
             type="button"
             onClick={() => setShowAllPoses((v) => !v)}
@@ -80,25 +108,293 @@ export function Viewer3DWorkspace() {
         </div>
       </header>
 
-      <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-md border border-border">
-        <Scene
-          data={data}
-          showAllPoses={showAllPoses}
-          cameraDimensions={cameraDimensions}
-          fallbackImage={{ width: 1024, height: 768 }}
-        />
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between border-t border-border bg-bg-soft/80 px-3 py-1.5 font-mono text-[10px] text-muted-foreground backdrop-blur-sm">
-          <span>
-            cameras {numCameras} · poses {numPoses}
-          </span>
-          <span>
-            cam {cameraA} · pose {selectedPose}
-          </span>
-          <span>drag · scroll to zoom · click a frustum to select</span>
+      <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_18rem] gap-3 overflow-hidden">
+        <div className="relative overflow-hidden rounded-md border border-border">
+          <Scene
+            data={data}
+            showAllPoses={showAllPoses}
+            cameraDimensions={cameraDimensions}
+            fallbackImage={{ width: 1024, height: 768 }}
+          />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between border-t border-border bg-bg-soft/80 px-3 py-1.5 font-mono text-[10px] text-muted-foreground backdrop-blur-sm">
+            <span>
+              cameras {numCameras} · poses {numPoses}
+            </span>
+            <span>
+              cam {safeCameraA} · pose {safePose} · ref {safeRefCamera}
+            </span>
+            <span>drag · scroll to zoom · click a frustum to select</span>
+          </div>
         </div>
+
+        <aside className="flex min-h-0 flex-col gap-3 overflow-y-auto rounded-md border border-border bg-surface p-3 text-[12px]">
+          <CameraIntrinsicsPanel
+            cameraIndex={safeCameraA}
+            camera={selectedCameraData}
+          />
+          <TargetExtrinsicsPanel
+            cameraIndex={safeCameraA}
+            poseIndex={safePose}
+            camSe3Rig={selectedCamSe3Rig}
+            rigSe3Target={targetPose}
+          />
+          <RelativePosePanel
+            referenceCamera={safeRefCamera}
+            selectedCamera={safeCameraA}
+            referenceCamSe3Rig={referenceCamSe3Rig}
+            selectedCamSe3Rig={selectedCamSe3Rig}
+          />
+        </aside>
       </div>
     </div>
   );
+}
+
+interface RefCameraSelectProps {
+  cameraIndices: number[];
+  value: number;
+  onChange: (v: number) => void;
+}
+
+function RefCameraSelect({
+  cameraIndices,
+  value,
+  onChange,
+}: RefCameraSelectProps) {
+  return (
+    <label className="flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+      <span className="uppercase tracking-wider">ref cam</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-7 rounded-md border border-border bg-surface px-1 text-foreground"
+        title="Reference camera for the relative-pose readout"
+      >
+        {cameraIndices.map((i) => (
+          <option key={i} value={i}>
+            {i}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+interface CameraIntrinsicsPanelProps {
+  cameraIndex: number;
+  camera: PinholeCameraWire | undefined;
+}
+
+function CameraIntrinsicsPanel({
+  cameraIndex,
+  camera,
+}: CameraIntrinsicsPanelProps) {
+  return (
+    <section>
+      <PanelHeading title="Selected camera" subtitle={`cam ${cameraIndex}`} />
+      {camera ? (
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono text-[11px] tabular-nums">
+          <div className="col-span-2 mt-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+            intrinsics
+          </div>
+          <span className="text-muted-foreground">fx</span>
+          <span>{camera.k.fx.toFixed(2)} px</span>
+          <span className="text-muted-foreground">fy</span>
+          <span>{camera.k.fy.toFixed(2)} px</span>
+          <span className="text-muted-foreground">cx</span>
+          <span>{camera.k.cx.toFixed(2)} px</span>
+          <span className="text-muted-foreground">cy</span>
+          <span>{camera.k.cy.toFixed(2)} px</span>
+          {camera.k.skew !== 0 && (
+            <>
+              <span className="text-muted-foreground">skew</span>
+              <span>{camera.k.skew.toFixed(4)}</span>
+            </>
+          )}
+          {camera.dist && (
+            <>
+              <div className="col-span-2 mt-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                distortion (Brown-Conrady)
+              </div>
+              <span className="text-muted-foreground">k1</span>
+              <span>{camera.dist.k1.toFixed(5)}</span>
+              <span className="text-muted-foreground">k2</span>
+              <span>{camera.dist.k2.toFixed(5)}</span>
+              <span className="text-muted-foreground">p1</span>
+              <span>{camera.dist.p1.toFixed(5)}</span>
+              <span className="text-muted-foreground">p2</span>
+              <span>{camera.dist.p2.toFixed(5)}</span>
+              <span className="text-muted-foreground">k3</span>
+              <span>{camera.dist.k3.toFixed(5)}</span>
+            </>
+          )}
+        </div>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">no camera at this index</p>
+      )}
+    </section>
+  );
+}
+
+interface TargetExtrinsicsPanelProps {
+  cameraIndex: number;
+  poseIndex: number;
+  camSe3Rig: Iso3Wire | undefined;
+  rigSe3Target: Iso3Wire | undefined;
+}
+
+function TargetExtrinsicsPanel({
+  cameraIndex,
+  poseIndex,
+  camSe3Rig,
+  rigSe3Target,
+}: TargetExtrinsicsPanelProps) {
+  if (!camSe3Rig || !rigSe3Target) {
+    return (
+      <section>
+        <PanelHeading title="Target extrinsic" subtitle="—" />
+        <p className="text-[11px] text-muted-foreground">no pose data</p>
+      </section>
+    );
+  }
+  const t = targetInCameraPose(camSe3Rig, rigSe3Target);
+  const dist = iso3DistanceM(t);
+  const euler = iso3EulerXYZDeg(t);
+  const angle = iso3RotationAngleDeg(t);
+  return (
+    <section>
+      <PanelHeading
+        title="Target extrinsic"
+        subtitle={`cam ${cameraIndex} → pose ${poseIndex}`}
+      />
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono text-[11px] tabular-nums">
+        <span className="text-muted-foreground">distance</span>
+        <span>
+          {(dist * 1000).toFixed(1)} mm
+          <span className="ml-1 text-muted-foreground">({dist.toFixed(3)} m)</span>
+        </span>
+        <span className="text-muted-foreground">euler X</span>
+        <span>{formatDeg(euler.x)}</span>
+        <span className="text-muted-foreground">euler Y</span>
+        <span>{formatDeg(euler.y)}</span>
+        <span className="text-muted-foreground">euler Z</span>
+        <span>{formatDeg(euler.z)}</span>
+        <span className="text-muted-foreground">|rot|</span>
+        <span>{formatDeg(angle)}</span>
+      </div>
+    </section>
+  );
+}
+
+interface RelativePosePanelProps {
+  referenceCamera: number;
+  selectedCamera: number;
+  referenceCamSe3Rig: Iso3Wire | undefined;
+  selectedCamSe3Rig: Iso3Wire | undefined;
+}
+
+function RelativePosePanel({
+  referenceCamera,
+  selectedCamera,
+  referenceCamSe3Rig,
+  selectedCamSe3Rig,
+}: RelativePosePanelProps) {
+  if (!referenceCamSe3Rig || !selectedCamSe3Rig) {
+    return (
+      <section>
+        <PanelHeading title="Relative pose" subtitle="—" />
+        <p className="text-[11px] text-muted-foreground">no pose data</p>
+      </section>
+    );
+  }
+  if (referenceCamera === selectedCamera) {
+    return (
+      <section>
+        <PanelHeading
+          title="Relative pose"
+          subtitle={`cam ${referenceCamera} ↔ cam ${selectedCamera}`}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          selected camera is the reference — pick a different camera (click a
+          frustum) to see a relative pose.
+        </p>
+      </section>
+    );
+  }
+  const rel = relativeCameraPose(referenceCamSe3Rig, selectedCamSe3Rig);
+  const dist = iso3DistanceM(rel);
+  const euler = iso3EulerXYZDeg(rel);
+  const angle = iso3RotationAngleDeg(rel);
+  return (
+    <section>
+      <PanelHeading
+        title="Relative pose"
+        subtitle={`cam ${referenceCamera} ⇒ cam ${selectedCamera}`}
+      />
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono text-[11px] tabular-nums">
+        <span className="text-muted-foreground">baseline</span>
+        <span>
+          {(dist * 1000).toFixed(1)} mm
+          <span className="ml-1 text-muted-foreground">({dist.toFixed(4)} m)</span>
+        </span>
+        <span className="text-muted-foreground">tx</span>
+        <span>{(rel.translation[0] * 1000).toFixed(1)} mm</span>
+        <span className="text-muted-foreground">ty</span>
+        <span>{(rel.translation[1] * 1000).toFixed(1)} mm</span>
+        <span className="text-muted-foreground">tz</span>
+        <span>{(rel.translation[2] * 1000).toFixed(1)} mm</span>
+        <span className="text-muted-foreground">euler X</span>
+        <span>{formatDeg(euler.x)}</span>
+        <span className="text-muted-foreground">euler Y</span>
+        <span>{formatDeg(euler.y)}</span>
+        <span className="text-muted-foreground">euler Z</span>
+        <span>{formatDeg(euler.z)}</span>
+        <span className="text-muted-foreground">|rot|</span>
+        <span>{formatDeg(angle)}</span>
+      </div>
+    </section>
+  );
+}
+
+function PanelHeading({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <header className="mb-1.5 flex items-baseline justify-between border-b border-border pb-1">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
+        {title}
+      </h3>
+      <span className="font-mono text-[10px] text-muted-foreground">
+        {subtitle}
+      </span>
+    </header>
+  );
+}
+
+function formatDeg(value: number): string {
+  // Tabular alignment helper: always sign + at least one decimal.
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}°`;
+}
+
+/** Build a per-camera (width, height) map from the manifest's ROI
+ * entries. For tiled rigs (puzzle 130×130: one 4320×540 PNG per pose
+ * with six 720×540 ROIs) this gives every frustum its real sensor
+ * dimensions; for single-image-per-camera shapes the ROI is absent and
+ * the camera falls back to the workspace default. */
+function cameraDimensionsFromFrames(
+  frames: FrameKey[],
+): Map<number, { width: number; height: number }> {
+  const dims = new Map<number, { width: number; height: number }>();
+  for (const f of frames) {
+    if (dims.has(f.camera)) continue;
+    if (f.roi) dims.set(f.camera, { width: f.roi.w, height: f.roi.h });
+  }
+  return dims;
 }
 
 function Empty({ body }: { body: string }) {

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -283,6 +283,15 @@ pub struct RigHandeyeExport {
     /// Transform from rig frame to camera frame.
     pub cam_se3_rig: Vec<Iso3>,
 
+    /// Per-view rig poses: `rig_se3_target` (T_R_T), derived from the
+    /// hand-eye chain (`handeye_observer_se3_target`) so downstream
+    /// viewers (3D scene, epipolar overlay) can read board poses
+    /// without re-implementing the chain. One entry per input view.
+    /// `#[serde(default)]` keeps older exports forward-compatible at
+    /// load time; they decode with an empty Vec.
+    #[serde(default)]
+    pub rig_se3_target: Vec<Iso3>,
+
     /// Hand-eye mode used to interpret mode-dependent transforms.
     pub handeye_mode: HandEyeMode,
 
@@ -549,6 +558,7 @@ impl ProblemType for RigHandeyeProblem {
             cameras: output.cameras().to_vec(),
             sensors: output.sensors().map(|s| s.to_vec()),
             cam_se3_rig,
+            rig_se3_target: rig_se3_target.clone(),
             handeye_mode: mode,
             gripper_se3_rig,
             rig_se3_base,
@@ -761,6 +771,11 @@ mod tests {
         assert!(export.base_se3_target.is_some());
         assert!(export.rig_se3_base.is_none());
         assert!(export.gripper_se3_target.is_none());
+        assert_eq!(
+            export.rig_se3_target.len(),
+            1,
+            "rig_se3_target must have one entry per input view"
+        );
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
@@ -4,7 +4,7 @@ use crate::Error;
 use crate::rig_handeye::RigHandeyeExport;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    BrownConrady5, Camera, FeatureResidualHistogram, FxFyCxCySkew, Iso3, NoMeta,
+    BrownConrady5, Camera, FeatureResidualHistogram, FxFyCxCySkew, ImageManifest, Iso3, NoMeta,
     PerFeatureResiduals, Pinhole, Real, RigDataset, RigView, RigViewObs, ScheimpflugParams,
     build_feature_histogram, compute_rig_target_residuals,
 };
@@ -126,6 +126,16 @@ pub struct RigLaserlineDeviceExport {
     /// are populated.
     #[serde(default)]
     pub per_feature_residuals: PerFeatureResiduals,
+
+    /// Optional image manifest (ADR 0014, viewer-side contract). When
+    /// populated, downstream viewers (the diagnose / 3D / epipolar UIs)
+    /// can locate the source image for each `(pose, camera)` slot.
+    /// Tiled multi-camera frames (e.g. 6× 720×540 horizontal strips on
+    /// the puzzle 130×130 rig) point multiple `FrameRef`s at the same
+    /// `path` with disjoint ROIs. `None` means "no images shipped"; the
+    /// calibration pipeline never reads this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_manifest: Option<ImageManifest>,
 }
 
 /// Rig laserline calibration problem.
@@ -273,6 +283,80 @@ impl ProblemType for RigLaserlineDeviceProblem {
                 target_hist_per_camera: Some(target_hist_per_camera),
                 laser_hist_per_camera: Some(laser_hist_per_camera),
             },
+            // Manifest is populated by callers that wrote images for the
+            // dataset; the pipeline never has image paths to fill in.
+            image_manifest: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_minimal_export() -> RigLaserlineDeviceExport {
+        // Construct an export directly — RigLaserlineDeviceExport is
+        // `#[non_exhaustive]` so external callers can't, but in-module
+        // tests can. This keeps the manifest tests independent of the
+        // upstream calibration setup needed to drive `export()`.
+        RigLaserlineDeviceExport {
+            laser_planes_rig: Vec::new(),
+            laser_planes_cam: Vec::new(),
+            per_camera_stats: Vec::new(),
+            per_feature_residuals: PerFeatureResiduals::default(),
+            image_manifest: None,
+        }
+    }
+
+    #[test]
+    fn export_image_manifest_defaults_absent_from_wire() {
+        // ADR 0014: when the pipeline emits an export the manifest is
+        // None and `skip_serializing_if` keeps the legacy JSON byte-stable.
+        let export = make_minimal_export();
+        assert!(export.image_manifest.is_none());
+
+        let json = serde_json::to_string(&export).unwrap();
+        assert!(
+            !json.contains("image_manifest"),
+            "absent manifest must not appear on the wire"
+        );
+        let restored: RigLaserlineDeviceExport = serde_json::from_str(&json).unwrap();
+        assert!(restored.image_manifest.is_none());
+    }
+
+    #[test]
+    fn export_image_manifest_roundtrip_with_tiled_roi() {
+        // The puzzle 130×130 rig writes a single 4320×540 PNG per pose
+        // and references each of its six 720×540 camera tiles via ROI;
+        // mirror that shape here so any future change to PixelRect or
+        // FrameRef serialization is caught at PR time.
+        use vision_calibration_core::{FrameRef, ImageManifest, PixelRect};
+
+        let mut export = make_minimal_export();
+        export.image_manifest = Some(ImageManifest {
+            root: std::path::PathBuf::from("."),
+            frames: (0..6)
+                .map(|cam| FrameRef {
+                    pose: 0,
+                    camera: cam,
+                    path: std::path::PathBuf::from("target_0.png"),
+                    roi: Some(PixelRect {
+                        x: (cam as u32) * 720,
+                        y: 0,
+                        w: 720,
+                        h: 540,
+                    }),
+                })
+                .collect(),
+        });
+
+        let json = serde_json::to_string(&export).unwrap();
+        let restored: RigLaserlineDeviceExport = serde_json::from_str(&json).unwrap();
+        let manifest = restored
+            .image_manifest
+            .expect("manifest survives roundtrip");
+        assert_eq!(manifest.frames.len(), 6);
+        assert_eq!(manifest.frames[0].camera, 0);
+        assert_eq!(manifest.frames[5].roi.unwrap().x, 5 * 720);
     }
 }

--- a/crates/vision-calibration/examples/support/stereo_charuco_io.rs
+++ b/crates/vision-calibration/examples/support/stereo_charuco_io.rs
@@ -6,7 +6,7 @@ use calib_targets::charuco::{CharucoBoardSpec, CharucoParams, MarkerLayout};
 use calib_targets::detect;
 use chess_corners::ChessConfig;
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use vision_calibration::prelude::*;
 use vision_calibration::rig_extrinsics::RigExtrinsicsInput;
 
@@ -26,6 +26,13 @@ pub struct StereoCharucoDatasetSummary {
     pub skipped_views: usize,
     pub usable_left: usize,
     pub usable_right: usize,
+    /// Per-accepted-view absolute paths `[cam1, cam2]`. Indexed by the
+    /// view's position in the resulting `RigExtrinsicsInput` (so the
+    /// pose index in any downstream `*Export` matches the slot here).
+    /// Read by the `viewer_fixtures` example; the existing
+    /// `stereo_charuco_session` / `manual_init_proof` examples ignore it.
+    #[allow(dead_code)]
+    pub view_paths: Vec<[PathBuf; 2]>,
 }
 
 /// Build ChArUco detector params used by the stereo example.
@@ -85,6 +92,7 @@ where
 
     let total_pairs = suffixes.len();
     let mut views = Vec::new();
+    let mut view_paths: Vec<[PathBuf; 2]> = Vec::new();
     let mut usable_left = 0usize;
     let mut usable_right = 0usize;
     let mut skipped_views = 0usize;
@@ -124,6 +132,7 @@ where
                 cameras: vec![left, right],
             },
         });
+        view_paths.push([left_path, right_path]);
     }
 
     ensure!(
@@ -139,6 +148,7 @@ where
         skipped_views,
         usable_left,
         usable_right,
+        view_paths,
     };
 
     use vision_calibration::core::RigDataset;

--- a/crates/vision-calibration/examples/support/stereo_io.rs
+++ b/crates/vision-calibration/examples/support/stereo_io.rs
@@ -5,7 +5,7 @@ use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams
 use calib_targets::detect;
 use chess_corners::ChessConfig;
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use vision_calibration::prelude::*;
 use vision_calibration::rig_extrinsics::RigExtrinsicsInput;
 
@@ -17,6 +17,15 @@ pub struct StereoDatasetSummary {
     pub skipped_views: usize,
     pub usable_left: usize,
     pub usable_right: usize,
+    /// Per-accepted-view absolute paths `[left, right]`. Indexed by the
+    /// view's position in the resulting `RigExtrinsicsInput` (so the
+    /// pose index in any downstream `*Export` matches the slot here).
+    /// Populated for every view pushed into the dataset, including
+    /// views where detection failed on one of the two cameras.
+    /// Read by the `viewer_fixtures` example; the existing
+    /// `stereo_session` / `manual_init_proof` examples ignore it.
+    #[allow(dead_code)]
+    pub view_paths: Vec<[PathBuf; 2]>,
 }
 
 /// Load stereo dataset from images directory.
@@ -60,6 +69,7 @@ where
 
     let total_pairs = indices.len();
     let mut views = Vec::new();
+    let mut view_paths: Vec<[PathBuf; 2]> = Vec::new();
     let mut usable_left = 0usize;
     let mut usable_right = 0usize;
     let mut skipped_views = 0usize;
@@ -100,6 +110,7 @@ where
                 cameras: vec![left, right],
             },
         });
+        view_paths.push([left_path, right_path]);
     }
 
     ensure!(
@@ -115,6 +126,7 @@ where
         skipped_views,
         usable_left,
         usable_right,
+        view_paths,
     };
 
     use vision_calibration::core::RigDataset;

--- a/crates/vision-calibration/examples/viewer_fixtures.rs
+++ b/crates/vision-calibration/examples/viewer_fixtures.rs
@@ -43,8 +43,7 @@ fn main() -> Result<()> {
 
     println!("=== Viewer fixture generator ===\n");
 
-    write_stereo_fixture(&repo_root)
-        .context("failed to generate stereo viewer fixture")?;
+    write_stereo_fixture(&repo_root).context("failed to generate stereo viewer fixture")?;
     println!();
     write_stereo_charuco_fixture(&repo_root)
         .context("failed to generate stereo_charuco viewer fixture")?;
@@ -57,7 +56,11 @@ fn main() -> Result<()> {
 fn write_stereo_fixture(repo_root: &Path) -> Result<()> {
     let dataset_dir = repo_root.join("data/stereo");
     let imgs_dir = dataset_dir.join("imgs");
-    ensure!(imgs_dir.exists(), "stereo dataset missing: {}", imgs_dir.display());
+    ensure!(
+        imgs_dir.exists(),
+        "stereo dataset missing: {}",
+        imgs_dir.display()
+    );
 
     println!("[stereo] detecting chessboard corners (7×11, 30 mm)…");
     let chess_config = ChessConfig::default();

--- a/crates/vision-calibration/examples/viewer_fixtures.rs
+++ b/crates/vision-calibration/examples/viewer_fixtures.rs
@@ -1,0 +1,195 @@
+//! Generate viewer-loadable rig exports for the public test datasets.
+//!
+//! Walks the public datasets in `data/`, runs the calibration pipeline,
+//! and writes a `viewer_export.json` for each one with the
+//! `image_manifest` field populated against the actual image paths used
+//! by the dataset loader. The B0 / B1 / B2 desktop workspaces (Diagnose
+//! / 3D viewer / Epipolar) are then opened against these JSON files.
+//!
+//! Run with: `cargo run -p vision-calibration --example viewer_fixtures`
+//!
+//! Datasets covered (rig exports the new B1 + B2 workspaces consume):
+//! - `data/stereo/imgs/` — stereo rig (7×11 chessboard, 30 mm)
+//! - `data/stereo_charuco/` — stereo rig (22×22 ChArUco, 1.35 mm)
+//!
+//! `data/kuka_1/` is single-camera hand-eye and the SingleCamHandeye
+//! export does not yet carry `image_manifest` (B3 follow-up). `data/DS8/`
+//! has no example wired up yet.
+
+#[path = "support/stereo_charuco_io.rs"]
+mod stereo_charuco_io;
+#[path = "support/stereo_io.rs"]
+mod stereo_io;
+
+use anyhow::{Context, Result, ensure};
+use calib_targets::chessboard::DetectorParams;
+use chess_corners::ChessConfig;
+use std::path::{Path, PathBuf};
+use stereo_charuco_io::{
+    BOARD_CELL_SIZE_MM, BOARD_COLS, BOARD_DICTIONARY_NAME, BOARD_ROWS,
+    load_stereo_charuco_input_with_progress, make_charuco_detector_params,
+};
+use stereo_io::load_stereo_input_with_progress;
+use vision_calibration::core::{FrameRef, ImageManifest};
+use vision_calibration::prelude::*;
+use vision_calibration::rig_extrinsics::{
+    RigExtrinsicsExport, RigExtrinsicsProblem, run_calibration,
+};
+
+const STEREO_SQUARE_SIZE_M: f64 = 0.03;
+
+fn main() -> Result<()> {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+
+    println!("=== Viewer fixture generator ===\n");
+
+    write_stereo_fixture(&repo_root)
+        .context("failed to generate stereo viewer fixture")?;
+    println!();
+    write_stereo_charuco_fixture(&repo_root)
+        .context("failed to generate stereo_charuco viewer fixture")?;
+    println!();
+
+    println!("Done. Open each viewer_export.json from `bun run tauri dev`.");
+    Ok(())
+}
+
+fn write_stereo_fixture(repo_root: &Path) -> Result<()> {
+    let dataset_dir = repo_root.join("data/stereo");
+    let imgs_dir = dataset_dir.join("imgs");
+    ensure!(imgs_dir.exists(), "stereo dataset missing: {}", imgs_dir.display());
+
+    println!("[stereo] detecting chessboard corners (7×11, 30 mm)…");
+    let chess_config = ChessConfig::default();
+    let board_params = DetectorParams::default();
+    let (input, summary) = load_stereo_input_with_progress(
+        &imgs_dir,
+        &chess_config,
+        &board_params,
+        STEREO_SQUARE_SIZE_M,
+        None,
+        |_, _, _| {},
+    )?;
+    println!(
+        "[stereo] {} pairs total, {} accepted ({} skipped); usable left={} right={}",
+        summary.total_pairs,
+        summary.used_views,
+        summary.skipped_views,
+        summary.usable_left,
+        summary.usable_right
+    );
+
+    println!("[stereo] running calibration…");
+    let mut session = CalibrationSession::<RigExtrinsicsProblem>::new();
+    session.set_input(input)?;
+    run_calibration(&mut session)?;
+    let mut export = session.export()?;
+    println!(
+        "[stereo] mean reproj error: {:.4} px",
+        export.mean_reproj_error
+    );
+
+    // Manifest root = imgs/ (relative to data/stereo/), per-camera paths
+    // join leftcamera/Im_L_*.png + rightcamera/Im_R_*.png. The dataset
+    // loader's view_paths are absolute; convert to manifest-relative.
+    let manifest = manifest_from_view_paths(&summary.view_paths, &imgs_dir, "imgs")?;
+    export.image_manifest = Some(manifest);
+
+    let out_path = dataset_dir.join("viewer_export.json");
+    write_pretty(&out_path, &export)?;
+    println!("[stereo] wrote {}", out_path.display());
+    Ok(())
+}
+
+fn write_stereo_charuco_fixture(repo_root: &Path) -> Result<()> {
+    let dataset_dir = repo_root.join("data/stereo_charuco");
+    ensure!(
+        dataset_dir.exists(),
+        "stereo_charuco dataset missing: {}",
+        dataset_dir.display()
+    );
+
+    println!(
+        "[stereo_charuco] detecting ChArUco corners ({BOARD_ROWS}×{BOARD_COLS} board, \
+         cell {BOARD_CELL_SIZE_MM:.4} mm, dict {BOARD_DICTIONARY_NAME})…"
+    );
+    let chess_config = ChessConfig::default();
+    let charuco_params = make_charuco_detector_params();
+    let (input, summary) = load_stereo_charuco_input_with_progress(
+        &dataset_dir,
+        &chess_config,
+        &charuco_params,
+        None,
+        |_, _, _| {},
+    )?;
+    println!(
+        "[stereo_charuco] {} pairs total, {} accepted ({} skipped); usable left={} right={}",
+        summary.total_pairs,
+        summary.used_views,
+        summary.skipped_views,
+        summary.usable_left,
+        summary.usable_right
+    );
+
+    println!("[stereo_charuco] running calibration…");
+    let mut session = CalibrationSession::<RigExtrinsicsProblem>::new();
+    session.set_input(input)?;
+    run_calibration(&mut session)?;
+    let mut export = session.export()?;
+    println!(
+        "[stereo_charuco] mean reproj error: {:.4} px",
+        export.mean_reproj_error
+    );
+
+    // Manifest root = "." (relative to data/stereo_charuco/); per-camera
+    // paths join cam1/Cam1_*.png + cam2/Cam2_*.png.
+    let manifest = manifest_from_view_paths(&summary.view_paths, &dataset_dir, ".")?;
+    export.image_manifest = Some(manifest);
+
+    let out_path = dataset_dir.join("viewer_export.json");
+    write_pretty(&out_path, &export)?;
+    println!("[stereo_charuco] wrote {}", out_path.display());
+    Ok(())
+}
+
+/// Build an `ImageManifest` from the loader's per-view absolute paths.
+///
+/// `image_root_abs` is the directory the manifest's `root` resolves to
+/// (the loader's `imgs_dir` for stereo, the dataset dir itself for
+/// stereo_charuco); `manifest_root` is the path written into the
+/// manifest, relative to the export JSON's directory.
+fn manifest_from_view_paths(
+    view_paths: &[[PathBuf; 2]],
+    image_root_abs: &Path,
+    manifest_root: &str,
+) -> Result<ImageManifest> {
+    let mut frames: Vec<FrameRef> = Vec::with_capacity(view_paths.len() * 2);
+    for (pose_idx, pair) in view_paths.iter().enumerate() {
+        for (cam_idx, abs) in pair.iter().enumerate() {
+            let rel = abs.strip_prefix(image_root_abs).with_context(|| {
+                format!(
+                    "image path {} not under {}",
+                    abs.display(),
+                    image_root_abs.display()
+                )
+            })?;
+            frames.push(FrameRef {
+                pose: pose_idx,
+                camera: cam_idx,
+                path: rel.to_path_buf(),
+                roi: None,
+            });
+        }
+    }
+    Ok(ImageManifest {
+        root: PathBuf::from(manifest_root),
+        frames,
+    })
+}
+
+fn write_pretty(path: &Path, export: &RigExtrinsicsExport) -> Result<()> {
+    let json = serde_json::to_string_pretty(export)
+        .with_context(|| format!("serializing {}", path.display()))?;
+    std::fs::write(path, json).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}

--- a/scripts/patch_130puzzle_rig_se3_target.py
+++ b/scripts/patch_130puzzle_rig_se3_target.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Patch privatedata/130x130_puzzle/export.json with rig_se3_target.
+
+The puzzle 130x130 export was generated before RigHandeyeExport carried
+rig_se3_target. The 3D viewer needs that field to render the per-pose
+target boards. Re-running the full puzzle pipeline takes minutes; the
+chain is already deterministic so we recompute rig_se3_target here from
+the fields that *are* in the export, plus the source robot poses in
+poses.json.
+
+For EyeToHand:  T_R_T = T_R_B * T_B_G_corrected * T_G_T
+
+This script is one-off plumbing; once we re-run the pipeline (with the
+new export schema), the rig_se3_target field will be populated natively.
+"""
+
+import json
+import math
+from pathlib import Path
+
+DATA = Path("privatedata/130x130_puzzle")
+EXPORT = DATA / "export.json"
+POSES = DATA / "poses.json"
+
+
+def quat_mul(a, b):
+    ax, ay, az, aw = a
+    bx, by, bz, bw = b
+    return (
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+        aw * bw - ax * bx - ay * by - az * bz,
+    )
+
+
+def quat_rotate(q, v):
+    qx, qy, qz, qw = q
+    vx, vy, vz = v
+    # qv = q * (vx, vy, vz, 0) * q^-1, but use the more efficient form
+    # https://gamedev.stackexchange.com/a/50545
+    t = (
+        2 * (qy * vz - qz * vy),
+        2 * (qz * vx - qx * vz),
+        2 * (qx * vy - qy * vx),
+    )
+    return (
+        vx + qw * t[0] + (qy * t[2] - qz * t[1]),
+        vy + qw * t[1] + (qz * t[0] - qx * t[2]),
+        vz + qw * t[2] + (qx * t[1] - qy * t[0]),
+    )
+
+
+def iso_compose(a, b):
+    """Compose two iso3 dicts: result = a * b."""
+    aq = a["rotation"]
+    at = a["translation"]
+    bq = b["rotation"]
+    bt = b["translation"]
+    cq = quat_mul(aq, bq)
+    btr = quat_rotate(aq, bt)
+    return {
+        "rotation": list(cq),
+        "translation": [at[0] + btr[0], at[1] + btr[1], at[2] + btr[2]],
+    }
+
+
+def matrix_to_iso(m):
+    """Convert a 4x4 row-major homogeneous matrix to an iso3 (translation
+    in mm → m, mirroring PoseEntry::base_se3_gripper in the Rust loader)."""
+    # Translation in mm; convert to m.
+    tx = m[0][3] * 1e-3
+    ty = m[1][3] * 1e-3
+    tz = m[2][3] * 1e-3
+    # Quaternion from 3x3 rotation block (Shepperd's method, scalar-last).
+    r00, r01, r02 = m[0][0], m[0][1], m[0][2]
+    r10, r11, r12 = m[1][0], m[1][1], m[1][2]
+    r20, r21, r22 = m[2][0], m[2][1], m[2][2]
+    tr = r00 + r11 + r22
+    if tr > 0.0:
+        s = math.sqrt(tr + 1.0) * 2.0
+        qw = 0.25 * s
+        qx = (r21 - r12) / s
+        qy = (r02 - r20) / s
+        qz = (r10 - r01) / s
+    elif (r00 > r11) and (r00 > r22):
+        s = math.sqrt(1.0 + r00 - r11 - r22) * 2.0
+        qw = (r21 - r12) / s
+        qx = 0.25 * s
+        qy = (r01 + r10) / s
+        qz = (r02 + r20) / s
+    elif r11 > r22:
+        s = math.sqrt(1.0 + r11 - r00 - r22) * 2.0
+        qw = (r02 - r20) / s
+        qx = (r01 + r10) / s
+        qy = 0.25 * s
+        qz = (r12 + r21) / s
+    else:
+        s = math.sqrt(1.0 + r22 - r00 - r11) * 2.0
+        qw = (r10 - r01) / s
+        qx = (r02 + r20) / s
+        qy = (r12 + r21) / s
+        qz = 0.25 * s
+    return {
+        "rotation": [qx, qy, qz, qw],
+        "translation": [tx, ty, tz],
+    }
+
+
+def apply_robot_delta(base_se3_gripper, delta):
+    """Mirror the Rust apply_robot_delta: T_B_G_corr = exp(delta) * T_B_G."""
+    rx, ry, rz, tx, ty, tz = delta
+    angle = math.sqrt(rx * rx + ry * ry + rz * rz)
+    if angle > 1e-12:
+        ax, ay, az = rx / angle, ry / angle, rz / angle
+        s = math.sin(angle * 0.5)
+        delta_rot = [ax * s, ay * s, az * s, math.cos(angle * 0.5)]
+    else:
+        delta_rot = [0.0, 0.0, 0.0, 1.0]
+    delta_iso = {"rotation": delta_rot, "translation": [tx, ty, tz]}
+    return iso_compose(delta_iso, base_se3_gripper)
+
+
+def main() -> None:
+    export = json.loads(EXPORT.read_text())
+    poses = json.loads(POSES.read_text())
+
+    if export.get("rig_se3_target"):
+        print(
+            f"export already has rig_se3_target ({len(export['rig_se3_target'])} entries) — nothing to do"
+        )
+        return
+
+    mode = export["handeye_mode"]
+    deltas = export.get("robot_deltas") or [[0.0] * 6] * len(poses)
+    if mode != "EyeToHand":
+        raise SystemExit(f"unexpected handeye_mode {mode!r}; only EyeToHand patched")
+
+    rig_se3_base = export["rig_se3_base"]
+    gripper_se3_target = export["gripper_se3_target"]
+
+    rig_se3_target = []
+    for i, pose in enumerate(poses):
+        base_se3_gripper = matrix_to_iso(pose["tcp2base"])
+        if i < len(deltas):
+            base_se3_gripper = apply_robot_delta(base_se3_gripper, deltas[i])
+        # T_R_T = T_R_B * T_B_G * T_G_T
+        rig_se3_target.append(
+            iso_compose(iso_compose(rig_se3_base, base_se3_gripper), gripper_se3_target)
+        )
+
+    # Splice in alphabetical-ish position: after cam_se3_rig.
+    new_export = {}
+    inserted = False
+    for k, v in export.items():
+        new_export[k] = v
+        if k == "cam_se3_rig":
+            new_export["rig_se3_target"] = rig_se3_target
+            inserted = True
+    if not inserted:
+        new_export["rig_se3_target"] = rig_se3_target
+
+    EXPORT.write_text(json.dumps(new_export, indent=2))
+    print(f"patched {EXPORT} with {len(rig_se3_target)} rig_se3_target entries")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds the **Epipolar geometry** workspace: click a feature in pane A → see its epipolar line drawn through pane B, with the matching observed feature ghosted and the epipole marked.
- Implements `compute_epipolar_overlay` as a Tauri command that runs server-side through `vision_calibration_core`'s canonical camera models, so distortion + (optional) Scheimpflug projection stay consistent with the calibration pipeline. No re-implementing distortion in TS.
- Adds `image_manifest: Option<ImageManifest>` to `RigLaserlineDeviceExport`, completing the manifest sweep on the three rig export types the multi-camera workspaces consume.

## What changed

**Manifest sweep (B2.0)**
- `RigLaserlineDeviceExport` gains `image_manifest`, mirroring the rig_handeye / rig_extrinsics precedent. Two new round-trip tests (default-absent + tiled-ROI puzzle 130×130 shape).

**Tauri command (B2.1)**
- `app/src-tauri/src/export_cache.rs` — `tauri::State<ExportCache>` singleton holding the most recently loaded export's parsed JSON. Populated by `load_export`; read by `compute_epipolar_overlay`. No disk re-read per click.
- `app/src-tauri/src/epipolar.rs` — `compute_overlay(export, cam_a, cam_b, point_px)`:
  1. Backproject the click through cam-A's full chain (`Camera::backproject_pixel`).
  2. Compose `T_B_A = cam_se3_rig[b] · cam_se3_rig[a].inverse()`.
  3. Sample 64 logarithmic depths from 5 cm to 5 m.
  4. Project each through cam-B's full chain (`Camera::project_point_c`) — distortion + Scheimpflug applied for free via the type-erased `CameraModel` from `vision_calibration_core`.
  5. Project cam-A's optical center for the optional epipole.
- New side-tauri deps: `nalgebra` (was transitive) + `vision-calibration-core` (direct, for `CameraModel`).

**Workspace UI (B2.2)**
- Two-pane layout with **independent** controlled viewports (no linked zoom — the same pixel coordinate isn't the same physical thing across cameras).
- Top bar: pose / cam-A / cam-B selectors; "Tie-points" toggle dots every observed feature in both panes.
- Click in pane A → snap to nearest residual feature within 6 px (or free pixel pick beyond) → fire `compute_epipolar_overlay` → render the polyline as an SVG `<polyline>` over pane B in image-pixel coords inside a viewport-transformed `<g>`, so it follows zoom/pan. Selected feature: brand-coloured crosshair in pane A. Matching feature: ghost crosshair in pane B. Epipole: destructive-coloured marker.
- `FrameCanvas` gains an `onPick` prop that fires only on a discrete click (mousedown/mouseup with < 4 px movement), distinguishing it from a pan-drag.

## Test plan

- [x] `cargo fmt --all -- --check` (workspace + side-tauri)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` (side-tauri)
- [x] `cargo test --workspace` — 164 pipeline tests (incl. 2 new manifest tests)
- [x] `cargo test --lib` in `app/src-tauri` — 4 tests (3 new in `epipolar`)
- [x] `cd app && bun run build && bun tsc --noEmit`
- [ ] Smoke-test `bun run tauri dev` against the puzzle 130×130 `RigHandeyeExport`: load → `/epipolar` → click feature 0 in cam-0 → polyline crosses cam-1's observed feature 0 → tie-points toggle works → switching cam-B selector triggers a fresh overlay.

## Next

After this lands: **B3** — in-app calibration runner (pre-detected). Pipeline-side `dispatch::run_from_json`, ts-rs codegen, manifest carry-through across all 7 datasets, Tauri progress events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)