### PR TITLE
B3a + B3b: schema-driven configs, dataset manifest, detection cache, Tauri runner & Run workspace

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fax"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1300,12 @@ name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"
@@ -2616,6 +2628,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2753,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,6 +2825,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2953,6 +3021,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -3384,10 +3465,36 @@ dependencies = [
  "anyhow",
  "nalgebra",
  "rand 0.10.1",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "vision-calibration-dataset"
+version = "0.4.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vision-calibration-detect"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "calib-targets",
+ "chess-corners",
+ "image",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3411,6 +3518,7 @@ dependencies = [
  "faer",
  "faer-ext",
  "nalgebra",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3424,11 +3532,17 @@ name = "vision-calibration-pipeline"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "glob",
+ "image",
  "nalgebra",
+ "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "vision-calibration-core",
+ "vision-calibration-dataset",
+ "vision-calibration-detect",
  "vision-calibration-linear",
  "vision-calibration-optim",
 ]
@@ -3766,6 +3880,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "schemars",
+ "serde_json",
+ "vision-calibration-dataset",
+ "vision-calibration-pipeline",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b98343f595652ccc4da8ba4bb349ed9ce9c77b0472bad0e9d0858295dd092e"
+checksum = "87aa24dde918ca16f7456406a93fe76918ba55cc78fbd7b8aac42cf41810afc5"
 dependencies = [
  "rayon",
 ]
@@ -333,9 +333,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calib-targets"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d18cb135ca3684dc821f8713ff9ecad0fe9c6211ae6c6ebc49cd08f202fe52"
+checksum = "1db8d8448709b972efa2ef7efd8b4738cf06971713c837bc9c0082a98f57b4d5"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267668023ae49191eb6d7f6698cf7c82654492de83dcea5ccc53485e2f6123fe"
+checksum = "d990b6bd5696a0ab2b322a81d2e4d5148dc84d629e57977638637afd8991fc88"
 dependencies = [
  "calib-targets-core",
  "log",
@@ -367,14 +367,14 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d170181c2a3b9d025b7a96fb2989fc735188c7a1c0d0ecdd7d53d831f7f09faa"
+checksum = "7af66c739d481175bdd12e7d16ee7aadc67165b0d2c7bcebe5456eb240c6789b"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7463ec9e1e56f83622706212795752f9880a3c0f73cadab78d033c31c28a0ebf"
+checksum = "163b2769a687f46e681dafccb409d21feec422b098f63398e184a6630842e780"
 dependencies = [
  "calib-targets-core",
  "kiddo",
@@ -400,10 +400,11 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482c2ffa582b89e72417a544a8d2987f03a7b7eb8a5aa7ac204a6341643f4dc8"
+checksum = "92f9ad4b23e73fdb29124d26d74267f34686648181a919867431d2c89ea5eeea"
 dependencies = [
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -414,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac261ca1d918b7169bf7f61e6fe8c36eadea2390f857b39caeadfa4d1ec067e4"
+checksum = "4d74422dd07522178073cf222ed491e22064b1c03391aea4bd9c4b2b52a17c84"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -429,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ec99dee6408b1ac45b0dadd1d10b101292c635921c8422d22285072d80e6b9"
+checksum = "533ee6c6ba56e730254dc811a7099397e9d9c0c3b021f6ae8ccf80d8610d717f"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -446,13 +447,12 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3d29bff36af73f138aab4df9b01f36da913ba282e9ef8b6cd44ea5c2ceb106"
+checksum = "7edd0b32560c320d657250e9907b4bcdc1a0f88da95a40865a09a7dbb1b9f9fe"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
  "nalgebra",
  "projective-grid",
  "serde",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48621dcb7fc750c0c56563b604af9a9c4c74f482d1c81b004dbb86c67aafec04"
+checksum = "ec0f69e08802e9ec95a13a51f883c774d999d004fd866a1c4c14655edbd524af"
 dependencies = [
  "box-image-pyramid",
  "chess-corners-core",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c484dc3dc9736d59400c6439d27a81bdee9fcaa22bc8796f0ec573cf412e7d7"
+checksum = "c71f1f26caffa180c4574c220746db2655b77825cb8b34aaa6fe2f3a9b87a7b1"
 dependencies = [
  "log",
  "rayon",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-ml"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a943392ba88f9e418976030f720801b6e7268527a7ef1f9e22c7d907acd154e1"
+checksum = "b709a0831849b936ae970515c000cfa0ede4a2410db08263d4402d5aa79156ce"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -688,6 +688,15 @@ name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
+name = "delaunator"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1ee323c1275374f7e612d3724d12707079fb6a2117349fe144def656f5a880"
+dependencies = [
+ "robust",
+]
 
 [[package]]
 name = "deranged"
@@ -923,23 +932,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -952,13 +947,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1117,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "generativity"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5881e4c3c2433fe4905bb19cfd2b5d49d4248274862b68c27c33d9ba4e13f9ec"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
 name = "generator"
@@ -1340,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1398,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -1409,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1554,18 +1548,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1873,9 +1855,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -1948,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2054,7 +2036,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2125,12 +2107,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -2221,18 +2197,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2240,10 +2216,11 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b7ceeb3adc61de9a9cbf1e61952678e271a1e255f02872cb9166fcdfc5a8d6"
+checksum = "4821fcfd313fe1fbb525a156a0ee5360b7dcf89245348f1061ef89e7c127246b"
 dependencies = [
+ "delaunator",
  "kiddo",
  "nalgebra",
  "serde",
@@ -2619,15 +2596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2649,12 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rustfft"
@@ -3007,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3448,7 +3422,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "calib-targets",
- "chess-corners",
  "image",
  "nalgebra",
  "serde_json",
@@ -3488,7 +3461,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "calib-targets",
- "chess-corners",
  "image",
  "schemars",
  "serde",
@@ -3595,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3608,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3618,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3631,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = [
     "crates/vision-calibration-linear",
     "crates/vision-calibration-optim",
     "crates/vision-calibration-pipeline",
+    "crates/vision-calibration-dataset",
+    "crates/vision-calibration-detect",
+    "xtask",
 ]
 # `app/src-tauri/` is its own crate — it pulls in the Tauri build-time
 # dep tree and is built from `app/` (or via `npm run tauri dev`), not
@@ -32,6 +35,8 @@ vision-calibration-core = { path = "./crates/vision-calibration-core", version =
 vision-calibration-linear = { path = "./crates/vision-calibration-linear", version = "0.4.0" }
 vision-calibration-optim = { path = "./crates/vision-calibration-optim", version = "0.4.0" }
 vision-calibration-pipeline = { path = "./crates/vision-calibration-pipeline", version = "0.4.0" }
+vision-calibration-dataset = { path = "./crates/vision-calibration-dataset", version = "0.4.0" }
+vision-calibration-detect = { path = "./crates/vision-calibration-detect", version = "0.4.0" }
 
 anyhow = "1"
 thiserror = "2"
@@ -39,11 +44,13 @@ nalgebra = { version = "0.34", features = ["serde-serialize"] }
 num-dual = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+schemars = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 log = "0.4"
 image = { version = "0.25" }
 chess-corners = { version = "0.6", features = ["rayon", "ml-refiner"] }
 calib-targets = "0.7"
+glob = "0.3"
 rand = { version = "0.10" }
 tracing = { version = "0.1" }
 tiny-solver = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ schemars = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 log = "0.4"
 image = { version = "0.25" }
-chess-corners = { version = "0.6", features = ["rayon", "ml-refiner"] }
-calib-targets = "0.7"
+calib-targets = "0.8"
 glob = "0.3"
 rand = { version = "0.10" }
 tracing = { version = "0.1" }

--- a/app/bun.lock
+++ b/app/bun.lock
@@ -13,6 +13,7 @@
         "react-dom": "^19.2.5",
         "react-router-dom": "^7",
         "three": "^0.184.0",
+        "toml": "^4.1.1",
         "zustand": "^5",
       },
       "devDependencies": {
@@ -320,6 +321,8 @@
     "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
     "troika-three-text": ["troika-three-text@0.52.4", "", { "dependencies": { "bidi-js": "^1.0.2", "troika-three-utils": "^0.52.4", "troika-worker-utils": "^0.52.0", "webgl-sdf-generator": "1.1.1" }, "peerDependencies": { "three": ">=0.125.0" } }, "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.2.5",
     "react-router-dom": "^7",
     "three": "^0.184.0",
+    "toml": "^4.1.1",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -9,12 +9,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator 0.4.2",
 ]
 
 [[package]]
@@ -42,10 +72,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "anymap3"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "approx"
@@ -54,6 +146,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -102,6 +232,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,18 +294,39 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -141,6 +341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -159,6 +368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "box-image-pyramid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b98343f595652ccc4da8ba4bb349ed9ce9c77b0472bad0e9d0858295dd092e"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -181,6 +399,12 @@ dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -213,6 +437,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -249,11 +479,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "calib-targets"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ebcdd8eb12711dd4342f2b3d22e6b4a98a17eec53a2e6e6cb25aafcd6f47ea"
+dependencies = [
+ "calib-targets-aruco",
+ "calib-targets-charuco",
+ "calib-targets-chessboard",
+ "calib-targets-core",
+ "calib-targets-marker",
+ "calib-targets-print",
+ "calib-targets-puzzleboard",
+ "chess-corners",
+ "clap",
+ "image",
+ "nalgebra",
+ "projective-grid",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "calib-targets-aruco"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63cc01177982500442017ad4e8b7066bdf0901f2409f0d95abe5d5999215e75"
+dependencies = [
+ "calib-targets-core",
+ "log",
+ "nalgebra",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "calib-targets-charuco"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5faafed15f2c114f7430d326f1913a3b68ddf6892d4a2867842302420b524bc0"
+dependencies = [
+ "calib-targets-aruco",
+ "calib-targets-chessboard",
+ "calib-targets-core",
+ "chess-corners-core",
+ "log",
+ "nalgebra",
+ "projective-grid",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "calib-targets-chessboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d722baba1ddbe0c6b239b3054a7b593e66b560e4c831ed89a9b175fd9cff8268"
+dependencies = [
+ "calib-targets-core",
+ "kiddo",
+ "log",
+ "nalgebra",
+ "projective-grid",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "calib-targets-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f87430c0973312d043b80d4bff03a1da37574239d3778640cff67509b90b3d"
+dependencies = [
+ "log",
+ "nalgebra",
+ "projective-grid",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "calib-targets-marker"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4de16719bde92eab612d90a16733e404f04879b761994b60a396317c1335ca"
+dependencies = [
+ "calib-targets-chessboard",
+ "calib-targets-core",
+ "log",
+ "nalgebra",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "calib-targets-print"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52d8a8aed0aa2dad4f8555b5ee75665ab4d78a89fdcf2a67eda4c9a0bfea2ac"
+dependencies = [
+ "calib-targets-aruco",
+ "calib-targets-charuco",
+ "calib-targets-core",
+ "calib-targets-marker",
+ "calib-targets-puzzleboard",
+ "png 0.18.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "calib-targets-puzzleboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3290a2606df3c51300a36dff255bda5897d2545f846cc6df35f8eb24cd00a36c"
+dependencies = [
+ "calib-targets-chessboard",
+ "calib-targets-core",
+ "chess-corners-core",
+ "nalgebra",
+ "projective-grid",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "calibration-diagnose"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "dirs 5.0.1",
  "nalgebra",
  "serde",
  "serde_json",
@@ -262,6 +622,9 @@ dependencies = [
  "tauri-plugin-dialog",
  "vision-calibration",
  "vision-calibration-core",
+ "vision-calibration-dataset",
+ "vision-calibration-detect",
+ "vision-calibration-pipeline",
 ]
 
 [[package]]
@@ -313,6 +676,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -361,6 +726,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "chess-corners"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48621dcb7fc750c0c56563b604af9a9c4c74f482d1c81b004dbb86c67aafec04"
+dependencies = [
+ "box-image-pyramid",
+ "chess-corners-core",
+ "chess-corners-ml",
+ "image",
+ "log",
+ "rayon",
+ "serde",
+]
+
+[[package]]
+name = "chess-corners-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c484dc3dc9736d59400c6439d27a81bdee9fcaa22bc8796f0ec573cf412e7d7"
+dependencies = [
+ "log",
+ "rayon",
+ "serde",
+]
+
+[[package]]
+name = "chess-corners-ml"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a943392ba88f9e418976030f720801b6e7268527a7ef1f9e22c7d907acd154e1"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "tract-onnx",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +773,64 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -632,6 +1092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,11 +1135,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -679,7 +1171,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -705,6 +1197,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "divrem"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
 
 [[package]]
 name = "dlopen2"
@@ -735,7 +1233,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser",
  "foldhash 0.2.0",
  "html5ever",
@@ -743,6 +1241,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -794,6 +1298,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "dyn-stack"
@@ -907,6 +1417,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "faer"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +1462,7 @@ dependencies = [
  "private-gemm-x86",
  "pulp",
  "rand 0.9.4",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rayon",
  "reborrow",
  "spindle",
@@ -980,6 +1515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,10 +1540,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "flate2"
@@ -1426,6 +1991,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +2274,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1981,6 +2565,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,6 +2672,39 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2113,6 +2781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2836,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiddo"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5053bc2cb3ed5739b2ef170e00d40ecca487612fa0ee1535a912424ac18d2bb2"
+dependencies = [
+ "aligned-vec",
+ "array-init",
+ "az",
+ "cmov",
+ "divrem",
+ "fixed",
+ "generator",
+ "num-traits",
+ "ordered-float",
+ "sorted-vec",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2876,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libappindicator"
@@ -2209,6 +2923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,7 +2954,70 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "liquid"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a494c3f9dad3cb7ed16f1c51812cbe4b29493d6c2e5cd1e2b87477263d9534d"
+dependencies = [
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc623edee8a618b4543e8e8505584f4847a4e51b805db1af6d9af0a3395d0d57"
+dependencies = [
+ "anymap2",
+ "itertools 0.14.0",
+ "kstring",
+ "liquid-derive",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de66c928222984aea59fcaed8ba627f388aaac3c1f57dcb05cc25495ef8faefe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9befeedd61f5995bc128c571db65300aeb50d62e4f0542c88282dbcb5f72372a"
+dependencies = [
+ "itertools 0.14.0",
+ "liquid-core",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2268,6 +3055,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,10 +3100,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2337,6 +3158,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2477,6 +3308,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,6 +3351,39 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "npyz"
@@ -2553,6 +3432,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-dual"
@@ -2831,10 +3721,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "pango"
@@ -2879,7 +3784,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2889,6 +3794,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
@@ -3047,6 +3958,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +4000,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3123,6 +4055,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -3204,6 +4145,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "projective-grid"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d68e7e2b69d64b7e6a552dd98684d16d49e8dc468a0ad9badeccf51877a6b3"
+dependencies = [
+ "kiddo",
+ "nalgebra",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pulp"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3216,6 +4211,12 @@ dependencies = [
  "reborrow",
  "version_check",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "py_literal"
@@ -3241,6 +4242,21 @@ dependencies = [
  "num-traits",
  "pulp",
 ]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3278,6 +4294,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3287,7 +4305,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -3300,6 +4318,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3317,6 +4345,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3335,12 +4366,72 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
 ]
 
 [[package]]
@@ -3397,6 +4488,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3518,6 +4629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,6 +4647,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3548,12 +4692,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172dd94c5a87b5c79f945c863da53b2ebc7ccef4eca24ac63cca66a41aab2178"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -3857,6 +5020,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,12 +5071,18 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "sorted-vec"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f58d7b0190c7f12df7e8be6b79767a0836059159811b869d5ab55721fe14d0"
 
 [[package]]
 name = "soup3"
@@ -3950,6 +5128,29 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f9fdfdd31a0ff38b59deb401be81b73913d76c9cc5b1aed4e1330a223420b9"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "serde",
+]
 
 [[package]]
 name = "string_cache"
@@ -4113,6 +5314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,7 +5339,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4177,7 +5389,7 @@ checksum = "be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4449,6 +5661,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,6 +5730,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4704,7 +5945,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4747,13 +6000,166 @@ dependencies = [
 ]
 
 [[package]]
+name = "tract-core"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d67f5190132365dda73fe215bfc5e01b031e8cbfbea9d486bb5b0dbba3545"
+dependencies = [
+ "anyhow",
+ "anymap3",
+ "bit-set 0.5.3",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pastey",
+ "rustfft",
+ "smallvec",
+ "tract-data",
+ "tract-linalg",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd7fda1e5e8b854ea3abdd09126a87fc4af81e6d1e29ec1710a8a4abf4f13a"
+dependencies = [
+ "anyhow",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-hash",
+ "half",
+ "itertools 0.12.1",
+ "lazy_static",
+ "libm",
+ "maplit",
+ "ndarray",
+ "nom",
+ "nom-language",
+ "num-integer",
+ "num-traits",
+ "parking_lot",
+ "scan_fmt",
+ "smallvec",
+ "string-interner",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "554df991b647dba8af0547ee5838b6912ed20b424f2adda0ea0b7faf8db1b151"
+dependencies = [
+ "derive-new",
+ "log",
+ "tract-core",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72097a89cc4e7c5f1bc4f854b9294dd30fa6f6d8f7f409c556953b49078c94f"
+dependencies = [
+ "byteorder",
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-hash",
+ "half",
+ "lazy_static",
+ "liquid",
+ "liquid-core",
+ "liquid-derive",
+ "log",
+ "num-traits",
+ "pastey",
+ "scan_fmt",
+ "smallvec",
+ "time",
+ "tract-data",
+ "unicode-normalization",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b3755dd0948111b407085d11033ba218cb85b85ce8d795cec2b8353db552ea"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "liquid",
+ "liquid-core",
+ "log",
+ "nom",
+ "nom-language",
+ "safetensors",
+ "serde_json",
+ "tar",
+ "tract-core",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac23ad1d2d5da3256ae1a78757b1072a8a3fac2a4b28d27cfb561c5942ec2701"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "log",
+ "memmap2",
+ "num-integer",
+ "prost",
+ "smallvec",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87561bf0b84f74a124afc0f1997682728da6cd821083511e0357432954fd24f6"
+dependencies = [
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.6",
+ "rand_distr 0.4.3",
+ "rustfft",
+ "tract-nnef",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4840,6 +6246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4889,6 +6304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4897,6 +6318,17 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -4941,6 +6373,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "vision-calibration-dataset"
+version = "0.4.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vision-calibration-detect"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "calib-targets",
+ "chess-corners",
+ "image",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "vision-calibration-linear"
 version = "0.4.0"
 dependencies = [
@@ -4971,11 +6425,15 @@ name = "vision-calibration-pipeline"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "glob",
+ "image",
  "nalgebra",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "vision-calibration-core",
+ "vision-calibration-dataset",
+ "vision-calibration-detect",
  "vision-calibration-linear",
  "vision-calibration-optim",
 ]
@@ -5248,6 +6706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,6 +6932,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5506,6 +6979,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5567,6 +7055,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5585,6 +7079,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5600,6 +7100,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5633,6 +7139,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5648,6 +7160,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5669,6 +7187,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5684,6 +7208,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5841,7 +7371,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -5895,6 +7425,22 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -5998,3 +7544,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "dirs 5.0.1",
+ "image",
  "nalgebra",
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b98343f595652ccc4da8ba4bb349ed9ce9c77b0472bad0e9d0858295dd092e"
+checksum = "87aa24dde918ca16f7456406a93fe76918ba55cc78fbd7b8aac42cf41810afc5"
 dependencies = [
  "rayon",
 ]
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ebcdd8eb12711dd4342f2b3d22e6b4a98a17eec53a2e6e6cb25aafcd6f47ea"
+checksum = "1db8d8448709b972efa2ef7efd8b4738cf06971713c837bc9c0082a98f57b4d5"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63cc01177982500442017ad4e8b7066bdf0901f2409f0d95abe5d5999215e75"
+checksum = "d990b6bd5696a0ab2b322a81d2e4d5148dc84d629e57977638637afd8991fc88"
 dependencies = [
  "calib-targets-core",
  "log",
@@ -514,14 +514,14 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5faafed15f2c114f7430d326f1913a3b68ddf6892d4a2867842302420b524bc0"
+checksum = "7af66c739d481175bdd12e7d16ee7aadc67165b0d2c7bcebe5456eb240c6789b"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d722baba1ddbe0c6b239b3054a7b593e66b560e4c831ed89a9b175fd9cff8268"
+checksum = "163b2769a687f46e681dafccb409d21feec422b098f63398e184a6630842e780"
 dependencies = [
  "calib-targets-core",
  "kiddo",
@@ -547,10 +547,11 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f87430c0973312d043b80d4bff03a1da37574239d3778640cff67509b90b3d"
+checksum = "92f9ad4b23e73fdb29124d26d74267f34686648181a919867431d2c89ea5eeea"
 dependencies = [
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -561,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4de16719bde92eab612d90a16733e404f04879b761994b60a396317c1335ca"
+checksum = "4d74422dd07522178073cf222ed491e22064b1c03391aea4bd9c4b2b52a17c84"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -576,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52d8a8aed0aa2dad4f8555b5ee75665ab4d78a89fdcf2a67eda4c9a0bfea2ac"
+checksum = "533ee6c6ba56e730254dc811a7099397e9d9c0c3b021f6ae8ccf80d8610d717f"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -593,13 +594,12 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3290a2606df3c51300a36dff255bda5897d2545f846cc6df35f8eb24cd00a36c"
+checksum = "7edd0b32560c320d657250e9907b4bcdc1a0f88da95a40865a09a7dbb1b9f9fe"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
  "nalgebra",
  "projective-grid",
  "serde",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48621dcb7fc750c0c56563b604af9a9c4c74f482d1c81b004dbb86c67aafec04"
+checksum = "ec0f69e08802e9ec95a13a51f883c774d999d004fd866a1c4c14655edbd524af"
 dependencies = [
  "box-image-pyramid",
  "chess-corners-core",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c484dc3dc9736d59400c6439d27a81bdee9fcaa22bc8796f0ec573cf412e7d7"
+checksum = "c71f1f26caffa180c4574c220746db2655b77825cb8b34aaa6fe2f3a9b87a7b1"
 dependencies = [
  "log",
  "rayon",
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-ml"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a943392ba88f9e418976030f720801b6e7268527a7ef1f9e22c7d907acd154e1"
+checksum = "b709a0831849b936ae970515c000cfa0ede4a2410db08263d4402d5aa79156ce"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1081,6 +1081,15 @@ name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
+name = "delaunator"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1ee323c1275374f7e612d3724d12707079fb6a2117349fe144def656f5a880"
+dependencies = [
+ "robust",
+]
 
 [[package]]
 name = "deranged"
@@ -4166,10 +4175,11 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d68e7e2b69d64b7e6a552dd98684d16d49e8dc468a0ad9badeccf51877a6b3"
+checksum = "4821fcfd313fe1fbb525a156a0ee5360b7dcf89245348f1061ef89e7c127246b"
 dependencies = [
+ "delaunator",
  "kiddo",
  "nalgebra",
  "serde",
@@ -4634,6 +4644,12 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rustc-hash"
@@ -6388,7 +6404,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "calib-targets",
- "chess-corners",
  "image",
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ anyhow = "1"
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
 vision-calibration = { path = "../../crates/vision-calibration" }
 vision-calibration-core = { path = "../../crates/vision-calibration-core" }
+vision-calibration-pipeline = { path = "../../crates/vision-calibration-pipeline" }
+vision-calibration-dataset = { path = "../../crates/vision-calibration-dataset" }
+vision-calibration-detect = { path = "../../crates/vision-calibration-detect" }
+dirs = "5"
 
 [features]
 # Avoid touching the embed_plist build hooks unless explicitly running

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 base64 = "0.22"
 anyhow = "1"
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
+image = "0.25"
 vision-calibration = { path = "../../crates/vision-calibration" }
 vision-calibration-core = { path = "../../crates/vision-calibration-core" }
 vision-calibration-pipeline = { path = "../../crates/vision-calibration-pipeline" }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -10,6 +10,7 @@ use base64::Engine;
 use serde::Serialize;
 use std::path::PathBuf;
 use tauri::State;
+use vision_calibration_core::PixelRect;
 
 use crate::epipolar::{self, EpipolarOverlay};
 use crate::export_cache::ExportCache;
@@ -91,6 +92,37 @@ pub async fn load_image(path: String) -> Result<String, String> {
     Ok(format!("data:{mime};base64,{b64}"))
 }
 
+/// Read an image file and render it into a camera's undistorted pixel
+/// frame. This is only used by the Epipolar workspace; Diagnose keeps
+/// showing the raw source image.
+#[tauri::command]
+pub async fn load_undistorted_image(
+    path: String,
+    camera: usize,
+    roi: Option<PixelRect>,
+    cache: State<'_, ExportCache>,
+) -> Result<String, String> {
+    let path_buf = PathBuf::from(&path);
+    let bytes = cache
+        .read(|cached| epipolar::undistort_image_png(&cached.value, &path_buf, camera, roi))
+        .ok_or_else(|| "no export loaded yet".to_string())??;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:image/png;base64,{b64}"))
+}
+
+/// Map raw/distorted camera pixels into the undistorted pixel frame
+/// used by the Epipolar workspace.
+#[tauri::command]
+pub async fn undistort_points(
+    camera: usize,
+    points_px: Vec<[f64; 2]>,
+    cache: State<'_, ExportCache>,
+) -> Result<Vec<[f64; 2]>, String> {
+    cache
+        .read(|cached| epipolar::undistort_points(&cached.value, camera, points_px))
+        .ok_or_else(|| "no export loaded yet".to_string())?
+}
+
 /// Compute the epipolar polyline + epipole for a click in pane A.
 ///
 /// Reads the most recently loaded export from [`ExportCache`] (no disk
@@ -109,6 +141,31 @@ pub async fn compute_epipolar_overlay(
 ) -> Result<EpipolarOverlay, String> {
     cache
         .read(|cached| epipolar::compute_overlay(&cached.value, cam_a, cam_b, point_px))
+        .ok_or_else(|| "no export loaded yet".to_string())?
+}
+
+/// Compute a clipped straight epipolar segment in cam-B's undistorted
+/// image frame. `point_px` is in cam-A's undistorted pixel frame.
+#[tauri::command]
+pub async fn compute_epipolar_overlay_undistorted(
+    cam_a: usize,
+    cam_b: usize,
+    point_px: [f64; 2],
+    image_width_b: f64,
+    image_height_b: f64,
+    cache: State<'_, ExportCache>,
+) -> Result<EpipolarOverlay, String> {
+    cache
+        .read(|cached| {
+            epipolar::compute_overlay_undistorted(
+                &cached.value,
+                cam_a,
+                cam_b,
+                point_px,
+                image_width_b,
+                image_height_b,
+            )
+        })
         .ok_or_else(|| "no export loaded yet".to_string())?
 }
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -69,6 +69,17 @@ pub async fn set_active_export(
     Ok(())
 }
 
+/// Read a UTF-8 text file (TOML / JSON / arbitrary text) and return
+/// its contents. Used by the Run workspace's preset loader to fetch
+/// `data/<dataset>/dataset.toml` files at runtime so they round-trip
+/// to the form state via the same TOML→Manifest decoder the Rust
+/// runner uses. Errors carry the path so the UI can surface them
+/// directly.
+#[tauri::command]
+pub async fn load_text_file(path: String) -> Result<String, String> {
+    std::fs::read_to_string(&path).map_err(|e| format!("read {path}: {e}"))
+}
+
 /// Read an image file and return it as a `data:` URL the webview can use
 /// directly. PNG is the only format the v0 fixture writes; the MIME type
 /// is inferred from the extension.

--- a/app/src-tauri/src/epipolar.rs
+++ b/app/src-tauri/src/epipolar.rs
@@ -29,6 +29,14 @@ const DEPTH_SAMPLES: usize = 256;
 /// 130×130 working volume and shorter benchtop calibrations.
 const DEPTH_MIN_M: f64 = 0.05;
 const DEPTH_MAX_M: f64 = 5.0;
+/// Cutoff for cam-B-frame z below which we drop the sample. Even
+/// though `project_point_c` already filters strictly behind-camera
+/// points (`z <= 0`), depth samples that land *just* in front of cam
+/// B's image plane produce near-singular projections that fly off
+/// across the frame between consecutive samples — visually a fold /
+/// "parabola" in pane B. 5 cm is past the lens minimum focus on
+/// every dataset we ship; anything closer is meaningless geometry.
+const CAM_B_Z_MIN_M: f64 = 0.05;
 
 /// Result of a single epipolar overlay computation.
 #[derive(Debug, Clone, Serialize)]
@@ -105,6 +113,13 @@ pub fn compute_overlay(
     for d in log_depths() {
         let p_a = Point3::from(ray_a.point * d);
         let p_b = t_b_a * p_a;
+        // Pre-filter near-singular samples: in-front of cam B but so
+        // close to its image plane that the projection effectively
+        // jumps across the frame between this sample and the next.
+        if p_b.z < CAM_B_Z_MIN_M {
+            samples_clipped += 1;
+            continue;
+        }
         match cam_b_model.project_point_c(&p_b.coords) {
             Some(px) => line_b.push([px.x, px.y]),
             None => samples_clipped += 1,
@@ -286,5 +301,58 @@ mod tests {
         assert_eq!(depths.len(), DEPTH_SAMPLES);
         assert!((depths[0] - DEPTH_MIN_M).abs() < 1e-12);
         assert!((depths[DEPTH_SAMPLES - 1] - DEPTH_MAX_M).abs() < 1e-9);
+    }
+
+    /// Regression guard for the "parabola in pane B" fold bug. When
+    /// cam B is positioned so that early depth samples on cam A's ray
+    /// land less than `CAM_B_Z_MIN_M` in front of cam B's image plane,
+    /// `compute_overlay` must drop those samples (counted in
+    /// `samples_clipped`) so the polyline doesn't fork through the
+    /// near-singular projection zone.
+    ///
+    /// Construction: cam A at rig origin (`T_A_R = I`); cam B has the
+    /// same orientation as cam A but is offset so that a forward ray
+    /// from cam A's principal pixel maps to `p_b = (0, 0, d - 0.04)`
+    /// in cam B's frame. With the depth sweep starting at `d = 0.05`,
+    /// the smallest sample produces `p_b.z = 0.01 m`, which is well
+    /// below the `CAM_B_Z_MIN_M = 0.05` cutoff and must be dropped.
+    /// Samples at `d > 0.09` survive and form a usable polyline.
+    #[test]
+    fn overlay_drops_near_image_plane_samples() {
+        let k = K {
+            fx: 800.0,
+            fy: 800.0,
+            cx: 320.0,
+            cy: 240.0,
+            skew: 0.0,
+        };
+        let cam = make_pinhole_camera(k, BC5::default());
+        let t_a_r = Iso3::identity();
+        // Translation only — rotation is identity so cam B's forward
+        // axis aligns with cam A's. Translating (0, 0, -0.04) in
+        // T_B_R means cam B sits 4 cm further along Z than the rig
+        // origin (i.e. than cam A): a forward ray's `p_b.z` equals
+        // `d - 0.04`.
+        let t_b_r = Iso3::from_parts(
+            nalgebra::Translation3::new(0.0, 0.0, -0.04),
+            nalgebra::UnitQuaternion::identity(),
+        );
+        let export = serde_json::json!({
+            "cameras": [serde_json::to_value(&cam).unwrap(), serde_json::to_value(&cam).unwrap()],
+            "cam_se3_rig": [t_a_r, t_b_r],
+        });
+        // Click at cam A's principal point → back-projected ray is
+        // along the optical axis.
+        let overlay = compute_overlay(&export, 0, 1, [320.0, 240.0]).unwrap();
+        assert!(
+            overlay.samples_clipped > 0,
+            "expected the near-image-plane cutoff to drop at least one sample; got 0 clipped"
+        );
+        // Polyline should still have a non-trivial run after the cutoff.
+        assert!(
+            overlay.line_b.len() > 4,
+            "expected a usable polyline after the cutoff; got {}",
+            overlay.line_b.len()
+        );
     }
 }

--- a/app/src-tauri/src/epipolar.rs
+++ b/app/src-tauri/src/epipolar.rs
@@ -9,10 +9,12 @@
 //! "is the calibration wrong or is the viz wrong" moment becomes a
 //! science fair.
 
+use image::{DynamicImage, Rgba, RgbaImage};
 use nalgebra::{Point2, Point3, Vector3};
 use serde::Serialize;
+use std::{io::Cursor, path::Path};
 use vision_calibration::core::{
-    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams, Iso3,
+    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams, Iso3, PixelRect,
     ProjectionParams, ScheimpflugParams, SensorParams,
 };
 use vision_calibration_core::CameraModel;
@@ -141,6 +143,149 @@ pub fn compute_overlay(
     })
 }
 
+/// Convert raw/distorted pixel coordinates into the undistorted pixel
+/// frame used by the epipolar workspace. The output keeps the camera's
+/// original `K` scale/center but removes distortion and sensor warping.
+pub fn undistort_points(
+    export: &serde_json::Value,
+    camera: usize,
+    points_px: Vec<[f64; 2]>,
+) -> Result<Vec<[f64; 2]>, String> {
+    let geometry = camera_geometry(export, camera)?;
+    Ok(points_px
+        .iter()
+        .map(|p| raw_pixel_to_undistorted_pixel(&geometry, *p))
+        .collect())
+}
+
+/// Decode an image and render it into the undistorted pixel frame for
+/// `camera`. If `roi` is present, the source image is sampled from that
+/// source rectangle while the output dimensions remain ROI-local.
+pub fn undistort_image_png(
+    export: &serde_json::Value,
+    path: &Path,
+    camera: usize,
+    roi: Option<PixelRect>,
+) -> Result<Vec<u8>, String> {
+    let geometry = camera_geometry(export, camera)?;
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let src = image::load_from_memory(&bytes)
+        .map_err(|e| format!("decode {}: {e}", path.display()))?
+        .to_rgba8();
+    let (out_w, out_h) = match roi {
+        Some(r) => (r.w, r.h),
+        None => (src.width(), src.height()),
+    };
+    if out_w == 0 || out_h == 0 {
+        return Err("undistorted image dimensions must be non-zero".to_string());
+    }
+
+    let mut out = RgbaImage::new(out_w, out_h);
+    let offset_x = roi.map_or(0.0, |r| r.x as f64);
+    let offset_y = roi.map_or(0.0, |r| r.y as f64);
+    for y in 0..out_h {
+        for x in 0..out_w {
+            let raw = undistorted_pixel_to_raw_pixel(&geometry, [x as f64, y as f64]);
+            let Some(raw) = raw else {
+                out.put_pixel(x, y, Rgba([0, 0, 0, 255]));
+                continue;
+            };
+            let sample = sample_bilinear(&src, raw[0] + offset_x, raw[1] + offset_y);
+            out.put_pixel(x, y, sample);
+        }
+    }
+
+    let mut cursor = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(out)
+        .write_to(&mut cursor, image::ImageFormat::Png)
+        .map_err(|e| format!("encode undistorted PNG: {e}"))?;
+    Ok(cursor.into_inner())
+}
+
+/// Compute a straight epipolar line in cam-B's undistorted pixel frame.
+///
+/// `point_px` is already in cam-A's undistorted pixel frame. Returned
+/// `line_b` contains zero or two clipped endpoints in cam-B's
+/// undistorted pixel frame.
+pub fn compute_overlay_undistorted(
+    export: &serde_json::Value,
+    cam_a: usize,
+    cam_b: usize,
+    point_px: [f64; 2],
+    image_width_b: f64,
+    image_height_b: f64,
+) -> Result<EpipolarOverlay, String> {
+    if !(image_width_b.is_finite() && image_height_b.is_finite())
+        || image_width_b <= 0.0
+        || image_height_b <= 0.0
+    {
+        return Err("cam-B image dimensions must be finite and positive".to_string());
+    }
+
+    let cameras = export
+        .get("cameras")
+        .and_then(|v| v.as_array())
+        .ok_or("export has no `cameras` array (rig exports only)")?;
+    let cam_se3_rig: Vec<Iso3> = serde_json::from_value(
+        export
+            .get("cam_se3_rig")
+            .ok_or("export has no `cam_se3_rig`")?
+            .clone(),
+    )
+    .map_err(|e| format!("cam_se3_rig decode: {e}"))?;
+    let n = cameras.len();
+    if cam_a >= n || cam_b >= n {
+        return Err(format!(
+            "camera index out of range (cam_a={cam_a}, cam_b={cam_b}, num_cameras={n})"
+        ));
+    }
+    if cam_se3_rig.len() != n {
+        return Err(format!(
+            "cam_se3_rig length {} does not match cameras length {n}",
+            cam_se3_rig.len()
+        ));
+    }
+
+    let cam_a_geometry = camera_geometry(export, cam_a)?;
+    let cam_b_geometry = camera_geometry(export, cam_b)?;
+    let ray_a = undistorted_pixel_to_ray(&cam_a_geometry.k, point_px);
+    let t_b_a = cam_se3_rig[cam_b] * cam_se3_rig[cam_a].inverse();
+
+    let mut samples_clipped = 0usize;
+    let mut first: Option<[f64; 2]> = None;
+    let mut last: Option<[f64; 2]> = None;
+    for d in log_depths() {
+        let p_a = Point3::from(ray_a * d);
+        let p_b = t_b_a * p_a;
+        if p_b.z < CAM_B_Z_MIN_M {
+            samples_clipped += 1;
+            continue;
+        }
+        let Some(px) = project_undistorted_camera_point(&cam_b_geometry.k, &p_b.coords) else {
+            samples_clipped += 1;
+            continue;
+        };
+        if first.is_none() {
+            first = Some(px);
+        }
+        last = Some(px);
+    }
+
+    let line_b = match (first, last) {
+        (Some(a), Some(b)) => clip_line_to_image(a, b, image_width_b, image_height_b),
+        _ => Vec::new(),
+    };
+
+    let origin_b = t_b_a * Point3::<f64>::origin();
+    let epipole_b = project_undistorted_camera_point(&cam_b_geometry.k, &origin_b.coords);
+
+    Ok(EpipolarOverlay {
+        line_b,
+        epipole_b,
+        samples_clipped,
+    })
+}
+
 /// Logarithmically-spaced depths from `DEPTH_MIN_M` to `DEPTH_MAX_M`.
 fn log_depths() -> impl Iterator<Item = f64> {
     let ratio = DEPTH_MAX_M / DEPTH_MIN_M;
@@ -156,6 +301,36 @@ fn build_camera(
     camera_json: &serde_json::Value,
     sensor: Option<&ScheimpflugParams>,
 ) -> Result<CameraModel, String> {
+    Ok(build_camera_geometry(camera_json, sensor)?.model)
+}
+
+#[derive(Clone, Debug)]
+struct CameraGeometry {
+    model: CameraModel,
+    k: FxFyCxCySkew<f64>,
+}
+
+fn camera_geometry(export: &serde_json::Value, camera: usize) -> Result<CameraGeometry, String> {
+    let cameras = export
+        .get("cameras")
+        .and_then(|v| v.as_array())
+        .ok_or("export has no `cameras` array (rig exports only)")?;
+    let n = cameras.len();
+    if camera >= n {
+        return Err(format!(
+            "camera index out of range (camera={camera}, num_cameras={n})"
+        ));
+    }
+    let sensors = parse_sensors(export)?;
+    let sensor_for =
+        |idx: usize| -> Option<&ScheimpflugParams> { sensors.as_ref()?.get(idx)?.as_ref() };
+    build_camera_geometry(&cameras[camera], sensor_for(camera))
+}
+
+fn build_camera_geometry(
+    camera_json: &serde_json::Value,
+    sensor: Option<&ScheimpflugParams>,
+) -> Result<CameraGeometry, String> {
     let k: FxFyCxCySkew<f64> = serde_json::from_value(
         camera_json
             .get("k")
@@ -182,7 +357,10 @@ fn build_camera(
         sensor: sensor_params,
         intrinsics: IntrinsicsParams::FxFyCxCySkew { params: k },
     };
-    Ok(params.build())
+    Ok(CameraGeometry {
+        model: params.build(),
+        k,
+    })
 }
 
 /// Parse the optional `sensors` array. None when the export is a pinhole
@@ -217,6 +395,124 @@ fn parse_sensors(
 /// the current single-call shape.
 #[allow(dead_code)]
 type V3 = Vector3<f64>;
+
+fn raw_pixel_to_undistorted_pixel(geometry: &CameraGeometry, px: [f64; 2]) -> [f64; 2] {
+    let ray = geometry.model.backproject_pixel(&Point2::new(px[0], px[1]));
+    normalized_to_pixel(&geometry.k, ray.point.x, ray.point.y)
+}
+
+fn undistorted_pixel_to_raw_pixel(geometry: &CameraGeometry, px: [f64; 2]) -> Option<[f64; 2]> {
+    let ray = undistorted_pixel_to_ray(&geometry.k, px);
+    geometry
+        .model
+        .project_point_c(&ray)
+        .map(|p| [p.x, p.y])
+        .filter(|p| p[0].is_finite() && p[1].is_finite())
+}
+
+fn undistorted_pixel_to_ray(k: &FxFyCxCySkew<f64>, px: [f64; 2]) -> Vector3<f64> {
+    let y = (px[1] - k.cy) / k.fy;
+    let x = (px[0] - k.cx - k.skew * y) / k.fx;
+    Vector3::new(x, y, 1.0)
+}
+
+fn project_undistorted_camera_point(k: &FxFyCxCySkew<f64>, p_c: &Vector3<f64>) -> Option<[f64; 2]> {
+    if p_c.z <= 0.0 {
+        return None;
+    }
+    let x = p_c.x / p_c.z;
+    let y = p_c.y / p_c.z;
+    let px = normalized_to_pixel(k, x, y);
+    if px[0].is_finite() && px[1].is_finite() {
+        Some(px)
+    } else {
+        None
+    }
+}
+
+fn normalized_to_pixel(k: &FxFyCxCySkew<f64>, x: f64, y: f64) -> [f64; 2] {
+    [k.fx * x + k.skew * y + k.cx, k.fy * y + k.cy]
+}
+
+fn clip_line_to_image(a: [f64; 2], b: [f64; 2], w: f64, h: f64) -> Vec<[f64; 2]> {
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    let mut pts: Vec<[f64; 2]> = Vec::with_capacity(4);
+    let eps = 1e-9;
+
+    if dx.abs() > eps {
+        for x in [0.0, w] {
+            let t = (x - a[0]) / dx;
+            let y = a[1] + t * dy;
+            if y >= -eps && y <= h + eps {
+                push_unique(&mut pts, [x, y.clamp(0.0, h)]);
+            }
+        }
+    }
+    if dy.abs() > eps {
+        for y in [0.0, h] {
+            let t = (y - a[1]) / dy;
+            let x = a[0] + t * dx;
+            if x >= -eps && x <= w + eps {
+                push_unique(&mut pts, [x.clamp(0.0, w), y]);
+            }
+        }
+    }
+
+    if pts.len() <= 2 {
+        return pts;
+    }
+
+    let mut best = (0usize, 1usize, -1.0f64);
+    for i in 0..pts.len() {
+        for j in (i + 1)..pts.len() {
+            let d2 = (pts[i][0] - pts[j][0]).powi(2) + (pts[i][1] - pts[j][1]).powi(2);
+            if d2 > best.2 {
+                best = (i, j, d2);
+            }
+        }
+    }
+    vec![pts[best.0], pts[best.1]]
+}
+
+fn push_unique(pts: &mut Vec<[f64; 2]>, p: [f64; 2]) {
+    if pts
+        .iter()
+        .any(|q| (q[0] - p[0]).abs() < 1e-7 && (q[1] - p[1]).abs() < 1e-7)
+    {
+        return;
+    }
+    pts.push(p);
+}
+
+fn sample_bilinear(src: &RgbaImage, x: f64, y: f64) -> Rgba<u8> {
+    if !x.is_finite()
+        || !y.is_finite()
+        || x < 0.0
+        || y < 0.0
+        || x > (src.width().saturating_sub(1)) as f64
+        || y > (src.height().saturating_sub(1)) as f64
+    {
+        return Rgba([0, 0, 0, 255]);
+    }
+    let x0 = x.floor() as u32;
+    let y0 = y.floor() as u32;
+    let x1 = (x0 + 1).min(src.width() - 1);
+    let y1 = (y0 + 1).min(src.height() - 1);
+    let tx = x - x0 as f64;
+    let ty = y - y0 as f64;
+    let p00 = src.get_pixel(x0, y0).0;
+    let p10 = src.get_pixel(x1, y0).0;
+    let p01 = src.get_pixel(x0, y1).0;
+    let p11 = src.get_pixel(x1, y1).0;
+    let mut out = [0u8; 4];
+    for c in 0..4 {
+        let top = p00[c] as f64 * (1.0 - tx) + p10[c] as f64 * tx;
+        let bottom = p01[c] as f64 * (1.0 - tx) + p11[c] as f64 * tx;
+        out[c] = (top * (1.0 - ty) + bottom * ty).round().clamp(0.0, 255.0) as u8;
+    }
+    Rgba(out)
+}
 
 #[cfg(test)]
 mod tests {
@@ -354,5 +650,151 @@ mod tests {
             "expected a usable polyline after the cutoff; got {}",
             overlay.line_b.len()
         );
+    }
+
+    #[test]
+    fn undistorted_pixel_roundtrip_matches_raw_camera_frame() {
+        let export = stereo_like_export();
+        let geometry = camera_geometry(&export, 1).unwrap();
+
+        for raw in [[575.3, 108.2], [345.0, 500.0], [900.0, 220.0]] {
+            let undistorted = raw_pixel_to_undistorted_pixel(&geometry, raw);
+            let raw_roundtrip = undistorted_pixel_to_raw_pixel(&geometry, undistorted).unwrap();
+            let err =
+                ((raw_roundtrip[0] - raw[0]).powi(2) + (raw_roundtrip[1] - raw[1]).powi(2)).sqrt();
+            assert!(
+                err < 0.1,
+                "raw→undistorted→raw roundtrip drifted by {err:.4} px for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn raw_distorted_overlay_can_fold_but_undistorted_overlay_is_clipped_line() {
+        let export = stereo_like_export();
+        let raw_left_px = [358.4, 126.9];
+        let raw_right_px = [575.3, 108.2];
+
+        let raw = compute_overlay(&export, 0, 1, raw_left_px).unwrap();
+        let raw_runs = in_bounds_runs(&raw.line_b, 1024.0, 768.0, 192.0);
+        assert!(
+            raw_runs >= 2,
+            "expected raw distorted depth samples to split into multiple visible runs"
+        );
+
+        let point_a = undistort_points(&export, 0, vec![raw_left_px]).unwrap()[0];
+        let point_b = undistort_points(&export, 1, vec![raw_right_px]).unwrap()[0];
+        let undistorted =
+            compute_overlay_undistorted(&export, 0, 1, point_a, 1024.0, 768.0).unwrap();
+        assert_eq!(
+            undistorted.line_b.len(),
+            2,
+            "undistorted overlay should be represented by clipped endpoints"
+        );
+        for p in &undistorted.line_b {
+            assert!(
+                p[0] >= 0.0 && p[0] <= 1024.0 && p[1] >= 0.0 && p[1] <= 768.0,
+                "endpoint outside image bounds: {p:?}"
+            );
+        }
+        let dist = distance_to_segment(point_b, undistorted.line_b[0], undistorted.line_b[1]);
+        assert!(
+            dist < 3.0,
+            "corresponding feature should remain close to the undistorted epipolar line; got {dist:.3} px"
+        );
+    }
+
+    fn stereo_like_export() -> serde_json::Value {
+        serde_json::json!({
+            "cameras": [
+                {
+                    "k": {
+                        "fx": 713.8456995546412,
+                        "fy": 724.6690645729575,
+                        "cx": 523.4129016186437,
+                        "cy": 285.9522601918888,
+                        "skew": 0.0
+                    },
+                    "dist": {
+                        "k1": 0.015021094581498156,
+                        "k2": -0.07151318797378012,
+                        "k3": 0.0,
+                        "p1": 0.0006183511614000294,
+                        "p2": 0.0002526916716399372,
+                        "iters": 8
+                    }
+                },
+                {
+                    "k": {
+                        "fx": 724.7966090646895,
+                        "fy": 735.5984809398797,
+                        "cx": 513.9329313241342,
+                        "cy": 292.95508592356225,
+                        "skew": 0.0
+                    },
+                    "dist": {
+                        "k1": 0.00113846407979313,
+                        "k2": -0.0525607289860634,
+                        "k3": 0.0,
+                        "p1": -0.0014292429046042455,
+                        "p2": 0.0014269862041345035,
+                        "iters": 8
+                    }
+                }
+            ],
+            "cam_se3_rig": [
+                {
+                    "rotation": [0.0, 0.0, 0.0, 1.0],
+                    "translation": [0.0, 0.0, 0.0]
+                },
+                {
+                    "rotation": [
+                        0.013175949007657478,
+                        -0.01753553695143165,
+                        -0.004069965919389522,
+                        0.9997511363779427
+                    ],
+                    "translation": [
+                        0.1892859214228441,
+                        -0.004507939830404787,
+                        0.010062154737396994
+                    ]
+                }
+            ]
+        })
+    }
+
+    fn in_bounds_runs(pts: &[[f64; 2]], w: f64, h: f64, jump_px: f64) -> usize {
+        let mut runs = 0usize;
+        let mut prev: Option<[f64; 2]> = None;
+        for p in pts {
+            let in_bounds = p[0] >= 0.0 && p[0] <= w && p[1] >= 0.0 && p[1] <= h;
+            if !in_bounds {
+                prev = None;
+                continue;
+            }
+            if let Some(prev_p) = prev {
+                let jump = ((p[0] - prev_p[0]).powi(2) + (p[1] - prev_p[1]).powi(2)).sqrt();
+                if jump > jump_px {
+                    runs += 1;
+                }
+            } else {
+                runs += 1;
+            }
+            prev = Some(*p);
+        }
+        runs
+    }
+
+    fn distance_to_segment(p: [f64; 2], a: [f64; 2], b: [f64; 2]) -> f64 {
+        let abx = b[0] - a[0];
+        let aby = b[1] - a[1];
+        let len_sq = abx * abx + aby * aby;
+        if len_sq == 0.0 {
+            return ((p[0] - a[0]).powi(2) + (p[1] - a[1]).powi(2)).sqrt();
+        }
+        let t = (((p[0] - a[0]) * abx + (p[1] - a[1]) * aby) / len_sq).clamp(0.0, 1.0);
+        let q = [a[0] + t * abx, a[1] + t * aby];
+        ((p[0] - q[0]).powi(2) + (p[1] - q[1]).powi(2)).sqrt()
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run() {
             commands::load_export,
             commands::set_active_export,
             commands::load_image,
+            commands::load_text_file,
             commands::compute_epipolar_overlay,
             run::run_calibration_cmd,
         ])

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -17,11 +17,12 @@
 mod commands;
 mod epipolar;
 mod export_cache;
+mod run;
 
 use export_cache::ExportCache;
 
 /// Entry point invoked from `main.rs`. Wires up the dialog plugin, the
-/// shared export cache, and the viewer + math commands.
+/// shared export cache, and the viewer + math + runner commands.
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -31,6 +32,7 @@ pub fn run() {
             commands::set_active_export,
             commands::load_image,
             commands::compute_epipolar_overlay,
+            run::run_calibration_cmd,
         ])
         .run(tauri::generate_context!())
         .expect("failed to launch calibration-diagnose");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -31,8 +31,11 @@ pub fn run() {
             commands::load_export,
             commands::set_active_export,
             commands::load_image,
+            commands::load_undistorted_image,
             commands::load_text_file,
             commands::compute_epipolar_overlay,
+            commands::compute_epipolar_overlay_undistorted,
+            commands::undistort_points,
             run::run_calibration_cmd,
         ])
         .run(tauri::generate_context!())

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -1,0 +1,269 @@
+//! In-process calibration runner for the Run workspace (B3b).
+//!
+//! Takes a JSON-encoded [`DatasetSpec`] manifest plus a JSON-encoded
+//! per-problem `*Config`, dispatches to the right `CalibrationSession`,
+//! runs detection (cached) + calibration on a `tauri::async_runtime::spawn_blocking`
+//! task, and returns the export plus a structured log. PR 1 wires up
+//! `PlanarIntrinsics` only; PR 2 (B3c) extends to the other 7 topologies
+//! via the same shape.
+//!
+//! Per ADR 0019, ambiguity that the runtime cannot auto-resolve is
+//! surfaced as a structured `RunResponse::AskUser` so the Run workspace
+//! can render a blocking modal instead of silently guessing.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use vision_calibration_dataset::{DatasetSpec, Topology};
+use vision_calibration_detect::FsDetectionCache;
+use vision_calibration_pipeline::dataset_runner::{RunError, build_planar_input};
+use vision_calibration_pipeline::planar_intrinsics::{
+    PlanarIntrinsicsConfig, PlanarIntrinsicsProblem, run_calibration,
+};
+use vision_calibration_pipeline::session::CalibrationSession;
+
+use crate::export_cache::ExportCache;
+
+/// Successful calibration run.
+#[derive(Serialize, Deserialize)]
+pub struct RunSuccess {
+    /// Final export JSON, ready to drop into the diagnose viewer.
+    pub export: serde_json::Value,
+    /// Total wall-clock time for detection + calibration.
+    pub duration_ms: u64,
+    /// Number of views with >= 4 features after detection.
+    pub usable_views: usize,
+    /// Total number of images attempted.
+    pub total_views: usize,
+    /// Whether at least one detection was served from the cache.
+    /// (Useful as a sanity check for "second run is faster"
+    /// in PR 1; precise per-image hit/miss counts come in PR 4.)
+    pub cache_used: bool,
+}
+
+/// Tagged response shape so the React layer can match on `kind` rather
+/// than parsing free-form error strings.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RunResponse {
+    /// Calibration completed and an export was produced.
+    Ok(RunSuccess),
+    /// Runtime ambiguity per ADR 0019 — Run workspace must render a
+    /// modal asking the user to fill `field`.
+    AskUser {
+        /// Dotted field path the runtime needs help with.
+        field: String,
+        /// Human-friendly prompt copy for the modal.
+        prompt: String,
+        /// Optional preset suggestions (e.g. `["t_base_tcp", "t_tcp_base"]`).
+        suggestions: Vec<String>,
+    },
+    /// Manifest validation failed before the runner could touch the
+    /// filesystem. Holds the underlying validation message.
+    ValidationFailed { message: String },
+    /// User-correctable detection / IO / decode error. The frontend
+    /// surfaces `message` directly in a non-modal error banner.
+    Failed {
+        /// Stable kind tag for the frontend.
+        category: String,
+        /// Human-readable detail.
+        message: String,
+    },
+}
+
+/// Tauri command: run a calibration end-to-end.
+///
+/// `manifest_json` is the raw JSON of a [`DatasetSpec`] (typically
+/// emitted by the schema-driven form in the Run workspace). `config_json`
+/// is the matching per-problem `*Config` JSON. `manifest_dir` is the
+/// directory whose globs are resolved against — usually the parent of
+/// the `dataset.toml` file the user picked.
+#[tauri::command]
+pub async fn run_calibration_cmd(
+    manifest_json: serde_json::Value,
+    config_json: serde_json::Value,
+    manifest_dir: String,
+    cache: State<'_, ExportCache>,
+) -> Result<RunResponse, String> {
+    // Long-running solve: keep IPC responsive by running on a blocking
+    // task. The State can't cross the spawn_blocking boundary directly,
+    // so we do detection + calibration on the worker thread and pop
+    // the produced export into the cache here, in the async caller.
+    let response = tauri::async_runtime::spawn_blocking(move || {
+        run_blocking(manifest_json, config_json, &manifest_dir)
+    })
+    .await
+    .map_err(|e| format!("runner task panicked: {e}"))?;
+    if let RunResponse::Ok(success) = &response {
+        cache.set("<live-run>".to_string(), success.export.clone());
+    }
+    Ok(response)
+}
+
+fn run_blocking(
+    manifest_json: serde_json::Value,
+    config_json: serde_json::Value,
+    manifest_dir: &str,
+) -> RunResponse {
+    let started = Instant::now();
+    let spec: DatasetSpec = match serde_json::from_value(manifest_json) {
+        Ok(s) => s,
+        Err(e) => {
+            return RunResponse::Failed {
+                category: "manifest_parse".into(),
+                message: format!("manifest parse failed: {e}"),
+            };
+        }
+    };
+    let config: PlanarIntrinsicsConfig = match serde_json::from_value(config_json) {
+        Ok(c) => c,
+        Err(e) => {
+            return RunResponse::Failed {
+                category: "config_parse".into(),
+                message: format!("config parse failed: {e}"),
+            };
+        }
+    };
+    if !matches!(spec.topology, Topology::PlanarIntrinsics) {
+        return RunResponse::Failed {
+            category: "unsupported_topology".into(),
+            message: format!(
+                "PR 1 of the runner only supports PlanarIntrinsics; \
+                 manifest declares {:?}. Coverage for the other seven \
+                 topologies ships in B3c.",
+                spec.topology
+            ),
+        };
+    }
+
+    let base_dir = Path::new(manifest_dir);
+    let detection_cache = FsDetectionCache::new(detection_cache_root(&spec, base_dir));
+
+    // Dataset → IR conversion (validation + detection-with-cache).
+    let planar_run = match build_planar_input(&spec, base_dir, &detection_cache, false) {
+        Ok(r) => r,
+        Err(e) => return run_error_to_response(e),
+    };
+    let cache_used = planar_run.usable_views > 0; // refined in B3e with hit/miss counts
+
+    // Calibration: drive a session.
+    let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+    if let Err(e) = session.set_input(planar_run.dataset.clone()) {
+        return RunResponse::Failed {
+            category: "session_set_input".into(),
+            message: format!("set_input failed: {e}"),
+        };
+    }
+    if let Err(e) = session.set_config(config) {
+        return RunResponse::Failed {
+            category: "session_set_config".into(),
+            message: format!("set_config failed: {e}"),
+        };
+    }
+    if let Err(e) = run_calibration(&mut session) {
+        return RunResponse::Failed {
+            category: "calibration_failed".into(),
+            message: format!("calibration failed: {e}"),
+        };
+    }
+    let export = match session.export() {
+        Ok(e) => e,
+        Err(e) => {
+            return RunResponse::Failed {
+                category: "session_export".into(),
+                message: format!("export failed: {e}"),
+            };
+        }
+    };
+    let export_value = match serde_json::to_value(&export) {
+        Ok(v) => v,
+        Err(e) => {
+            return RunResponse::Failed {
+                category: "export_serialize".into(),
+                message: format!("export serialization failed: {e}"),
+            };
+        }
+    };
+
+    // The async caller pushes `export_value` into ExportCache after the
+    // worker returns, so the diagnose / 3D / epipolar workspaces can
+    // pick it up via the existing `compute_*` commands without a disk
+    // round-trip.
+    let _ = planar_run.view_paths; // PR 1 doesn't yet thread image_manifest back
+
+    RunResponse::Ok(RunSuccess {
+        export: export_value,
+        duration_ms: started.elapsed().as_millis() as u64,
+        usable_views: planar_run.usable_views,
+        total_views: planar_run.total_views,
+        cache_used,
+    })
+}
+
+fn run_error_to_response(err: RunError) -> RunResponse {
+    match err {
+        RunError::AskUser {
+            field,
+            prompt,
+            suggestions,
+        } => RunResponse::AskUser {
+            field,
+            prompt,
+            suggestions,
+        },
+        RunError::Validation(v) => RunResponse::ValidationFailed {
+            message: v.to_string(),
+        },
+        other => RunResponse::Failed {
+            category: error_category(&other).into(),
+            message: other.to_string(),
+        },
+    }
+}
+
+fn error_category(err: &RunError) -> &'static str {
+    match err {
+        RunError::Validation(_) => "validation",
+        RunError::UnsupportedTopology { .. } => "unsupported_topology",
+        RunError::UnsupportedTarget { .. } => "unsupported_target",
+        RunError::EmptyImageMatch { .. } => "empty_image_match",
+        RunError::BadGlob { .. } => "bad_glob",
+        RunError::Io(_) => "io",
+        RunError::Decode { .. } => "decode",
+        RunError::Detection { .. } => "detection",
+        RunError::Cache(_) => "cache",
+        RunError::AskUser { .. } => "ask_user",
+        RunError::InsufficientUsableViews { .. } => "insufficient_views",
+    }
+}
+
+fn detection_cache_root(spec: &DatasetSpec, base_dir: &Path) -> PathBuf {
+    // Per ADR 0017 the cache root is per-dataset. We use a stable id
+    // from the manifest's `description` if set, otherwise the absolute
+    // base directory mangled into a filesystem-safe slug.
+    let id = match &spec.description {
+        Some(d) if !d.is_empty() => slug(d),
+        _ => slug(&base_dir.to_string_lossy()),
+    };
+    let cache_home = dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
+    cache_home
+        .join("calibration-rs")
+        .join("detections")
+        .join(id)
+}
+
+fn slug(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
+use vision_calibration_core::{FrameRef, ImageManifest};
 use vision_calibration_dataset::{DatasetSpec, Topology};
 use vision_calibration_detect::FsDetectionCache;
 use vision_calibration_pipeline::dataset_runner::{RunError, build_planar_input};
@@ -169,12 +170,21 @@ fn run_blocking(
             message: format!("calibration failed: {e}"),
         };
     }
-    let export = match session.export() {
+    let mut export = match session.export() {
         Ok(e) => e,
         Err(e) => {
             return RunResponse::Failed {
                 category: "session_export".into(),
                 message: format!("export failed: {e}"),
+            };
+        }
+    };
+    export.image_manifest = match planar_image_manifest(&planar_run.view_paths, base_dir) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            return RunResponse::Failed {
+                category: "image_manifest".into(),
+                message: e,
             };
         }
     };
@@ -192,14 +202,41 @@ fn run_blocking(
     // worker returns, so the diagnose / 3D / epipolar workspaces can
     // pick it up via the existing `compute_*` commands without a disk
     // round-trip.
-    let _ = planar_run.view_paths; // PR 1 doesn't yet thread image_manifest back
-
     RunResponse::Ok(RunSuccess {
         export: export_value,
         duration_ms: started.elapsed().as_millis() as u64,
         usable_views: planar_run.usable_views,
         total_views: planar_run.total_views,
         cache_used,
+    })
+}
+
+fn planar_image_manifest(view_paths: &[PathBuf], base_dir: &Path) -> Result<ImageManifest, String> {
+    let base_abs = base_dir
+        .canonicalize()
+        .map_err(|e| format!("canonicalize manifest dir {}: {e}", base_dir.display()))?;
+    let mut frames = Vec::with_capacity(view_paths.len());
+    for (pose, path) in view_paths.iter().enumerate() {
+        let abs = path
+            .canonicalize()
+            .map_err(|e| format!("canonicalize image path {}: {e}", path.display()))?;
+        let rel = abs.strip_prefix(&base_abs).map_err(|_| {
+            format!(
+                "accepted image {} is not under manifest dir {}",
+                abs.display(),
+                base_abs.display()
+            )
+        })?;
+        frames.push(FrameRef {
+            pose,
+            camera: 0,
+            path: rel.to_path_buf(),
+            roi: None,
+        });
+    }
+    Ok(ImageManifest {
+        root: PathBuf::from("."),
+        frames,
     })
 }
 

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -6,8 +6,14 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "bun run dev",
-    "beforeBuildCommand": "bun run build"
+    "beforeDevCommand": {
+      "script": "bun run dev",
+      "cwd": ".."
+    },
+    "beforeBuildCommand": {
+      "script": "bun run build",
+      "cwd": ".."
+    }
   },
   "app": {
     "windows": [

--- a/app/src/hooks/useImageData.ts
+++ b/app/src/hooks/useImageData.ts
@@ -66,6 +66,77 @@ export function useImageData(
   return data;
 }
 
+/** Loads a frame through the backend's canonical camera model into the
+ * undistorted pixel frame. The returned image is already ROI-local when
+ * `frame.roi` is set, so callers should render it without applying the
+ * ROI crop a second time. */
+export function useUndistortedImageData(
+  frame: FrameKey | null,
+  camera: number,
+  onError?: (msg: string) => void,
+): ImageData | null {
+  const [data, setData] = useState<ImageData | null>(null);
+
+  useEffect(() => {
+    if (!frame) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+    setData(null);
+    invoke<string>("load_undistorted_image", {
+      path: frame.abs_path,
+      camera,
+      roi: frame.roi ?? null,
+    })
+      .then((dataUrl) => decodeImageDataUrl(dataUrl, () => cancelled, setData, onError))
+      .catch((e) => {
+        if (!cancelled) onError?.(`Could not load undistorted image: ${e}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    frame?.abs_path,
+    frame?.roi?.x,
+    frame?.roi?.y,
+    frame?.roi?.w,
+    frame?.roi?.h,
+    camera,
+    onError,
+  ]);
+
+  return data;
+}
+
+function decodeImageDataUrl(
+  dataUrl: string,
+  isCancelled: () => boolean,
+  setData: (data: ImageData) => void,
+  onError?: (msg: string) => void,
+) {
+  if (isCancelled()) return;
+  const img = new Image();
+  img.onload = () => {
+    if (isCancelled()) return;
+    try {
+      const luminance = decodeLuminance(img);
+      setData({
+        image: img,
+        naturalWidth: img.naturalWidth,
+        naturalHeight: img.naturalHeight,
+        luminance,
+      });
+    } catch (e) {
+      onError?.(`Pixel decode failed: ${e}`);
+    }
+  };
+  img.onerror = () => {
+    if (!isCancelled()) onError?.("Image failed to decode.");
+  };
+  img.src = dataUrl;
+}
+
 /** Pull luminance out of an HTMLImageElement by drawing it into an
  * OffscreenCanvas (or a hidden 2D canvas for older runtimes) and
  * extracting RGBA. We compute Rec. 601 luma and discard the rest. */

--- a/app/src/lib/configForm.tsx
+++ b/app/src/lib/configForm.tsx
@@ -1,0 +1,351 @@
+/** Schema-driven form generator (ADR 0018) for the JSON Schema subset
+ * `cargo xtask emit-schemas` produces. Handles primitives (string /
+ * number / integer / boolean), enums, objects with `properties` +
+ * `required`, `$ref` resolution, `oneOf` tagged unions on `kind`, and
+ * string arrays. Anything outside that subset falls back to a raw JSON
+ * textarea so the user is never blocked by a schema feature we haven't
+ * polished yet. ~250 LoC; rich array / number-range / file-picker
+ * widgets land in B3e.
+ */
+import { useMemo } from "react";
+
+// ─── Schema type (loose) ────────────────────────────────────────────────────
+export interface JsonSchema {
+  $defs?: Record<string, JsonSchema>;
+  $ref?: string;
+  type?: string | string[];
+  enum?: unknown[];
+  const?: unknown;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  oneOf?: JsonSchema[];
+  description?: string;
+  format?: string;
+  minimum?: number;
+  maximum?: number;
+  minItems?: number;
+  maxItems?: number;
+  default?: unknown;
+}
+
+interface FormCtx {
+  defs: Record<string, JsonSchema>;
+  path: string;
+}
+
+// Resolve `$ref` like "#/$defs/CameraSource" against the supplied defs.
+function resolveRef(ref: string, defs: Record<string, JsonSchema>): JsonSchema | null {
+  const prefix = "#/$defs/";
+  if (!ref.startsWith(prefix)) return null;
+  const key = ref.slice(prefix.length);
+  return defs[key] ?? null;
+}
+
+function resolve(schema: JsonSchema, ctx: FormCtx): JsonSchema {
+  if (schema.$ref) {
+    const r = resolveRef(schema.$ref, ctx.defs);
+    return r ? { ...r, description: schema.description ?? r.description } : schema;
+  }
+  return schema;
+}
+
+function hasType(schema: JsonSchema, t: string): boolean {
+  if (Array.isArray(schema.type)) return schema.type.includes(t);
+  return schema.type === t;
+}
+
+// ─── Public component ───────────────────────────────────────────────────────
+export interface ConfigFormProps {
+  schema: JsonSchema;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  /** Field path prefix shown to the user (e.g. "config" or "manifest"). */
+  rootLabel?: string;
+}
+
+export function ConfigForm({ schema, value, onChange, rootLabel }: ConfigFormProps) {
+  const defs = useMemo(() => schema.$defs ?? {}, [schema]);
+  const ctx: FormCtx = { defs, path: rootLabel ?? "" };
+  return (
+    <div className="flex flex-col gap-3 text-[13px]">
+      <SchemaField schema={schema} value={value} onChange={onChange} ctx={ctx} />
+    </div>
+  );
+}
+
+// ─── Field dispatch ─────────────────────────────────────────────────────────
+interface FieldProps {
+  schema: JsonSchema;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  ctx: FormCtx;
+  /** Label text — falls back to the path tail. */
+  label?: string;
+}
+
+function SchemaField(props: FieldProps) {
+  const schema = resolve(props.schema, props.ctx);
+
+  if (schema.oneOf && schema.oneOf.length > 0) {
+    return <OneOfField {...props} schema={schema} />;
+  }
+  if (schema.enum && hasType(schema, "string")) {
+    return <EnumField {...props} schema={schema} />;
+  }
+  if (hasType(schema, "object") && schema.properties) {
+    return <ObjectField {...props} schema={schema} />;
+  }
+  if (hasType(schema, "array")) {
+    return <ArrayField {...props} schema={schema} />;
+  }
+  if (hasType(schema, "boolean")) {
+    return <BoolField {...props} schema={schema} />;
+  }
+  if (hasType(schema, "integer") || hasType(schema, "number")) {
+    return <NumberField {...props} schema={schema} />;
+  }
+  if (hasType(schema, "string")) {
+    return <StringField {...props} schema={schema} />;
+  }
+
+  // Unknown shape — JSON textarea fallback.
+  return <JsonField {...props} schema={schema} />;
+}
+
+// ─── Object ────────────────────────────────────────────────────────────────
+function ObjectField({ schema, value, onChange, ctx, label }: FieldProps) {
+  const props = schema.properties ?? {};
+  const required = schema.required ?? [];
+  const obj =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+  return (
+    <fieldset className="flex flex-col gap-2 rounded-md border border-border bg-bg-soft p-3">
+      {(label || schema.description) && (
+        <legend className="px-1 text-[12px] font-semibold tracking-tight">
+          {label ?? ""}
+        </legend>
+      )}
+      {schema.description && (
+        <p className="text-[11px] text-muted-foreground">{schema.description}</p>
+      )}
+      {Object.entries(props).map(([key, sub]) => (
+        <div key={key} className="flex flex-col gap-1">
+          <label className="text-[11px] font-medium text-muted-foreground">
+            {key}
+            {required.includes(key) && <span className="ml-1 text-[color:var(--brand)]">*</span>}
+          </label>
+          <SchemaField
+            schema={sub}
+            value={obj[key]}
+            onChange={(next) => onChange({ ...obj, [key]: next })}
+            ctx={{ ...ctx, path: `${ctx.path}.${key}` }}
+            label={key}
+          />
+        </div>
+      ))}
+    </fieldset>
+  );
+}
+
+// ─── oneOf with `kind` discriminator ────────────────────────────────────────
+function OneOfField({ schema, value, onChange, ctx, label }: FieldProps) {
+  const variants = (schema.oneOf ?? []).map((variant) => resolve(variant, ctx));
+  const variantTags = variants.map((v) => {
+    const k = v.properties?.kind;
+    return typeof k?.const === "string" ? (k.const as string) : null;
+  });
+  const obj =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+  const currentKind = typeof obj.kind === "string" ? obj.kind : variantTags[0] ?? "";
+  const activeIdx = variantTags.findIndex((t) => t === currentKind);
+  const active = activeIdx >= 0 ? variants[activeIdx] : variants[0];
+
+  return (
+    <fieldset className="flex flex-col gap-2 rounded-md border border-border bg-bg-soft p-3">
+      {label && (
+        <legend className="px-1 text-[12px] font-semibold tracking-tight">{label}</legend>
+      )}
+      {schema.description && (
+        <p className="text-[11px] text-muted-foreground">{schema.description}</p>
+      )}
+      <select
+        className="rounded border border-border bg-bg px-2 py-1 text-[12px]"
+        value={currentKind}
+        onChange={(e) => {
+          const tag = e.target.value;
+          // Reset to a fresh variant body, preserving only `kind`.
+          onChange({ kind: tag });
+        }}
+      >
+        {variantTags.map((t, i) =>
+          t ? (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ) : (
+            <option key={`v${i}`} value="">
+              variant {i}
+            </option>
+          ),
+        )}
+      </select>
+      {active.properties && (
+        <ObjectField
+          schema={{ ...active, properties: omitKey(active.properties, "kind") }}
+          value={obj}
+          onChange={(next) => {
+            const merged = next as Record<string, unknown>;
+            onChange({ ...merged, kind: currentKind });
+          }}
+          ctx={ctx}
+        />
+      )}
+    </fieldset>
+  );
+}
+
+function omitKey<T>(obj: Record<string, T>, drop: string): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (k !== drop) out[k] = v;
+  }
+  return out;
+}
+
+// ─── Enums ──────────────────────────────────────────────────────────────────
+function EnumField({ schema, value, onChange }: FieldProps) {
+  const options = (schema.enum ?? []).map((v) => String(v));
+  const current = typeof value === "string" ? value : options[0] ?? "";
+  return (
+    <select
+      className="rounded border border-border bg-bg px-2 py-1 text-[12px]"
+      value={current}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map((opt) => (
+        <option key={opt} value={opt}>
+          {opt}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// ─── Primitives ─────────────────────────────────────────────────────────────
+function StringField({ schema, value, onChange }: FieldProps) {
+  const v = typeof value === "string" ? value : "";
+  const placeholder = schema.description ? schema.description.split("\n")[0] : undefined;
+  return (
+    <input
+      type="text"
+      value={v}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+      className="rounded border border-border bg-bg px-2 py-1 text-[12px]"
+    />
+  );
+}
+
+function NumberField({ schema, value, onChange }: FieldProps) {
+  const v = typeof value === "number" ? value : 0;
+  const step = hasType(schema, "integer") ? 1 : "any";
+  return (
+    <input
+      type="number"
+      value={v}
+      step={step}
+      min={schema.minimum}
+      max={schema.maximum}
+      onChange={(e) => {
+        const text = e.target.value;
+        if (text === "") return; // leave previous value if cleared mid-edit
+        const parsed = hasType(schema, "integer") ? parseInt(text, 10) : parseFloat(text);
+        if (!Number.isNaN(parsed)) onChange(parsed);
+      }}
+      className="rounded border border-border bg-bg px-2 py-1 text-[12px]"
+    />
+  );
+}
+
+function BoolField({ value, onChange }: FieldProps) {
+  const v = value === true;
+  return (
+    <input
+      type="checkbox"
+      checked={v}
+      onChange={(e) => onChange(e.target.checked)}
+      className="h-4 w-4"
+    />
+  );
+}
+
+// ─── Array (string-only fast path; JSON fallback otherwise) ────────────────
+function ArrayField(props: FieldProps) {
+  const { schema, ctx } = props;
+  const items = schema.items ? resolve(schema.items, ctx) : null;
+  if (items && hasType(items, "string")) {
+    return <StringArrayField {...props} schema={schema} />;
+  }
+  // Numbers / nested objects in arrays: defer to JSON textarea for v0.
+  return <JsonField {...props} schema={schema} />;
+}
+
+function StringArrayField({ value, onChange }: FieldProps) {
+  const arr = Array.isArray(value) ? (value as unknown[]).map((v) => String(v ?? "")) : [];
+  return (
+    <div className="flex flex-col gap-1">
+      {arr.map((entry, i) => (
+        <div key={i} className="flex gap-1">
+          <input
+            type="text"
+            value={entry}
+            onChange={(e) => {
+              const copy = arr.slice();
+              copy[i] = e.target.value;
+              onChange(copy);
+            }}
+            className="flex-1 rounded border border-border bg-bg px-2 py-1 text-[12px]"
+          />
+          <button
+            type="button"
+            onClick={() => onChange(arr.filter((_, j) => j !== i))}
+            className="rounded border border-border px-2 text-[11px]"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() => onChange([...arr, ""])}
+        className="self-start rounded border border-border px-2 py-1 text-[11px]"
+      >
+        + add
+      </button>
+    </div>
+  );
+}
+
+// ─── JSON textarea fallback ────────────────────────────────────────────────
+function JsonField({ value, onChange }: FieldProps) {
+  const text = useMemo(() => JSON.stringify(value, null, 2), [value]);
+  return (
+    <textarea
+      defaultValue={text}
+      onBlur={(e) => {
+        try {
+          onChange(JSON.parse(e.target.value));
+        } catch {
+          /* keep previous value; v0 doesn't surface parse errors yet */
+        }
+      }}
+      rows={6}
+      className="rounded border border-border bg-bg px-2 py-1 font-mono text-[11px]"
+    />
+  );
+}

--- a/app/src/lib/configForm.tsx
+++ b/app/src/lib/configForm.tsx
@@ -88,6 +88,9 @@ function SchemaField(props: FieldProps) {
   const schema = resolve(props.schema, props.ctx);
 
   if (schema.oneOf && schema.oneOf.length > 0) {
+    if (isExternalTaggedOneOf(schema, props.ctx)) {
+      return <ExternalTaggedOneOfField {...props} schema={schema} />;
+    }
     return <OneOfField {...props} schema={schema} />;
   }
   if (schema.enum && hasType(schema, "string")) {
@@ -148,6 +151,126 @@ function ObjectField({ schema, value, onChange, ctx, label }: FieldProps) {
       ))}
     </fieldset>
   );
+}
+
+// ─── oneOf with serde externally tagged enum shape ─────────────────────────
+interface ExternalVariant {
+  tag: string;
+  schema: JsonSchema | null;
+}
+
+function externalVariant(variant: JsonSchema, ctx: FormCtx): ExternalVariant | null {
+  const v = resolve(variant, ctx);
+  if (typeof v.const === "string" && hasType(v, "string")) {
+    return { tag: v.const, schema: null };
+  }
+  const required = v.required ?? [];
+  const props = v.properties ?? {};
+  if (required.length === 1 && props[required[0]]) {
+    return { tag: required[0], schema: props[required[0]] };
+  }
+  const keys = Object.keys(props);
+  if (keys.length === 1) {
+    return { tag: keys[0], schema: props[keys[0]] };
+  }
+  return null;
+}
+
+function isExternalTaggedOneOf(schema: JsonSchema, ctx: FormCtx): boolean {
+  const variants = schema.oneOf ?? [];
+  return variants.length > 0 && variants.every((v) => externalVariant(v, ctx) != null);
+}
+
+function ExternalTaggedOneOfField({ schema, value, onChange, ctx, label }: FieldProps) {
+  const variants = (schema.oneOf ?? [])
+    .map((v) => externalVariant(v, ctx))
+    .filter((v): v is ExternalVariant => v != null);
+  const currentTag = externalCurrentTag(value, variants);
+  const active = variants.find((v) => v.tag === currentTag) ?? variants[0];
+  const payload =
+    active?.schema &&
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    active.tag in value
+      ? (value as Record<string, unknown>)[active.tag]
+      : active?.schema
+        ? defaultValueForSchema(resolve(active.schema, ctx))
+        : undefined;
+
+  return (
+    <fieldset className="flex flex-col gap-2 rounded-md border border-border bg-bg-soft p-3">
+      {label && (
+        <legend className="px-1 text-[12px] font-semibold tracking-tight">{label}</legend>
+      )}
+      {schema.description && (
+        <p className="text-[11px] text-muted-foreground">{schema.description}</p>
+      )}
+      <select
+        className="rounded border border-border bg-bg px-2 py-1 text-[12px]"
+        value={active?.tag ?? ""}
+        onChange={(e) => {
+          const next = variants.find((v) => v.tag === e.target.value);
+          if (!next) return;
+          if (!next.schema) {
+            onChange(next.tag);
+          } else {
+            onChange({ [next.tag]: defaultValueForSchema(resolve(next.schema, ctx)) });
+          }
+        }}
+      >
+        {variants.map((v) => (
+          <option key={v.tag} value={v.tag}>
+            {v.tag}
+          </option>
+        ))}
+      </select>
+      {active?.schema && (
+        <SchemaField
+          schema={active.schema}
+          value={payload}
+          onChange={(next) => onChange({ [active.tag]: next })}
+          ctx={{ ...ctx, path: `${ctx.path}.${active.tag}` }}
+          label={active.tag}
+        />
+      )}
+    </fieldset>
+  );
+}
+
+function externalCurrentTag(value: unknown, variants: ExternalVariant[]): string {
+  if (typeof value === "string" && variants.some((v) => v.tag === value)) {
+    return value;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    const key = Object.keys(obj).find((k) => variants.some((v) => v.tag === k));
+    if (key) return key;
+  }
+  return variants[0]?.tag ?? "";
+}
+
+function defaultValueForSchema(schema: JsonSchema): unknown {
+  const resolved = schema;
+  if (resolved.default !== undefined) return resolved.default;
+  if (typeof resolved.const === "string") return resolved.const;
+  if (resolved.enum && resolved.enum.length > 0) return resolved.enum[0];
+  if (hasType(resolved, "object") && resolved.properties) {
+    const out: Record<string, unknown> = {};
+    const required = resolved.required ?? Object.keys(resolved.properties);
+    for (const key of required) {
+      const sub = resolved.properties[key];
+      if (sub) out[key] = defaultValueForSchema(sub);
+    }
+    return out;
+  }
+  if (hasType(resolved, "array")) return [];
+  if (hasType(resolved, "boolean")) return false;
+  if (hasType(resolved, "integer") || hasType(resolved, "number")) {
+    return resolved.minimum ?? 1;
+  }
+  if (hasType(resolved, "string")) return "";
+  return {};
 }
 
 // ─── oneOf with `kind` discriminator ────────────────────────────────────────

--- a/app/src/lib/runCalibration.ts
+++ b/app/src/lib/runCalibration.ts
@@ -1,0 +1,47 @@
+/** Typed wrapper around the `run_calibration_cmd` Tauri command.
+ * Mirrors the Rust `RunResponse` enum (see app/src-tauri/src/run.rs)
+ * so the React side can match on `kind` rather than parsing strings. */
+import { invoke } from "@tauri-apps/api/core";
+
+export interface RunSuccess {
+  kind: "ok";
+  export: unknown;
+  duration_ms: number;
+  usable_views: number;
+  total_views: number;
+  cache_used: boolean;
+}
+
+export interface RunAskUser {
+  kind: "ask_user";
+  field: string;
+  prompt: string;
+  suggestions: string[];
+}
+
+export interface RunValidationFailed {
+  kind: "validation_failed";
+  message: string;
+}
+
+export interface RunFailed {
+  kind: "failed";
+  category: string;
+  message: string;
+}
+
+export type RunResponse = RunSuccess | RunAskUser | RunValidationFailed | RunFailed;
+
+export interface RunInput {
+  manifest: unknown;
+  config: unknown;
+  manifestDir: string;
+}
+
+export async function runCalibration(input: RunInput): Promise<RunResponse> {
+  return invoke<RunResponse>("run_calibration_cmd", {
+    manifestJson: input.manifest,
+    configJson: input.config,
+    manifestDir: input.manifestDir,
+  });
+}

--- a/app/src/schemas/dataset_spec.json
+++ b/app/src/schemas/dataset_spec.json
@@ -1,0 +1,586 @@
+{
+  "$defs": {
+    "CameraSource": {
+      "additionalProperties": false,
+      "description": "Per-camera image source.",
+      "properties": {
+        "id": {
+          "description": "Stable camera identifier (e.g. `\"cam0\"`). Used as a key in\npose pairings and downstream exports.",
+          "type": "string"
+        },
+        "images": {
+          "$ref": "#/$defs/ImagePattern",
+          "description": "Glob pattern (e.g. `\"cam0/*.png\"`) or explicit list of image\npaths, relative to the manifest's directory unless absolute."
+        },
+        "roi_xywh": {
+          "description": "Optional rectangular ROI in source-image pixels — `[x, y, w, h]`.\nWhen set, only the cropped region is fed to the detector and\nstored in the export's image manifest.",
+          "items": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "images"
+      ],
+      "type": "object"
+    },
+    "ImagePattern": {
+      "description": "How image paths for a camera are listed.",
+      "oneOf": [
+        {
+          "description": "Single shell-glob pattern, evaluated relative to the manifest\ndirectory. Example: `\"cam0/*.png\"`.",
+          "properties": {
+            "kind": {
+              "const": "glob",
+              "type": "string"
+            },
+            "pattern": {
+              "description": "The glob pattern.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "pattern"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Explicit ordered list of paths.",
+          "properties": {
+            "kind": {
+              "const": "list",
+              "type": "string"
+            },
+            "paths": {
+              "description": "Paths relative to the manifest directory unless absolute.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "paths"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "PoseColumnMap": {
+      "additionalProperties": false,
+      "description": "Mapping from user-defined column / field names to the canonical\npose fields. All seven of `tx, ty, tz, qx, qy, qz, qw` are required\nwhen `rotation_format` is a quaternion; the runner rejects partial\nmappings as a fail-fast event.",
+      "properties": {
+        "pose_id": {
+          "description": "Optional view-id column (string or integer). When absent, the\npose row index is used as the implicit pose id.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rotation": {
+          "description": "Rotation columns. Length and meaning depend on the\n`pose_convention.rotation_format`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tx": {
+          "description": "Translation x column.",
+          "type": "string"
+        },
+        "ty": {
+          "description": "Translation y column.",
+          "type": "string"
+        },
+        "tz": {
+          "description": "Translation z column.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tx",
+        "ty",
+        "tz",
+        "rotation"
+      ],
+      "type": "object"
+    },
+    "PoseConvention": {
+      "additionalProperties": false,
+      "description": "Frame conventions for the robot pose stream.\n\nAll three components are required (no defaults). Each is a closed\nenum so the runtime supports a finite, validated set of conventions.",
+      "properties": {
+        "rotation_format": {
+          "$ref": "#/$defs/RotationFormat",
+          "description": "How rotation is parameterised in the file."
+        },
+        "transform": {
+          "$ref": "#/$defs/TransformConvention",
+          "description": "Which transform the pose row encodes."
+        },
+        "translation_units": {
+          "$ref": "#/$defs/TranslationUnits",
+          "description": "Translation units in the file."
+        }
+      },
+      "required": [
+        "transform",
+        "rotation_format",
+        "translation_units"
+      ],
+      "type": "object"
+    },
+    "PosePairing": {
+      "description": "How per-camera image lists align across views and (optionally)\nalign with robot poses.",
+      "oneOf": [
+        {
+          "description": "All cameras have the same number of images, paired by index\n(image[i] from cam0 ↔ image[i] from cam1 ↔ pose[i]).",
+          "properties": {
+            "kind": {
+              "const": "by_index",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A regex applied to filenames extracts a shared \"view token\"\n(e.g. timestamp or pose id). All cameras and the pose file\nmust produce the same set of tokens.",
+          "properties": {
+            "group": {
+              "description": "Name of the capture group whose value identifies the view.",
+              "type": "string"
+            },
+            "kind": {
+              "const": "shared_filename_token",
+              "type": "string"
+            },
+            "regex": {
+              "description": "Regex with at least one named capture group.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "regex",
+            "group"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "RobotPoseFormat": {
+      "description": "Robot-pose file format.",
+      "oneOf": [
+        {
+          "const": "csv",
+          "description": "Comma-separated values with a header row.",
+          "type": "string"
+        },
+        {
+          "const": "json",
+          "description": "JSON array of objects.",
+          "type": "string"
+        },
+        {
+          "const": "jsonl",
+          "description": "JSONL (one JSON object per line).",
+          "type": "string"
+        }
+      ]
+    },
+    "RobotPoseSource": {
+      "additionalProperties": false,
+      "description": "Where and how robot poses are stored on disk.",
+      "properties": {
+        "columns": {
+          "$ref": "#/$defs/PoseColumnMap",
+          "description": "Column / field mapping from the user's file to the canonical\nfields the converter consumes."
+        },
+        "format": {
+          "$ref": "#/$defs/RobotPoseFormat",
+          "description": "File-format selector."
+        },
+        "path": {
+          "description": "Path to the pose file, relative to the manifest directory\nunless absolute.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "format",
+        "columns"
+      ],
+      "type": "object"
+    },
+    "RotationFormat": {
+      "description": "Rotation parameterisation in the file.",
+      "oneOf": [
+        {
+          "const": "quat_xyzw",
+          "description": "Hamilton quaternion as `[qx, qy, qz, qw]`.",
+          "type": "string"
+        },
+        {
+          "const": "quat_wxyz",
+          "description": "Hamilton quaternion as `[qw, qx, qy, qz]`.",
+          "type": "string"
+        },
+        {
+          "const": "euler_xyz_deg",
+          "description": "Intrinsic XYZ Euler angles in degrees.",
+          "type": "string"
+        },
+        {
+          "const": "euler_xyz_rad",
+          "description": "Intrinsic XYZ Euler angles in radians.",
+          "type": "string"
+        },
+        {
+          "const": "euler_zyx_deg",
+          "description": "Intrinsic ZYX Euler angles in degrees.",
+          "type": "string"
+        },
+        {
+          "const": "euler_zyx_rad",
+          "description": "Intrinsic ZYX Euler angles in radians.",
+          "type": "string"
+        },
+        {
+          "const": "axis_angle_rad",
+          "description": "Axis-angle vector (length encodes magnitude, radians).",
+          "type": "string"
+        },
+        {
+          "const": "matrix4x4_row_major",
+          "description": "Row-major 4×4 homogeneous matrix flattened across 16 columns.",
+          "type": "string"
+        }
+      ]
+    },
+    "TargetSpec": {
+      "description": "Calibration-target metadata. Tagged on `kind`.",
+      "oneOf": [
+        {
+          "description": "Standard checkerboard. Counts are interior corners\n(i.e. `9x6` ⇒ a 10×7 black-and-white square grid).",
+          "properties": {
+            "cols": {
+              "description": "Number of interior corners along the cols axis.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "chessboard",
+              "type": "string"
+            },
+            "rows": {
+              "description": "Number of interior corners along the rows axis.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "square_size_m": {
+              "description": "Edge length of one square in metres.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "kind",
+            "rows",
+            "cols",
+            "square_size_m"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ChArUco board. Marker IDs and dictionary live here so detection\nis fully deterministic from the manifest.",
+          "properties": {
+            "cols": {
+              "description": "Number of squares along the cols axis.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "dictionary": {
+              "description": "ArUco dictionary identifier (e.g. `\"DICT_4X4_50\"`). The\ndetector validates this against the supported set.",
+              "type": "string"
+            },
+            "kind": {
+              "const": "charuco",
+              "type": "string"
+            },
+            "marker_size_m": {
+              "description": "Edge length of an embedded marker in metres.",
+              "format": "double",
+              "type": "number"
+            },
+            "rows": {
+              "description": "Number of squares along the rows axis (full grid, not\ninterior corners).",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "square_size_m": {
+              "description": "Edge length of one square in metres.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "kind",
+            "rows",
+            "cols",
+            "square_size_m",
+            "marker_size_m",
+            "dictionary"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Puzzleboard target (calib-targets crate). Layout is fully\ndescribed by the named variant in calib-targets; the manifest\njust carries the discriminator.",
+          "properties": {
+            "cell_size_m": {
+              "description": "Edge length of one cell in metres.",
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "puzzleboard",
+              "type": "string"
+            },
+            "layout": {
+              "description": "Named layout (e.g. `\"puzzle_130x130\"`).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "layout",
+            "cell_size_m"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Ringgrid target (ringgrid crate).",
+          "properties": {
+            "cols": {
+              "description": "Number of rings along the cols axis.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "inner_radius_m": {
+              "description": "Inner ring radius in metres.",
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "ringgrid",
+              "type": "string"
+            },
+            "outer_radius_m": {
+              "description": "Outer ring radius in metres.",
+              "format": "double",
+              "type": "number"
+            },
+            "rows": {
+              "description": "Number of rings along the rows axis.",
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "spacing_m": {
+              "description": "Centre-to-centre spacing of adjacent rings in metres.",
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "required": [
+            "kind",
+            "rows",
+            "cols",
+            "spacing_m",
+            "inner_radius_m",
+            "outer_radius_m"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Topology": {
+      "description": "Calibration topology — selects the problem-type dispatch.",
+      "oneOf": [
+        {
+          "const": "planar_intrinsics",
+          "description": "Single camera, planar target — `PlanarIntrinsicsProblem`.",
+          "type": "string"
+        },
+        {
+          "const": "scheimpflug_intrinsics",
+          "description": "Single camera with Scheimpflug tilt — `ScheimpflugIntrinsicsProblem`.",
+          "type": "string"
+        },
+        {
+          "const": "single_cam_handeye",
+          "description": "Single camera mounted on a robot — `SingleCamHandeyeProblem`.",
+          "type": "string"
+        },
+        {
+          "const": "laserline_device",
+          "description": "Camera + laser plane — `LaserlineDeviceProblem`.",
+          "type": "string"
+        },
+        {
+          "const": "rig_extrinsics",
+          "description": "Multi-camera rig, target only — `RigExtrinsicsProblem`.",
+          "type": "string"
+        },
+        {
+          "const": "rig_handeye",
+          "description": "Multi-camera rig + robot — `RigHandeyeProblem`.",
+          "type": "string"
+        },
+        {
+          "const": "rig_laserline_device",
+          "description": "Multi-camera rig + laser planes — `RigLaserlineDeviceProblem`.",
+          "type": "string"
+        }
+      ]
+    },
+    "TransformConvention": {
+      "description": "Which transform a pose row encodes.",
+      "oneOf": [
+        {
+          "const": "t_base_tcp",
+          "description": "`T_base_tcp` — gripper pose in the robot base frame (KUKA, UR\ndefault).",
+          "type": "string"
+        },
+        {
+          "const": "t_tcp_base",
+          "description": "`T_tcp_base` — base pose in the gripper frame (some ABB exports).",
+          "type": "string"
+        },
+        {
+          "const": "t_world_tcp",
+          "description": "`T_world_tcp` — gripper pose in a fixed world frame (less\ncommon; some lab-frame setups).",
+          "type": "string"
+        },
+        {
+          "const": "t_tcp_world",
+          "description": "`T_tcp_world` — world pose in the gripper frame.",
+          "type": "string"
+        }
+      ]
+    },
+    "TranslationUnits": {
+      "description": "Translation units in the file.",
+      "oneOf": [
+        {
+          "const": "m",
+          "description": "Metres (SI, preferred).",
+          "type": "string"
+        },
+        {
+          "const": "mm",
+          "description": "Millimetres (some ABB / Fanuc exports).",
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Top-level dataset manifest. Authoritative description of where\nthe user's calibration data lives and how to interpret it.",
+  "properties": {
+    "_unresolved": {
+      "description": "Field paths the AI manifest generator could not determine.\nValidated to be empty before the runner accepts the manifest.\nPopulated as e.g. `[\"pose_convention.transform\"]`.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "cameras": {
+      "description": "Per-camera image sources. Length must match the topology's\nexpected camera count (e.g. `Topology::Mono` requires exactly\none entry).",
+      "items": {
+        "$ref": "#/$defs/CameraSource"
+      },
+      "type": "array"
+    },
+    "description": {
+      "description": "Free-form human-readable description.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "pose_convention": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PoseConvention"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Frame conventions for robot poses. **No defaults** — every\ncomponent is required when `robot_poses` is set."
+    },
+    "pose_pairing": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PosePairing"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "How per-camera images are paired across views (and optionally\nwith robot poses). `None` is permitted only for `Topology::Mono`\nwhere pose-pairing is irrelevant."
+    },
+    "robot_poses": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RobotPoseSource"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Robot-pose source for hand-eye topologies. `None` for\npure-intrinsics calibrations."
+    },
+    "target": {
+      "$ref": "#/$defs/TargetSpec",
+      "description": "Calibration-target specification. Tagged enum on `kind`."
+    },
+    "topology": {
+      "$ref": "#/$defs/Topology",
+      "description": "Calibration topology — selects which problem type the runner\nwill dispatch to."
+    },
+    "version": {
+      "default": 1,
+      "description": "Format-version sentinel. Always `1` for now; bumped on\nbreaking schema revisions.",
+      "format": "uint32",
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": [
+    "cameras",
+    "target",
+    "topology"
+  ],
+  "title": "DatasetSpec",
+  "type": "object"
+}

--- a/app/src/schemas/laserline_device_config.json
+++ b/app/src/schemas/laserline_device_config.json
@@ -1,0 +1,268 @@
+{
+  "$defs": {
+    "LaserlineDeviceInitConfig": {
+      "description": "Initialization options for laserline device calibration.",
+      "properties": {
+        "fix_k3": {
+          "description": "Fix k3 during initialization (recommended for typical lenses).",
+          "type": "boolean"
+        },
+        "fix_tangential": {
+          "description": "Fix tangential distortion during initialization.",
+          "type": "boolean"
+        },
+        "iterations": {
+          "description": "Number of iterations for iterative intrinsics estimation.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "sensor_init": {
+          "$ref": "#/$defs/ScheimpflugParams",
+          "description": "Initial Scheimpflug sensor parameters (use zeros for pinhole/identity)."
+        },
+        "zero_skew": {
+          "description": "Enforce zero skew during initialization.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "iterations",
+        "fix_k3",
+        "fix_tangential",
+        "zero_skew",
+        "sensor_init"
+      ],
+      "type": "object"
+    },
+    "LaserlineDeviceOptimizeConfig": {
+      "description": "Bundle-adjustment options for laserline device calibration.",
+      "properties": {
+        "calib_loss": {
+          "$ref": "#/$defs/RobustLoss",
+          "description": "Robust loss for calibration reprojection residuals."
+        },
+        "calib_weight": {
+          "description": "Global weight for calibration residuals.",
+          "format": "double",
+          "type": "number"
+        },
+        "fix_distortion": {
+          "description": "Fix distortion parameters during optimization.",
+          "type": "boolean"
+        },
+        "fix_intrinsics": {
+          "description": "Fix camera intrinsics during optimization.",
+          "type": "boolean"
+        },
+        "fix_k3": {
+          "description": "Fix k3 distortion parameter during optimization.",
+          "type": "boolean"
+        },
+        "fix_plane": {
+          "description": "Fix laser plane parameters during optimization.",
+          "type": "boolean"
+        },
+        "fix_poses": {
+          "description": "Indices of poses to fix (e.g., \\[0\\] to fix first pose).",
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "fix_sensor": {
+          "description": "Fix Scheimpflug sensor parameters during optimization.",
+          "type": "boolean"
+        },
+        "laser_loss": {
+          "$ref": "#/$defs/RobustLoss",
+          "description": "Robust loss for laser residuals."
+        },
+        "laser_residual_type": {
+          "$ref": "#/$defs/LaserlineResidualType",
+          "description": "Laser residual type."
+        },
+        "laser_weight": {
+          "description": "Global weight for laser residuals.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "calib_loss",
+        "laser_loss",
+        "calib_weight",
+        "laser_weight",
+        "fix_intrinsics",
+        "fix_distortion",
+        "fix_k3",
+        "fix_sensor",
+        "fix_poses",
+        "fix_plane",
+        "laser_residual_type"
+      ],
+      "type": "object"
+    },
+    "LaserlineDeviceSolverConfig": {
+      "description": "Shared solver options for laserline device calibration.",
+      "properties": {
+        "max_iters": {
+          "description": "Maximum iterations for the optimizer.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "verbosity": {
+          "description": "Verbosity level (0 = silent, 1 = summary, 2+ = detailed).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "max_iters",
+        "verbosity"
+      ],
+      "type": "object"
+    },
+    "LaserlineResidualType": {
+      "description": "Type of laser plane residual to use.",
+      "oneOf": [
+        {
+          "const": "PointToPlane",
+          "description": "Point-to-plane distance (original approach).\n\nUndistorts pixel, back-projects to 3D ray, intersects with target plane,\ncomputes 3D point in camera frame, measures signed distance to laser plane.\nResidual: 1D distance in meters.",
+          "type": "string"
+        },
+        {
+          "const": "LineDistNormalized",
+          "description": "Line-distance in normalized plane (alternative approach).\n\nComputes 3D intersection line of laser plane and target plane, projects\nline onto z=1 normalized camera plane, undistorts laser pixels to normalized\ncoordinates, measures perpendicular distance from pixel to projected line,\nscales by sqrt(fx*fy) for pixel-comparable residual.\nResidual: 1D distance in pixels.",
+          "type": "string"
+        }
+      ]
+    },
+    "RobustLoss": {
+      "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
+      "oneOf": [
+        {
+          "const": "None",
+          "description": "No robustification (plain squared residual).",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Huber loss with transition scale.",
+          "properties": {
+            "Huber": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling quadratic-to-linear transition.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Huber"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Cauchy loss with scale parameter.",
+          "properties": {
+            "Cauchy": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling outlier down-weighting.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Cauchy"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Arctangent loss with bounded influence.",
+          "properties": {
+            "Arctan": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling curvature.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Arctan"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ScheimpflugParams": {
+      "description": "Scheimpflug tilt parameters (OpenCV-compatible).",
+      "properties": {
+        "tilt_x": {
+          "description": "Tilt around X axis in radians (alias: tau_x).",
+          "format": "double",
+          "type": "number"
+        },
+        "tilt_y": {
+          "description": "Tilt around Y axis in radians (alias: tau_y).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "tilt_x",
+        "tilt_y"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for laserline device calibration.",
+  "properties": {
+    "init": {
+      "$ref": "#/$defs/LaserlineDeviceInitConfig",
+      "description": "Initialization options."
+    },
+    "optimize": {
+      "$ref": "#/$defs/LaserlineDeviceOptimizeConfig",
+      "description": "Bundle-adjustment options."
+    },
+    "solver": {
+      "$ref": "#/$defs/LaserlineDeviceSolverConfig",
+      "description": "Shared solver options."
+    }
+  },
+  "required": [
+    "init",
+    "solver",
+    "optimize"
+  ],
+  "title": "LaserlineDeviceConfig",
+  "type": "object"
+}

--- a/app/src/schemas/planar_intrinsics_config.json
+++ b/app/src/schemas/planar_intrinsics_config.json
@@ -1,0 +1,213 @@
+{
+  "$defs": {
+    "DistortionFixMask": {
+      "description": "Mask for fixing distortion parameters during optimization.\n\nSupports Brown-Conrady distortion model with:\n- Radial coefficients: k1, k2, k3\n- Tangential coefficients: p1, p2\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Default\n\nBy default, `k3` is fixed because it often causes overfitting with\ntypical calibration data. Only enable k3 optimization for wide-angle\nlenses or with high-quality calibration data.\n\n# Example\n\n```\nuse vision_calibration_core::DistortionFixMask;\n\n// Default: k3 fixed, others free\nlet mask = DistortionFixMask::default();\nassert!(!mask.k1);\nassert!(mask.k3); // k3 fixed by default\n\n// Fix tangential distortion\nlet mask = DistortionFixMask {\n    p1: true,\n    p2: true,\n    ..Default::default()\n};\n```",
+      "properties": {
+        "k1": {
+          "description": "Fix first radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k2": {
+          "description": "Fix second radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k3": {
+          "description": "Fix third radial distortion coefficient (fixed by default).",
+          "type": "boolean"
+        },
+        "p1": {
+          "description": "Fix first tangential distortion coefficient.",
+          "type": "boolean"
+        },
+        "p2": {
+          "description": "Fix second tangential distortion coefficient.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "k1",
+        "k2",
+        "k3",
+        "p1",
+        "p2"
+      ],
+      "type": "object"
+    },
+    "IntrinsicsFixMask": {
+      "description": "Mask for fixing intrinsics parameters during optimization.\n\nEach field corresponds to a component of the camera matrix K:\n```text\nK = | fx   skew  cx |\n    | 0    fy    cy |\n    | 0    0     1  |\n```\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Example\n\n```\nuse vision_calibration_core::IntrinsicsFixMask;\n\n// Fix only the principal point\nlet mask = IntrinsicsFixMask {\n    cx: true,\n    cy: true,\n    ..Default::default()\n};\n\nassert!(!mask.fx); // fx will be optimized\nassert!(mask.cx);  // cx is fixed\n```",
+      "properties": {
+        "cx": {
+          "description": "Fix principal point x component.",
+          "type": "boolean"
+        },
+        "cy": {
+          "description": "Fix principal point y component.",
+          "type": "boolean"
+        },
+        "fx": {
+          "description": "Fix focal length x component.",
+          "type": "boolean"
+        },
+        "fy": {
+          "description": "Fix focal length y component.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "fx",
+        "fy",
+        "cx",
+        "cy"
+      ],
+      "type": "object"
+    },
+    "RobustLoss": {
+      "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
+      "oneOf": [
+        {
+          "const": "None",
+          "description": "No robustification (plain squared residual).",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Huber loss with transition scale.",
+          "properties": {
+            "Huber": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling quadratic-to-linear transition.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Huber"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Cauchy loss with scale parameter.",
+          "properties": {
+            "Cauchy": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling outlier down-weighting.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Cauchy"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Arctangent loss with bounded influence.",
+          "properties": {
+            "Arctan": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling curvature.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Arctan"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for planar intrinsics calibration.\n\nContains settings for both initialization and optimization phases.",
+  "properties": {
+    "fix_distortion": {
+      "$ref": "#/$defs/DistortionFixMask",
+      "description": "Mask for fixing distortion parameters during optimization."
+    },
+    "fix_intrinsics": {
+      "$ref": "#/$defs/IntrinsicsFixMask",
+      "description": "Mask for fixing intrinsic parameters during optimization."
+    },
+    "fix_k3_in_init": {
+      "description": "Fix k3 during initialization (recommended for typical lenses).",
+      "type": "boolean"
+    },
+    "fix_poses": {
+      "description": "Indices of poses to fix during optimization (e.g., \\[0\\] to fix first pose).",
+      "items": {
+        "format": "uint",
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "fix_tangential_in_init": {
+      "description": "Fix tangential distortion (p1, p2) during initialization.",
+      "type": "boolean"
+    },
+    "init_iterations": {
+      "description": "Number of iterations for iterative intrinsics estimation.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "max_iters": {
+      "description": "Maximum iterations for the optimizer.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "robust_loss": {
+      "$ref": "#/$defs/RobustLoss",
+      "description": "Robust loss function for outlier handling."
+    },
+    "verbosity": {
+      "description": "Verbosity level (0 = silent, 1 = summary, 2+ = detailed).",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "zero_skew": {
+      "description": "Enforce zero skew during initialization.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "init_iterations",
+    "fix_k3_in_init",
+    "fix_tangential_in_init",
+    "zero_skew",
+    "max_iters",
+    "verbosity",
+    "robust_loss",
+    "fix_intrinsics",
+    "fix_distortion",
+    "fix_poses"
+  ],
+  "title": "PlanarIntrinsicsConfig",
+  "type": "object"
+}

--- a/app/src/schemas/rig_extrinsics_config.json
+++ b/app/src/schemas/rig_extrinsics_config.json
@@ -1,0 +1,274 @@
+{
+  "$defs": {
+    "DistortionFixMask": {
+      "description": "Mask for fixing distortion parameters during optimization.\n\nSupports Brown-Conrady distortion model with:\n- Radial coefficients: k1, k2, k3\n- Tangential coefficients: p1, p2\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Default\n\nBy default, `k3` is fixed because it often causes overfitting with\ntypical calibration data. Only enable k3 optimization for wide-angle\nlenses or with high-quality calibration data.\n\n# Example\n\n```\nuse vision_calibration_core::DistortionFixMask;\n\n// Default: k3 fixed, others free\nlet mask = DistortionFixMask::default();\nassert!(!mask.k1);\nassert!(mask.k3); // k3 fixed by default\n\n// Fix tangential distortion\nlet mask = DistortionFixMask {\n    p1: true,\n    p2: true,\n    ..Default::default()\n};\n```",
+      "properties": {
+        "k1": {
+          "description": "Fix first radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k2": {
+          "description": "Fix second radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k3": {
+          "description": "Fix third radial distortion coefficient (fixed by default).",
+          "type": "boolean"
+        },
+        "p1": {
+          "description": "Fix first tangential distortion coefficient.",
+          "type": "boolean"
+        },
+        "p2": {
+          "description": "Fix second tangential distortion coefficient.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "k1",
+        "k2",
+        "k3",
+        "p1",
+        "p2"
+      ],
+      "type": "object"
+    },
+    "RobustLoss": {
+      "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
+      "oneOf": [
+        {
+          "const": "None",
+          "description": "No robustification (plain squared residual).",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Huber loss with transition scale.",
+          "properties": {
+            "Huber": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling quadratic-to-linear transition.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Huber"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Cauchy loss with scale parameter.",
+          "properties": {
+            "Cauchy": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling outlier down-weighting.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Cauchy"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Arctangent loss with bounded influence.",
+          "properties": {
+            "Arctan": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling curvature.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Arctan"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ScheimpflugFixMask": {
+      "description": "Mask for Scheimpflug tilt parameters.",
+      "properties": {
+        "tilt_x": {
+          "description": "Keep `tilt_x` fixed during optimization.",
+          "type": "boolean"
+        },
+        "tilt_y": {
+          "description": "Keep `tilt_y` fixed during optimization.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "tilt_x",
+        "tilt_y"
+      ],
+      "type": "object"
+    },
+    "SensorMode": {
+      "description": "Sensor flavour for rig calibration workflows.\n\n`Pinhole` is the default and matches a standard multi-camera rig with\npure pinhole + Brown-Conrady distortion projection. `Scheimpflug` adds\nper-camera tilt parameters; per-camera intrinsics share the pinhole core\nbut include a tilted sensor plane in projection.\n\nThe `Scheimpflug` variant carries its own bootstrap defaults and BA-stage\nfix masks so the rest of the workflow config stays shared between flavours.\n\nRe-exported by [`crate::rig_extrinsics::SensorMode`] and\n[`crate::rig_handeye::SensorMode`] (single source of truth in `rig_family`).",
+      "oneOf": [
+        {
+          "description": "Pinhole + Brown-Conrady projection (no sensor tilt).",
+          "properties": {
+            "kind": {
+              "const": "Pinhole",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Pinhole + Brown-Conrady + Scheimpflug-tilted sensor.",
+          "properties": {
+            "distortion_mask_in_percam_ba": {
+              "$ref": "#/$defs/DistortionFixMask",
+              "default": {
+                "k1": false,
+                "k2": false,
+                "k3": true,
+                "p1": true,
+                "p2": true
+              },
+              "description": "Distortion mask applied during per-camera Scheimpflug intrinsics\nrefinement. Defaults to [`DistortionFixMask::radial_only`]\n(k1, k2 free; k3, p1, p2 fixed) — a safe choice for typical\nScheimpflug rigs where tangential distortion can absorb tilt-like\nsignal. Narrow-FOV rigs that overfit k2 may want\n`(k1, p1, p2) free, (k2, k3) fixed` instead."
+            },
+            "fix_scheimpflug_in_intrinsics": {
+              "$ref": "#/$defs/ScheimpflugFixMask",
+              "default": {
+                "tilt_x": false,
+                "tilt_y": false
+              },
+              "description": "Mask for Scheimpflug parameters during per-camera intrinsics refinement."
+            },
+            "init_tilt_x": {
+              "default": 0.0,
+              "description": "Initial Scheimpflug tilt around X (radians) — used only when no\nper-camera sensor seed is supplied via the workflow's manual init.",
+              "format": "double",
+              "type": "number"
+            },
+            "init_tilt_y": {
+              "default": 0.0,
+              "description": "Initial Scheimpflug tilt around Y (radians) — same convention.",
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "Scheimpflug",
+              "type": "string"
+            },
+            "refine_scheimpflug_in_rig_ba": {
+              "default": false,
+              "description": "Re-refine Scheimpflug parameters in rig BA (default: false).",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for multi-camera rig extrinsics calibration.\n\nShared between pinhole and Scheimpflug rigs; the [`SensorMode`] field\n`sensor` selects the sensor flavour.",
+  "properties": {
+    "fix_first_rig_pose": {
+      "description": "Fix first rig pose for gauge freedom (default: true, fixes view 0).",
+      "type": "boolean"
+    },
+    "fix_k3": {
+      "description": "Fix k3 during intrinsics calibration.",
+      "type": "boolean"
+    },
+    "fix_tangential": {
+      "description": "Fix tangential distortion (p1, p2).",
+      "type": "boolean"
+    },
+    "intrinsics_init_iterations": {
+      "description": "Number of iterations for iterative intrinsics estimation.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "max_iters": {
+      "description": "Maximum iterations for optimization.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "reference_camera_idx": {
+      "description": "Reference camera index for rig frame (identity extrinsics).",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "refine_intrinsics_in_rig_ba": {
+      "description": "Re-refine intrinsics in rig BA (default: false).",
+      "type": "boolean"
+    },
+    "robust_loss": {
+      "$ref": "#/$defs/RobustLoss",
+      "description": "Robust loss function for outlier handling."
+    },
+    "sensor": {
+      "$ref": "#/$defs/SensorMode",
+      "default": {
+        "kind": "Pinhole"
+      },
+      "description": "Sensor flavour (pinhole or Scheimpflug)."
+    },
+    "verbosity": {
+      "description": "Verbosity level (0 = silent, 1 = summary, 2+ = detailed).",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "zero_skew": {
+      "description": "Enforce zero skew.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "intrinsics_init_iterations",
+    "fix_k3",
+    "fix_tangential",
+    "zero_skew",
+    "reference_camera_idx",
+    "max_iters",
+    "verbosity",
+    "robust_loss",
+    "refine_intrinsics_in_rig_ba",
+    "fix_first_rig_pose"
+  ],
+  "title": "RigExtrinsicsConfig",
+  "type": "object"
+}

--- a/app/src/schemas/rig_handeye_config.json
+++ b/app/src/schemas/rig_handeye_config.json
@@ -1,0 +1,392 @@
+{
+  "$defs": {
+    "DistortionFixMask": {
+      "description": "Mask for fixing distortion parameters during optimization.\n\nSupports Brown-Conrady distortion model with:\n- Radial coefficients: k1, k2, k3\n- Tangential coefficients: p1, p2\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Default\n\nBy default, `k3` is fixed because it often causes overfitting with\ntypical calibration data. Only enable k3 optimization for wide-angle\nlenses or with high-quality calibration data.\n\n# Example\n\n```\nuse vision_calibration_core::DistortionFixMask;\n\n// Default: k3 fixed, others free\nlet mask = DistortionFixMask::default();\nassert!(!mask.k1);\nassert!(mask.k3); // k3 fixed by default\n\n// Fix tangential distortion\nlet mask = DistortionFixMask {\n    p1: true,\n    p2: true,\n    ..Default::default()\n};\n```",
+      "properties": {
+        "k1": {
+          "description": "Fix first radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k2": {
+          "description": "Fix second radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k3": {
+          "description": "Fix third radial distortion coefficient (fixed by default).",
+          "type": "boolean"
+        },
+        "p1": {
+          "description": "Fix first tangential distortion coefficient.",
+          "type": "boolean"
+        },
+        "p2": {
+          "description": "Fix second tangential distortion coefficient.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "k1",
+        "k2",
+        "k3",
+        "p1",
+        "p2"
+      ],
+      "type": "object"
+    },
+    "HandEyeMode": {
+      "description": "Hand-eye calibration mode.\n\nSpecifies the transform chain used for hand-eye calibration.",
+      "oneOf": [
+        {
+          "const": "EyeInHand",
+          "description": "Camera mounted on robot end-effector (gripper).\n\nTransform chain: P_camera = extr^-1 * handeye^-1 * robot^-1 * target * P_world",
+          "type": "string"
+        },
+        {
+          "const": "EyeToHand",
+          "description": "Camera fixed in workspace, observes robot end-effector.\n\nTransform chain: P_camera = extr^-1 * handeye * robot * target * P_world",
+          "type": "string"
+        }
+      ]
+    },
+    "RigHandeyeBaConfig": {
+      "description": "Hand-eye bundle-adjustment options.",
+      "properties": {
+        "refine_cam_se3_rig_in_handeye_ba": {
+          "description": "Refine cam_se3_rig in hand-eye BA (default: false).\nWhen true, rig extrinsics are further refined during hand-eye optimization.",
+          "type": "boolean"
+        },
+        "refine_robot_poses": {
+          "description": "Refine robot poses in hand-eye BA (default: true).",
+          "type": "boolean"
+        },
+        "refine_scheimpflug_in_handeye_ba": {
+          "default": false,
+          "description": "Refine Scheimpflug tilt parameters in hand-eye BA (default: false).\nOnly consulted when [`SensorMode::Scheimpflug`] is configured; ignored\nfor [`SensorMode::Pinhole`].",
+          "type": "boolean"
+        },
+        "robot_rot_sigma": {
+          "description": "Robot rotation sigma for prior (radians). Default: 0.5° ≈ 0.0087 rad.",
+          "format": "double",
+          "type": "number"
+        },
+        "robot_trans_sigma": {
+          "description": "Robot translation sigma for prior (meters). Default: 1mm = 0.001.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "refine_robot_poses",
+        "robot_rot_sigma",
+        "robot_trans_sigma",
+        "refine_cam_se3_rig_in_handeye_ba"
+      ],
+      "type": "object"
+    },
+    "RigHandeyeInitConfig": {
+      "description": "Hand-eye linear initialization options for rig hand-eye calibration.",
+      "properties": {
+        "handeye_mode": {
+          "$ref": "#/$defs/HandEyeMode",
+          "description": "Hand-eye mode: EyeInHand or EyeToHand."
+        },
+        "min_motion_angle_deg": {
+          "description": "Minimum motion angle (degrees) for linear hand-eye initialization.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "handeye_mode",
+        "min_motion_angle_deg"
+      ],
+      "type": "object"
+    },
+    "RigHandeyeIntrinsicsConfig": {
+      "description": "Per-camera intrinsics initialization options for rig hand-eye calibration.",
+      "properties": {
+        "fix_k3": {
+          "description": "Fix k3 during intrinsics calibration.",
+          "type": "boolean"
+        },
+        "fix_tangential": {
+          "description": "Fix tangential distortion (p1, p2).",
+          "type": "boolean"
+        },
+        "init_iterations": {
+          "description": "Number of iterations for iterative intrinsics estimation.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "zero_skew": {
+          "description": "Enforce zero skew.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "init_iterations",
+        "fix_k3",
+        "fix_tangential",
+        "zero_skew"
+      ],
+      "type": "object"
+    },
+    "RigHandeyeRigConfig": {
+      "description": "Rig-specific options for rig hand-eye calibration.",
+      "properties": {
+        "fix_first_rig_pose": {
+          "description": "Fix first rig pose for gauge freedom (default: true, fixes view 0).",
+          "type": "boolean"
+        },
+        "reference_camera_idx": {
+          "description": "Reference camera index for rig frame (identity extrinsics).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "refine_intrinsics_in_rig_ba": {
+          "description": "Re-refine intrinsics in rig BA (default: false).",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "reference_camera_idx",
+        "refine_intrinsics_in_rig_ba",
+        "fix_first_rig_pose"
+      ],
+      "type": "object"
+    },
+    "RigHandeyeSolverConfig": {
+      "description": "Solver options shared across rig and hand-eye optimization stages.",
+      "properties": {
+        "max_iters": {
+          "description": "Maximum iterations for optimization.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "robust_loss": {
+          "$ref": "#/$defs/RobustLoss",
+          "description": "Robust loss function for outlier handling."
+        },
+        "verbosity": {
+          "description": "Verbosity level (0 = silent, 1 = summary, 2+ = detailed).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "max_iters",
+        "verbosity",
+        "robust_loss"
+      ],
+      "type": "object"
+    },
+    "RobustLoss": {
+      "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
+      "oneOf": [
+        {
+          "const": "None",
+          "description": "No robustification (plain squared residual).",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Huber loss with transition scale.",
+          "properties": {
+            "Huber": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling quadratic-to-linear transition.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Huber"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Cauchy loss with scale parameter.",
+          "properties": {
+            "Cauchy": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling outlier down-weighting.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Cauchy"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Arctangent loss with bounded influence.",
+          "properties": {
+            "Arctan": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling curvature.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Arctan"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ScheimpflugFixMask": {
+      "description": "Mask for Scheimpflug tilt parameters.",
+      "properties": {
+        "tilt_x": {
+          "description": "Keep `tilt_x` fixed during optimization.",
+          "type": "boolean"
+        },
+        "tilt_y": {
+          "description": "Keep `tilt_y` fixed during optimization.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "tilt_x",
+        "tilt_y"
+      ],
+      "type": "object"
+    },
+    "SensorMode": {
+      "description": "Sensor flavour for rig calibration workflows.\n\n`Pinhole` is the default and matches a standard multi-camera rig with\npure pinhole + Brown-Conrady distortion projection. `Scheimpflug` adds\nper-camera tilt parameters; per-camera intrinsics share the pinhole core\nbut include a tilted sensor plane in projection.\n\nThe `Scheimpflug` variant carries its own bootstrap defaults and BA-stage\nfix masks so the rest of the workflow config stays shared between flavours.\n\nRe-exported by [`crate::rig_extrinsics::SensorMode`] and\n[`crate::rig_handeye::SensorMode`] (single source of truth in `rig_family`).",
+      "oneOf": [
+        {
+          "description": "Pinhole + Brown-Conrady projection (no sensor tilt).",
+          "properties": {
+            "kind": {
+              "const": "Pinhole",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Pinhole + Brown-Conrady + Scheimpflug-tilted sensor.",
+          "properties": {
+            "distortion_mask_in_percam_ba": {
+              "$ref": "#/$defs/DistortionFixMask",
+              "default": {
+                "k1": false,
+                "k2": false,
+                "k3": true,
+                "p1": true,
+                "p2": true
+              },
+              "description": "Distortion mask applied during per-camera Scheimpflug intrinsics\nrefinement. Defaults to [`DistortionFixMask::radial_only`]\n(k1, k2 free; k3, p1, p2 fixed) — a safe choice for typical\nScheimpflug rigs where tangential distortion can absorb tilt-like\nsignal. Narrow-FOV rigs that overfit k2 may want\n`(k1, p1, p2) free, (k2, k3) fixed` instead."
+            },
+            "fix_scheimpflug_in_intrinsics": {
+              "$ref": "#/$defs/ScheimpflugFixMask",
+              "default": {
+                "tilt_x": false,
+                "tilt_y": false
+              },
+              "description": "Mask for Scheimpflug parameters during per-camera intrinsics refinement."
+            },
+            "init_tilt_x": {
+              "default": 0.0,
+              "description": "Initial Scheimpflug tilt around X (radians) — used only when no\nper-camera sensor seed is supplied via the workflow's manual init.",
+              "format": "double",
+              "type": "number"
+            },
+            "init_tilt_y": {
+              "default": 0.0,
+              "description": "Initial Scheimpflug tilt around Y (radians) — same convention.",
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "Scheimpflug",
+              "type": "string"
+            },
+            "refine_scheimpflug_in_rig_ba": {
+              "default": false,
+              "description": "Re-refine Scheimpflug parameters in rig BA (default: false).",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for multi-camera rig hand-eye calibration.\n\nShared between pinhole and Scheimpflug rigs; the [`SensorMode`] field\n`sensor` selects the sensor flavour.",
+  "properties": {
+    "handeye_ba": {
+      "$ref": "#/$defs/RigHandeyeBaConfig",
+      "description": "Final hand-eye bundle-adjustment options."
+    },
+    "handeye_init": {
+      "$ref": "#/$defs/RigHandeyeInitConfig",
+      "description": "Hand-eye linear initialization options."
+    },
+    "intrinsics": {
+      "$ref": "#/$defs/RigHandeyeIntrinsicsConfig",
+      "description": "Per-camera intrinsics initialization options."
+    },
+    "rig": {
+      "$ref": "#/$defs/RigHandeyeRigConfig",
+      "description": "Rig and gauge options."
+    },
+    "sensor": {
+      "$ref": "#/$defs/SensorMode",
+      "default": {
+        "kind": "Pinhole"
+      },
+      "description": "Sensor flavour (pinhole or Scheimpflug). Default is `Pinhole`."
+    },
+    "solver": {
+      "$ref": "#/$defs/RigHandeyeSolverConfig",
+      "description": "Shared solver settings for optimization stages."
+    }
+  },
+  "required": [
+    "intrinsics",
+    "rig",
+    "handeye_init",
+    "solver",
+    "handeye_ba"
+  ],
+  "title": "RigHandeyeConfig",
+  "type": "object"
+}

--- a/app/src/schemas/rig_laserline_device_config.json
+++ b/app/src/schemas/rig_laserline_device_config.json
@@ -1,0 +1,50 @@
+{
+  "$defs": {
+    "LaserlineResidualType": {
+      "description": "Type of laser plane residual to use.",
+      "oneOf": [
+        {
+          "const": "PointToPlane",
+          "description": "Point-to-plane distance (original approach).\n\nUndistorts pixel, back-projects to 3D ray, intersects with target plane,\ncomputes 3D point in camera frame, measures signed distance to laser plane.\nResidual: 1D distance in meters.",
+          "type": "string"
+        },
+        {
+          "const": "LineDistNormalized",
+          "description": "Line-distance in normalized plane (alternative approach).\n\nComputes 3D intersection line of laser plane and target plane, projects\nline onto z=1 normalized camera plane, undistorts laser pixels to normalized\ncoordinates, measures perpendicular distance from pixel to projected line,\nscales by sqrt(fx*fy) for pixel-comparable residual.\nResidual: 1D distance in pixels.",
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for rig laserline calibration.",
+  "properties": {
+    "laser_residual_type": {
+      "$ref": "#/$defs/LaserlineResidualType",
+      "description": "Laser residual type (point-to-plane vs line-distance)."
+    },
+    "max_iters": {
+      "description": "Maximum solver iterations.",
+      "format": "uint",
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "verbosity": {
+      "description": "Verbosity level.",
+      "format": "uint",
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "laser_residual_type"
+  ],
+  "title": "RigLaserlineDeviceConfig",
+  "type": "object"
+}

--- a/app/src/schemas/scheimpflug_intrinsics_config.json
+++ b/app/src/schemas/scheimpflug_intrinsics_config.json
@@ -1,0 +1,226 @@
+{
+  "$defs": {
+    "DistortionFixMask": {
+      "description": "Mask for fixing distortion parameters during optimization.\n\nSupports Brown-Conrady distortion model with:\n- Radial coefficients: k1, k2, k3\n- Tangential coefficients: p1, p2\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Default\n\nBy default, `k3` is fixed because it often causes overfitting with\ntypical calibration data. Only enable k3 optimization for wide-angle\nlenses or with high-quality calibration data.\n\n# Example\n\n```\nuse vision_calibration_core::DistortionFixMask;\n\n// Default: k3 fixed, others free\nlet mask = DistortionFixMask::default();\nassert!(!mask.k1);\nassert!(mask.k3); // k3 fixed by default\n\n// Fix tangential distortion\nlet mask = DistortionFixMask {\n    p1: true,\n    p2: true,\n    ..Default::default()\n};\n```",
+      "properties": {
+        "k1": {
+          "description": "Fix first radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k2": {
+          "description": "Fix second radial distortion coefficient.",
+          "type": "boolean"
+        },
+        "k3": {
+          "description": "Fix third radial distortion coefficient (fixed by default).",
+          "type": "boolean"
+        },
+        "p1": {
+          "description": "Fix first tangential distortion coefficient.",
+          "type": "boolean"
+        },
+        "p2": {
+          "description": "Fix second tangential distortion coefficient.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "k1",
+        "k2",
+        "k3",
+        "p1",
+        "p2"
+      ],
+      "type": "object"
+    },
+    "IntrinsicsFixMask": {
+      "description": "Mask for fixing intrinsics parameters during optimization.\n\nEach field corresponds to a component of the camera matrix K:\n```text\nK = | fx   skew  cx |\n    | 0    fy    cy |\n    | 0    0     1  |\n```\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Example\n\n```\nuse vision_calibration_core::IntrinsicsFixMask;\n\n// Fix only the principal point\nlet mask = IntrinsicsFixMask {\n    cx: true,\n    cy: true,\n    ..Default::default()\n};\n\nassert!(!mask.fx); // fx will be optimized\nassert!(mask.cx);  // cx is fixed\n```",
+      "properties": {
+        "cx": {
+          "description": "Fix principal point x component.",
+          "type": "boolean"
+        },
+        "cy": {
+          "description": "Fix principal point y component.",
+          "type": "boolean"
+        },
+        "fx": {
+          "description": "Fix focal length x component.",
+          "type": "boolean"
+        },
+        "fy": {
+          "description": "Fix focal length y component.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "fx",
+        "fy",
+        "cx",
+        "cy"
+      ],
+      "type": "object"
+    },
+    "RobustLoss": {
+      "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
+      "oneOf": [
+        {
+          "const": "None",
+          "description": "No robustification (plain squared residual).",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Huber loss with transition scale.",
+          "properties": {
+            "Huber": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling quadratic-to-linear transition.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Huber"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Cauchy loss with scale parameter.",
+          "properties": {
+            "Cauchy": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling outlier down-weighting.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Cauchy"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Arctangent loss with bounded influence.",
+          "properties": {
+            "Arctan": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling curvature.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Arctan"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ScheimpflugFixMask": {
+      "description": "Optimization mask for Scheimpflug tilt parameters.",
+      "properties": {
+        "tilt_x": {
+          "description": "Keep `tilt_x` fixed during optimization.",
+          "type": "boolean"
+        },
+        "tilt_y": {
+          "description": "Keep `tilt_y` fixed during optimization.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "tilt_x",
+        "tilt_y"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for planar Scheimpflug intrinsics calibration.",
+  "properties": {
+    "fix_distortion": {
+      "$ref": "#/$defs/DistortionFixMask",
+      "description": "Distortion parameter fix mask for non-linear optimization."
+    },
+    "fix_first_pose": {
+      "description": "Keep the first pose fixed to remove gauge ambiguity.",
+      "type": "boolean"
+    },
+    "fix_intrinsics": {
+      "$ref": "#/$defs/IntrinsicsFixMask",
+      "description": "Intrinsics parameter fix mask for non-linear optimization."
+    },
+    "fix_k3_in_init": {
+      "description": "Keep `k3` fixed in the linear initialization stage.",
+      "type": "boolean"
+    },
+    "fix_scheimpflug": {
+      "$ref": "#/$defs/ScheimpflugFixMask",
+      "description": "Scheimpflug tilt parameter fix mask for non-linear optimization."
+    },
+    "init_iterations": {
+      "description": "Number of iterative linear intrinsics initialization rounds.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "max_iters": {
+      "description": "Maximum LM iterations for non-linear optimization.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "robust_loss": {
+      "$ref": "#/$defs/RobustLoss",
+      "description": "Robust loss applied per reprojection residual."
+    },
+    "verbosity": {
+      "description": "Backend verbosity level.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "zero_skew": {
+      "description": "Enforce zero skew in initialization.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "init_iterations",
+    "fix_k3_in_init",
+    "zero_skew",
+    "max_iters",
+    "verbosity",
+    "robust_loss",
+    "fix_intrinsics",
+    "fix_distortion",
+    "fix_scheimpflug",
+    "fix_first_pose"
+  ],
+  "title": "ScheimpflugIntrinsicsConfig",
+  "type": "object"
+}

--- a/app/src/schemas/single_cam_handeye_config.json
+++ b/app/src/schemas/single_cam_handeye_config.json
@@ -1,0 +1,175 @@
+{
+  "$defs": {
+    "HandEyeMode": {
+      "description": "Hand-eye calibration mode.\n\nSpecifies the transform chain used for hand-eye calibration.",
+      "oneOf": [
+        {
+          "const": "EyeInHand",
+          "description": "Camera mounted on robot end-effector (gripper).\n\nTransform chain: P_camera = extr^-1 * handeye^-1 * robot^-1 * target * P_world",
+          "type": "string"
+        },
+        {
+          "const": "EyeToHand",
+          "description": "Camera fixed in workspace, observes robot end-effector.\n\nTransform chain: P_camera = extr^-1 * handeye * robot * target * P_world",
+          "type": "string"
+        }
+      ]
+    },
+    "RobustLoss": {
+      "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
+      "oneOf": [
+        {
+          "const": "None",
+          "description": "No robustification (plain squared residual).",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Huber loss with transition scale.",
+          "properties": {
+            "Huber": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling quadratic-to-linear transition.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Huber"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Cauchy loss with scale parameter.",
+          "properties": {
+            "Cauchy": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling outlier down-weighting.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Cauchy"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Arctangent loss with bounded influence.",
+          "properties": {
+            "Arctan": {
+              "properties": {
+                "scale": {
+                  "description": "Scale parameter controlling curvature.",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "scale"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "Arctan"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Configuration for single-camera hand-eye calibration.",
+  "properties": {
+    "fix_k3": {
+      "description": "Fix k3 during initialization.",
+      "type": "boolean"
+    },
+    "fix_tangential": {
+      "description": "Fix tangential distortion (p1, p2) during initialization.",
+      "type": "boolean"
+    },
+    "handeye_mode": {
+      "$ref": "#/$defs/HandEyeMode",
+      "description": "Hand-eye mode (EyeInHand or EyeToHand)."
+    },
+    "intrinsics_init_iterations": {
+      "description": "Number of iterations for iterative intrinsics estimation.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "max_iters": {
+      "description": "Maximum iterations for optimization.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "min_motion_angle_deg": {
+      "description": "Minimum motion angle (degrees) for linear hand-eye initialization.",
+      "format": "double",
+      "type": "number"
+    },
+    "refine_robot_poses": {
+      "description": "Refine robot poses with per-view se(3) corrections (default: true).",
+      "type": "boolean"
+    },
+    "robot_rot_sigma": {
+      "description": "Robot rotation prior sigma (radians). Default: 0.5 deg.",
+      "format": "double",
+      "type": "number"
+    },
+    "robot_trans_sigma": {
+      "description": "Robot translation prior sigma (meters). Default: 1 mm.",
+      "format": "double",
+      "type": "number"
+    },
+    "robust_loss": {
+      "$ref": "#/$defs/RobustLoss",
+      "description": "Robust loss function for outlier handling."
+    },
+    "verbosity": {
+      "description": "Verbosity level (0 = silent, 1 = summary, 2+ = detailed).",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "zero_skew": {
+      "description": "Enforce zero skew.",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "intrinsics_init_iterations",
+    "fix_k3",
+    "fix_tangential",
+    "zero_skew",
+    "handeye_mode",
+    "min_motion_angle_deg",
+    "max_iters",
+    "verbosity",
+    "robust_loss",
+    "refine_robot_poses",
+    "robot_rot_sigma",
+    "robot_trans_sigma"
+  ],
+  "title": "SingleCamHandeyeConfig",
+  "type": "object"
+}

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -19,6 +19,88 @@ function nextInWrap(arr: number[], current: number, delta: number): number {
   return arr[(((idx + delta) % n) + n) % n];
 }
 
+interface MaterializedExport {
+  frames: FrameKey[];
+  poseValues: number[];
+  cameraValues: number[];
+  posesByCamera: Map<number, number[]>;
+  camerasByPose: Map<number, number[]>;
+  first: FrameKey;
+  second: FrameKey;
+}
+
+function materializeExport(data: AnyExport, exportDir: string):
+  | { ok: true; value: MaterializedExport }
+  | { ok: false; error: string } {
+  const manifest = data.image_manifest;
+  if (!manifest) {
+    return {
+      ok: false,
+      error:
+        "This export has no image_manifest field. v0 requires the manifest to render the source images alongside the residuals.",
+    };
+  }
+  const root = joinPath(exportDir, manifest.root);
+  const frames: FrameKey[] = manifest.frames.map((f) => ({
+    pose: f.pose,
+    camera: f.camera,
+    label: `pose ${f.pose} · cam ${f.camera}`,
+    abs_path: joinPath(root, f.path),
+    roi: f.roi,
+  }));
+  if (frames.length === 0) {
+    return {
+      ok: false,
+      error:
+        "This export's image_manifest is empty. v0 needs at least one (pose, camera) frame to render.",
+    };
+  }
+
+  const poseSet = new Set<number>();
+  const cameraSet = new Set<number>();
+  const posesByCameraSet = new Map<number, Set<number>>();
+  const camerasByPoseSet = new Map<number, Set<number>>();
+  for (const f of frames) {
+    poseSet.add(f.pose);
+    cameraSet.add(f.camera);
+    if (!posesByCameraSet.has(f.camera)) {
+      posesByCameraSet.set(f.camera, new Set());
+    }
+    posesByCameraSet.get(f.camera)!.add(f.pose);
+    if (!camerasByPoseSet.has(f.pose)) {
+      camerasByPoseSet.set(f.pose, new Set());
+    }
+    camerasByPoseSet.get(f.pose)!.add(f.camera);
+  }
+  const sortNum = (s: Set<number>) => [...s].sort((a, b) => a - b);
+  const poseValues = sortNum(poseSet);
+  const cameraValues = sortNum(cameraSet);
+  const posesByCamera = new Map(
+    [...posesByCameraSet].map(([k, v]) => [k, sortNum(v)]),
+  );
+  const camerasByPose = new Map(
+    [...camerasByPoseSet].map(([k, v]) => [k, sortNum(v)]),
+  );
+
+  const first = frames[0];
+  const second =
+    frames.find((f) => f.pose !== first.pose || f.camera !== first.camera) ??
+    first;
+
+  return {
+    ok: true,
+    value: {
+      frames,
+      poseValues,
+      cameraValues,
+      posesByCamera,
+      camerasByPose,
+      first,
+      second,
+    },
+  };
+}
+
 export interface ExportSlice {
   exportPath: string | null;
   exportDir: string | null;
@@ -31,6 +113,7 @@ export interface ExportSlice {
   camerasByPose: Map<number, number[]>;
   loadError: string | null;
   loadExport: (path: string) => Promise<void>;
+  acceptLiveRunExport: (exportValue: unknown, exportDir: string) => void;
   resetExport: () => void;
   setLoadError: (msg: string | null) => void;
 }
@@ -91,68 +174,11 @@ export const useStore = create<AppState>()(
         return;
       }
       const data = result.export;
-      const manifest = data.image_manifest;
-      if (!manifest) {
-        // Reject the file. We deliberately do NOT promote it to the
-        // backend export cache — `compute_epipolar_overlay` (and any
-        // future math command) must keep operating against the
-        // previous accepted export until the user picks a valid one.
-        set({
-          loadError:
-            "This export has no image_manifest field. v0 requires the manifest to render the source images alongside the residuals.",
-        });
+      const materialized = materializeExport(data, result.export_dir);
+      if (!materialized.ok) {
+        set({ loadError: materialized.error });
         return;
       }
-      const root = joinPath(result.export_dir, manifest.root);
-      const frames: FrameKey[] = manifest.frames.map((f) => ({
-        pose: f.pose,
-        camera: f.camera,
-        label: `pose ${f.pose} · cam ${f.camera}`,
-        abs_path: joinPath(root, f.path),
-        roi: f.roi,
-      }));
-      if (frames.length === 0) {
-        set({
-          loadError:
-            "This export's image_manifest is empty. v0 needs at least one (pose, camera) frame to render.",
-        });
-        return;
-      }
-
-      // Build sparse availability indices off the actual manifest entries.
-      // A manifest may be sparse (detector failures, partial captures), so
-      // navigation must NOT walk a dense [0..max] Cartesian grid.
-      const poseSet = new Set<number>();
-      const cameraSet = new Set<number>();
-      const posesByCameraSet = new Map<number, Set<number>>();
-      const camerasByPoseSet = new Map<number, Set<number>>();
-      for (const f of frames) {
-        poseSet.add(f.pose);
-        cameraSet.add(f.camera);
-        if (!posesByCameraSet.has(f.camera)) {
-          posesByCameraSet.set(f.camera, new Set());
-        }
-        posesByCameraSet.get(f.camera)!.add(f.pose);
-        if (!camerasByPoseSet.has(f.pose)) {
-          camerasByPoseSet.set(f.pose, new Set());
-        }
-        camerasByPoseSet.get(f.pose)!.add(f.camera);
-      }
-      const sortNum = (s: Set<number>) => [...s].sort((a, b) => a - b);
-      const poseValues = sortNum(poseSet);
-      const cameraValues = sortNum(cameraSet);
-      const posesByCamera = new Map(
-        [...posesByCameraSet].map(([k, v]) => [k, sortNum(v)]),
-      );
-      const camerasByPose = new Map(
-        [...camerasByPoseSet].map(([k, v]) => [k, sortNum(v)]),
-      );
-
-      const first = frames[0];
-      const second =
-        frames.find(
-          (f) => f.pose !== first.pose || f.camera !== first.camera,
-        ) ?? first;
 
       // Promote the validated export into the backend cache *before*
       // updating the frontend state, so `compute_epipolar_overlay` and
@@ -171,16 +197,43 @@ export const useStore = create<AppState>()(
         exportDir: result.export_dir,
         data,
         kind: inferExportKind(data),
-        frames,
-        poseValues,
-        cameraValues,
-        posesByCamera,
-        camerasByPose,
+        frames: materialized.value.frames,
+        poseValues: materialized.value.poseValues,
+        cameraValues: materialized.value.cameraValues,
+        posesByCamera: materialized.value.posesByCamera,
+        camerasByPose: materialized.value.camerasByPose,
         loadError: null,
-        selectedPose: first.pose,
-        selectedPoseB: second.pose,
-        cameraA: first.camera,
-        cameraB: second.camera,
+        selectedPose: materialized.value.first.pose,
+        selectedPoseB: materialized.value.second.pose,
+        cameraA: materialized.value.first.camera,
+        cameraB: materialized.value.second.camera,
+        selectedFeature: null,
+        hoverFeature: null,
+      });
+    },
+
+    acceptLiveRunExport: (exportValue, exportDir) => {
+      const data = exportValue as AnyExport;
+      const materialized = materializeExport(data, exportDir);
+      if (!materialized.ok) {
+        set({ loadError: materialized.error });
+        return;
+      }
+      set({
+        exportPath: "<live-run>",
+        exportDir,
+        data,
+        kind: inferExportKind(data),
+        frames: materialized.value.frames,
+        poseValues: materialized.value.poseValues,
+        cameraValues: materialized.value.cameraValues,
+        posesByCamera: materialized.value.posesByCamera,
+        camerasByPose: materialized.value.camerasByPose,
+        loadError: null,
+        selectedPose: materialized.value.first.pose,
+        selectedPoseB: materialized.value.second.pose,
+        cameraA: materialized.value.first.camera,
+        cameraB: materialized.value.second.camera,
         selectedFeature: null,
         hoverFeature: null,
       });

--- a/app/src/workspaces/EpipolarWorkspace/index.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/index.tsx
@@ -11,7 +11,7 @@ import {
   type FrameCanvasHandle,
 } from "../../components/FrameCanvas";
 import { PoseStepper } from "../../components/PoseStepper";
-import { useImageData } from "../../hooks/useImageData";
+import { useUndistortedImageData } from "../../hooks/useImageData";
 import {
   iso3DistanceM,
   iso3EulerXYZDeg,
@@ -231,8 +231,61 @@ function EpipolarBody(props: BodyProps) {
     () => residualsForPose.filter((r) => r.camera === cameraB),
     [residualsForPose, cameraB],
   );
+  const [undistortedResidualsA, setUndistortedResidualsA] = useState<
+    TargetFeatureResidual[]
+  >([]);
+  const [undistortedResidualsB, setUndistortedResidualsB] = useState<
+    TargetFeatureResidual[]
+  >([]);
+
+  const imageA = useUndistortedImageData(frameA, cameraA, setOverlayError);
+  const imageB = useUndistortedImageData(frameB, cameraB, setOverlayError);
 
   const latestRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      try {
+        const [pointsA, pointsB] = await Promise.all([
+          residualsA.length > 0
+            ? invoke<[number, number][]>("undistort_points", {
+                camera: cameraA,
+                pointsPx: residualsA.map((r) => r.observed_px),
+              })
+            : Promise.resolve<[number, number][]>([]),
+          residualsB.length > 0
+            ? invoke<[number, number][]>("undistort_points", {
+                camera: cameraB,
+                pointsPx: residualsB.map((r) => r.observed_px),
+              })
+            : Promise.resolve<[number, number][]>([]),
+        ]);
+        if (cancelled) return;
+        setUndistortedResidualsA(
+          residualsA.map((r, i) => ({
+            ...r,
+            observed_px: pointsA[i] ?? r.observed_px,
+          })),
+        );
+        setUndistortedResidualsB(
+          residualsB.map((r, i) => ({
+            ...r,
+            observed_px: pointsB[i] ?? r.observed_px,
+          })),
+        );
+      } catch (e) {
+        if (cancelled) return;
+        setUndistortedResidualsA([]);
+        setUndistortedResidualsB([]);
+        setOverlayError(`undistort points failed: ${e}`);
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [cameraA, cameraB, residualsA, residualsB, setOverlayError]);
 
   // Reset the overlay whenever the working tuple changes; bump the
   // request id so any in-flight response from the previous tuple is
@@ -252,7 +305,7 @@ function EpipolarBody(props: BodyProps) {
       let feature: number | null = null;
       let bestDist = FEATURE_SNAP_PX;
       let snappedPx: [number, number] = px;
-      for (const r of residualsA) {
+      for (const r of undistortedResidualsA) {
         const dx = r.observed_px[0] - px[0];
         const dy = r.observed_px[1] - px[1];
         const d = Math.hypot(dx, dy);
@@ -266,10 +319,21 @@ function EpipolarBody(props: BodyProps) {
       setOverlayError(null);
       latestRequestIdRef.current += 1;
       const myRequestId = latestRequestIdRef.current;
+      if (!imageB) {
+        setOverlay(null);
+        setOverlayError("epipolar overlay failed: pane-B undistorted image is not ready yet");
+        return;
+      }
       try {
         const result = await invoke<EpipolarOverlayResult>(
-          "compute_epipolar_overlay",
-          { camA: cameraA, camB: cameraB, pointPx: snappedPx },
+          "compute_epipolar_overlay_undistorted",
+          {
+            camA: cameraA,
+            camB: cameraB,
+            pointPx: snappedPx,
+            imageWidthB: imageB.naturalWidth,
+            imageHeightB: imageB.naturalHeight,
+          },
         );
         if (myRequestId !== latestRequestIdRef.current) return;
         setOverlay(result);
@@ -279,38 +343,23 @@ function EpipolarBody(props: BodyProps) {
         setOverlayError(`epipolar overlay failed: ${e}`);
       }
     },
-    [cameraA, cameraB, residualsA, setOverlay, setOverlayError, setPicked],
+    [
+      cameraA,
+      cameraB,
+      imageB,
+      setOverlay,
+      setOverlayError,
+      setPicked,
+      undistortedResidualsA,
+    ],
   );
 
   const ghostInB = useMemo<TargetFeatureResidual | null>(() => {
     if (!picked || picked.feature == null) return null;
-    return residualsB.find((r) => r.feature === picked.feature) ?? null;
-  }, [picked, residualsB]);
+    return undistortedResidualsB.find((r) => r.feature === picked.feature) ?? null;
+  }, [picked, undistortedResidualsB]);
 
-  // Polyline clipped strictly to pane-B's image bounds + split on
-  // unphysically large jumps. The Rust side sweeps depths from 0.05 m
-  // to 5 m, which is wider than any real dataset's working volume —
-  // most samples land outside the image and pull the polyline into a
-  // long curve (distortion gets visually amplified far from the
-  // principal point). On top of that, when cam A's ray approaches
-  // cam B's optical axis the projection passes through a near-
-  // singular fold zone and consecutive samples can land hundreds of
-  // pixels apart on opposite sides of the epipolar line — visually a
-  // "parabola" / fork. We keep only the longest contiguous in-image
-  // run AND require that consecutive surviving samples are close
-  // enough that the line is physically plausible.
-  const clippedPolyline = useMemo<[number, number][] | undefined>(() => {
-    if (!overlay || overlay.line_b.length < 2) return undefined;
-    if (!frameB) return overlay.line_b;
-    const w = frameB.roi?.w ?? 0;
-    const h = frameB.roi?.h ?? 0;
-    if (w === 0 || h === 0) return overlay.line_b;
-    // Quarter-frame jumps between consecutive depth samples are
-    // physically impossible for a smooth epipolar line and reliably
-    // indicate a fold-through-singularity in the projection.
-    const jumpPx = Math.min(w, h) * 0.25;
-    return longestContinuousRun(overlay.line_b, w, h, jumpPx);
-  }, [overlay, frameB]);
+  const clippedPolyline = overlay && overlay.line_b.length >= 2 ? overlay.line_b : undefined;
 
   // Distance from the corresponding pane-B feature to the polyline in
   // pixels — the calibration's epipolar residual for the picked
@@ -332,42 +381,42 @@ function EpipolarBody(props: BodyProps) {
 
   const tieMarkersA = useMemo<OverlayPoint[]>(() => {
     if (!showTieLines) return [];
-    return residualsA.map((r) => ({
+    return undistortedResidualsA.map((r) => ({
       px: r.observed_px,
       color: "var(--color-muted-foreground, #888)",
       dot: true,
       size: 4,
     }));
-  }, [showTieLines, residualsA]);
+  }, [showTieLines, undistortedResidualsA]);
 
   const tieMarkersB = useMemo<OverlayPoint[]>(() => {
     if (!showTieLines) return [];
-    return residualsB.map((r) => ({
+    return undistortedResidualsB.map((r) => ({
       px: r.observed_px,
       color: "var(--color-muted-foreground, #888)",
       dot: true,
       size: 4,
     }));
-  }, [showTieLines, residualsB]);
+  }, [showTieLines, undistortedResidualsB]);
 
   const featureMarkersA = useMemo<OverlayPoint[]>(() => {
     if (!showFeatures) return [];
-    return residualsA.map((r) => ({
+    return undistortedResidualsA.map((r) => ({
       px: r.observed_px,
       color: "var(--color-accent, #888)",
       dot: true,
       size: 6,
     }));
-  }, [showFeatures, residualsA]);
+  }, [showFeatures, undistortedResidualsA]);
   const featureMarkersB = useMemo<OverlayPoint[]>(() => {
     if (!showFeatures) return [];
-    return residualsB.map((r) => ({
+    return undistortedResidualsB.map((r) => ({
       px: r.observed_px,
       color: "var(--color-accent, #888)",
       dot: true,
       size: 6,
     }));
-  }, [showFeatures, residualsB]);
+  }, [showFeatures, undistortedResidualsB]);
 
   const markersA: OverlayPoint[] = [
     ...featureMarkersA,
@@ -502,23 +551,23 @@ function EpipolarBody(props: BodyProps) {
       <div className="grid min-h-0 flex-1 grid-cols-2 gap-2 overflow-hidden rounded-md bg-bg-soft p-2">
         <Pane
           frame={frameA}
-          residuals={residualsForPose}
           transform={linked ? linkedTransform : transformA}
           onTransformChange={linked ? setLinkedTransform : setTransformA}
           onPick={handlePickA}
           markers={markersA}
-          caption={frameA ? `pane A · cam ${cameraA}${showFeatures ? " · click feature or anywhere" : " · click to pick"}` : undefined}
+          image={imageA?.image ?? null}
+          caption={frameA ? `pane A · cam ${cameraA} · undistorted${showFeatures ? " · click feature or anywhere" : " · click to pick"}` : undefined}
           handleRef={handleARef}
         />
         <Pane
           frame={frameB}
-          residuals={residualsForPose}
           transform={linked ? linkedTransform : transformB}
           onTransformChange={linked ? setLinkedTransform : setTransformB}
           polyline={clippedPolyline}
           polylineColor="var(--color-brand, #1abc9c)"
           markers={markersB}
-          caption={frameB ? `pane B · cam ${cameraB}` : undefined}
+          image={imageB?.image ?? null}
+          caption={frameB ? `pane B · cam ${cameraB} · undistorted` : undefined}
           handleRef={handleBRef}
           annotation={
             ghostInB && ghostDistancePx != null
@@ -538,69 +587,6 @@ function EpipolarBody(props: BodyProps) {
       </div>
     </section>
   );
-}
-
-/** Return the longest contiguous run of polyline points that
- * (a) fall inside `[0, w] × [0, h]` AND
- * (b) sit within `jumpPx` of the previous in-run point.
- *
- * The Rust side densely samples depths along the back-projected ray;
- * only some samples project inside pane B's image. Filtering
- * in-bounds points and re-stitching them into one polyline draws a
- * "straight bridge" across out-of-image gaps, which looks like a
- * curve. Worse, when the ray passes near cam B's principal axis the
- * projection wraps around a near-singularity and consecutive in-image
- * samples can land hundreds of pixels apart on opposite sides of the
- * actual epipolar line — visually a fork / "parabola". Picking the
- * single longest run that survives both filters sidesteps both
- * artefacts. */
-function longestContinuousRun(
-  pts: [number, number][],
-  w: number,
-  h: number,
-  jumpPx: number,
-): [number, number][] {
-  let bestStart = 0;
-  let bestLen = 0;
-  let curStart = -1;
-  let curLen = 0;
-  const flushIfBetter = () => {
-    if (curLen > bestLen) {
-      bestLen = curLen;
-      bestStart = curStart;
-    }
-  };
-  const reset = (i: number) => {
-    flushIfBetter();
-    curStart = i;
-    curLen = 0;
-  };
-  const inBounds = (x: number, y: number) => x >= 0 && x <= w && y >= 0 && y <= h;
-  for (let i = 0; i < pts.length; i++) {
-    const [x, y] = pts[i];
-    if (!inBounds(x, y)) {
-      if (curLen > 0) reset(-1);
-      continue;
-    }
-    if (curStart < 0) {
-      curStart = i;
-      curLen = 1;
-      continue;
-    }
-    const [px, py] = pts[curStart + curLen - 1];
-    const dx = x - px;
-    const dy = y - py;
-    if (dx * dx + dy * dy > jumpPx * jumpPx) {
-      // Singularity-induced fold: end the current run at `i-1` and
-      // start a new one at `i`.
-      reset(i);
-      curLen = 1;
-      continue;
-    }
-    curLen += 1;
-  }
-  flushIfBetter();
-  return bestLen > 0 ? pts.slice(bestStart, bestStart + bestLen) : [];
 }
 
 function distanceToPolyline(
@@ -635,7 +621,6 @@ function distanceToSegment(
 
 interface PaneProps {
   frame: FrameKey | null;
-  residuals: TargetFeatureResidual[];
   transform: ViewportTransform;
   onTransformChange: (t: ViewportTransform) => void;
   onPick?: (pixel: { x: number; y: number }) => void;
@@ -643,13 +628,13 @@ interface PaneProps {
   polylineColor?: string;
   markers?: OverlayPoint[];
   caption?: string;
+  image: HTMLImageElement | null;
   handleRef: React.MutableRefObject<FrameCanvasHandle | null>;
   annotation?: { px: [number, number]; text: string; color: string };
 }
 
 function Pane({
   frame,
-  residuals,
   transform,
   onTransformChange,
   onPick,
@@ -657,6 +642,7 @@ function Pane({
   polylineColor,
   markers,
   caption,
+  image,
   handleRef,
   annotation,
 }: PaneProps) {
@@ -671,7 +657,6 @@ function Pane({
     <PaneInner
       key={frame.abs_path}
       frame={frame}
-      residuals={residuals}
       transform={transform}
       onTransformChange={onTransformChange}
       onPick={onPick}
@@ -679,6 +664,7 @@ function Pane({
       polylineColor={polylineColor}
       markers={markers}
       caption={caption}
+      image={image}
       handleRef={handleRef}
       annotation={annotation}
     />
@@ -687,7 +673,6 @@ function Pane({
 
 function PaneInner({
   frame,
-  residuals,
   transform,
   onTransformChange,
   onPick,
@@ -695,18 +680,22 @@ function PaneInner({
   polylineColor,
   markers,
   caption,
+  image,
   handleRef,
   annotation,
 }: PaneProps & { frame: FrameKey }) {
-  const image = useImageData(frame);
+  const displayFrame = useMemo<FrameKey>(
+    () => ({ ...frame, roi: undefined }),
+    [frame],
+  );
   return (
     <div className="relative flex h-full flex-col">
       <div className="relative flex-1 overflow-hidden">
         <FrameCanvas
           ref={handleRef}
-          frame={frame}
-          residuals={residuals}
-          image={image?.image ?? null}
+          frame={displayFrame}
+          residuals={[]}
+          image={image}
           transform={transform}
           onTransformChange={onTransformChange}
           onPick={onPick}

--- a/app/src/workspaces/EpipolarWorkspace/index.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/index.tsx
@@ -287,21 +287,29 @@ function EpipolarBody(props: BodyProps) {
     return residualsB.find((r) => r.feature === picked.feature) ?? null;
   }, [picked, residualsB]);
 
-  // Polyline clipped strictly to pane-B's image bounds. The Rust side
-  // sweeps depths from 0.05 m to 5 m, which is wider than any real
-  // dataset's working volume — most samples land outside the image
-  // and pull the polyline into a long curve (distortion gets visually
-  // amplified far from the principal point). Only the in-image
-  // portion is what the engineer actually reads, so we drop the rest
-  // and keep only the longest contiguous in-image run to avoid a
-  // straight bridge across an out-of-image gap.
+  // Polyline clipped strictly to pane-B's image bounds + split on
+  // unphysically large jumps. The Rust side sweeps depths from 0.05 m
+  // to 5 m, which is wider than any real dataset's working volume —
+  // most samples land outside the image and pull the polyline into a
+  // long curve (distortion gets visually amplified far from the
+  // principal point). On top of that, when cam A's ray approaches
+  // cam B's optical axis the projection passes through a near-
+  // singular fold zone and consecutive samples can land hundreds of
+  // pixels apart on opposite sides of the epipolar line — visually a
+  // "parabola" / fork. We keep only the longest contiguous in-image
+  // run AND require that consecutive surviving samples are close
+  // enough that the line is physically plausible.
   const clippedPolyline = useMemo<[number, number][] | undefined>(() => {
     if (!overlay || overlay.line_b.length < 2) return undefined;
     if (!frameB) return overlay.line_b;
     const w = frameB.roi?.w ?? 0;
     const h = frameB.roi?.h ?? 0;
     if (w === 0 || h === 0) return overlay.line_b;
-    return longestInImageRun(overlay.line_b, w, h);
+    // Quarter-frame jumps between consecutive depth samples are
+    // physically impossible for a smooth epipolar line and reliably
+    // indicate a fold-through-singularity in the projection.
+    const jumpPx = Math.min(w, h) * 0.25;
+    return longestContinuousRun(overlay.line_b, w, h, jumpPx);
   }, [overlay, frameB]);
 
   // Distance from the corresponding pane-B feature to the polyline in
@@ -532,43 +540,66 @@ function EpipolarBody(props: BodyProps) {
   );
 }
 
-/** Return the longest contiguous run of polyline points that fall
- * inside `[0, w] × [0, h]`. The Rust side densely samples depths along
- * the back-projected ray; only some samples project inside pane B's
- * image. Filtering kept-in-bounds points and re-stitching them into
- * one polyline draws a "straight bridge" across out-of-image gaps,
- * which looks like a curve. Picking the single longest in-image run
- * sidesteps that. */
-function longestInImageRun(
+/** Return the longest contiguous run of polyline points that
+ * (a) fall inside `[0, w] × [0, h]` AND
+ * (b) sit within `jumpPx` of the previous in-run point.
+ *
+ * The Rust side densely samples depths along the back-projected ray;
+ * only some samples project inside pane B's image. Filtering
+ * in-bounds points and re-stitching them into one polyline draws a
+ * "straight bridge" across out-of-image gaps, which looks like a
+ * curve. Worse, when the ray passes near cam B's principal axis the
+ * projection wraps around a near-singularity and consecutive in-image
+ * samples can land hundreds of pixels apart on opposite sides of the
+ * actual epipolar line — visually a fork / "parabola". Picking the
+ * single longest run that survives both filters sidesteps both
+ * artefacts. */
+function longestContinuousRun(
   pts: [number, number][],
   w: number,
   h: number,
+  jumpPx: number,
 ): [number, number][] {
   let bestStart = 0;
   let bestLen = 0;
   let curStart = -1;
   let curLen = 0;
-  const flush = (i: number) => {
+  const flushIfBetter = () => {
     if (curLen > bestLen) {
       bestLen = curLen;
       bestStart = curStart;
     }
+  };
+  const reset = (i: number) => {
+    flushIfBetter();
     curStart = i;
     curLen = 0;
   };
+  const inBounds = (x: number, y: number) => x >= 0 && x <= w && y >= 0 && y <= h;
   for (let i = 0; i < pts.length; i++) {
     const [x, y] = pts[i];
-    if (x >= 0 && x <= w && y >= 0 && y <= h) {
-      if (curStart < 0) curStart = i;
-      curLen += 1;
-    } else if (curLen > 0) {
-      flush(i + 1);
+    if (!inBounds(x, y)) {
+      if (curLen > 0) reset(-1);
+      continue;
     }
+    if (curStart < 0) {
+      curStart = i;
+      curLen = 1;
+      continue;
+    }
+    const [px, py] = pts[curStart + curLen - 1];
+    const dx = x - px;
+    const dy = y - py;
+    if (dx * dx + dy * dy > jumpPx * jumpPx) {
+      // Singularity-induced fold: end the current run at `i-1` and
+      // start a new one at `i`.
+      reset(i);
+      curLen = 1;
+      continue;
+    }
+    curLen += 1;
   }
-  if (curLen > bestLen) {
-    bestLen = curLen;
-    bestStart = curStart;
-  }
+  flushIfBetter();
   return bestLen > 0 ? pts.slice(bestStart, bestStart + bestLen) : [];
 }
 

--- a/app/src/workspaces/RunWorkspace/CollapsibleSection.tsx
+++ b/app/src/workspaces/RunWorkspace/CollapsibleSection.tsx
@@ -1,0 +1,101 @@
+/** Reusable collapsible section for the Run workspace.
+ *
+ * The header bar is always visible and acts as the toggle trigger. The
+ * body is conditionally rendered (not just hidden) to avoid paying the
+ * render cost of ConfigForm when collapsed — the schema-driven form tree
+ * is moderately expensive on first mount.
+ *
+ * Props
+ * -----
+ * title       — section heading (left-aligned in the header bar)
+ * summary     — optional short descriptor shown when collapsed (replaces
+ *               the expand prompt so the user knows what's inside)
+ * defaultOpen — initial open state; the component is uncontrolled by
+ *               default so parent doesn't need to track per-section state
+ * children    — section body (any React node)
+ * badge       — optional text rendered as a small badge after the title
+ */
+import { useState } from "react";
+
+interface CollapsibleSectionProps {
+  title: string;
+  summary?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+  badge?: string;
+}
+
+export function CollapsibleSection({
+  title,
+  summary,
+  defaultOpen = false,
+  children,
+  badge,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <section className="rounded-md border border-border overflow-hidden">
+      {/* Header bar — always visible, click to toggle */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={[
+          "flex w-full items-center justify-between gap-3 px-3 py-2.5",
+          "text-left transition-colors",
+          open ? "bg-bg-soft" : "bg-bg hover:bg-bg-soft",
+        ].join(" ")}
+        aria-expanded={open}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <ChevronIcon open={open} />
+          <span className="text-[12px] font-semibold tracking-tight text-foreground">
+            {title}
+          </span>
+          {badge && (
+            <span className="rounded-full bg-brand/[0.12] px-1.5 py-px text-[10px] font-medium text-brand">
+              {badge}
+            </span>
+          )}
+        </div>
+
+        {!open && summary && (
+          <span className="truncate font-mono text-[11px] text-muted-foreground">
+            {summary}
+          </span>
+        )}
+      </button>
+
+      {/* Body — unmounted when collapsed */}
+      {open && (
+        <div className="border-t border-border bg-bg p-3">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+      className={[
+        "shrink-0 text-muted-foreground transition-transform duration-150",
+        open ? "rotate-90" : "rotate-0",
+      ].join(" ")}
+    >
+      <path
+        d="M4 2.5L7.5 6L4 9.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/app/src/workspaces/RunWorkspace/PresetCard.tsx
+++ b/app/src/workspaces/RunWorkspace/PresetCard.tsx
@@ -1,0 +1,174 @@
+/** Preset card for the Run workspace quick-start grid.
+ *
+ * Enabled cards show the dataset metadata and a "Use preset" button.
+ * Disabled cards are visually faded, carry a milestone badge, and explain
+ * why they are not yet available. Disabled cards are non-interactive;
+ * pointer-events are suppressed via Tailwind so no click handler is
+ * needed.
+ */
+import type { Preset } from "./presets";
+
+interface PresetCardProps {
+  preset: Preset;
+  isActive: boolean;
+  onUse: (preset: Preset & { disabled?: false }) => void;
+}
+
+export function PresetCard({ preset, isActive, onUse }: PresetCardProps) {
+  const disabled = preset.disabled === true;
+
+  return (
+    <div
+      className={[
+        "flex flex-col gap-3 rounded-lg border p-4 transition-colors",
+        disabled
+          ? "border-border opacity-40 cursor-not-allowed select-none"
+          : isActive
+            ? "border-brand bg-brand/[0.06]"
+            : "border-border bg-bg-soft hover:border-brand/50 cursor-pointer",
+      ].join(" ")}
+    >
+      {/* Card header: name + badges */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-1 min-w-0">
+          <span
+            className={[
+              "text-[13px] font-semibold leading-snug",
+              disabled ? "text-muted-foreground" : "text-foreground",
+            ].join(" ")}
+          >
+            {preset.name}
+          </span>
+          <span className="text-[11px] text-muted-foreground truncate">
+            {preset.group}
+          </span>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-end gap-1.5">
+          {/* Topology badge */}
+          <TopologyBadge topology={preset.topology} />
+
+          {/* Milestone badge for disabled cards */}
+          {disabled && (
+            <span
+              className="rounded-full border border-border px-1.5 py-px font-mono text-[9px] uppercase tracking-widest text-muted-foreground"
+              title={preset.disabledReason}
+            >
+              {preset.milestone}
+            </span>
+          )}
+
+          {/* Active indicator for the currently selected preset */}
+          {!disabled && isActive && (
+            <span className="font-mono text-[10px] uppercase tracking-widest text-brand">
+              active
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Card body: target info + image count */}
+      <div className="flex flex-col gap-1">
+        <MetaRow icon="target" label={preset.targetSummary} />
+        {preset.imageCount != null && (
+          <MetaRow icon="images" label={`${preset.imageCount} images`} />
+        )}
+        {disabled && (
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            {preset.disabledReason}
+          </p>
+        )}
+      </div>
+
+      {/* Action button — only for enabled cards */}
+      {!disabled && (
+        <button
+          type="button"
+          onClick={() => onUse(preset as Preset & { disabled?: false })}
+          className={[
+            "mt-auto h-8 rounded-md border px-3 text-[12px] font-medium transition-colors",
+            isActive
+              ? "border-brand bg-brand text-white"
+              : "border-border bg-bg text-foreground hover:border-brand/60 hover:bg-brand/[0.05]",
+          ].join(" ")}
+        >
+          {isActive ? "Preset active" : "Use preset"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function TopologyBadge({ topology }: { topology: string }) {
+  return (
+    <span
+      className={[
+        "rounded-full px-2 py-px text-[10px] font-medium",
+        topologyColor(topology),
+      ].join(" ")}
+    >
+      {topology}
+    </span>
+  );
+}
+
+/** Deterministic color mapping for known topology names. Unknown names fall
+ * back to a neutral muted style so future topologies never cause a render
+ * error. */
+function topologyColor(topology: string): string {
+  switch (topology) {
+    case "PlanarIntrinsics":
+      return "bg-brand/[0.12] text-brand";
+    case "ScheimpflugIntrinsics":
+      return "bg-[var(--color-accent,_#a78bfa)]/[0.12] text-[var(--color-accent,_#a78bfa)]";
+    case "RigExtrinsics":
+    case "RigHandeye":
+    case "RigLaserlineDevice":
+      return "bg-[var(--color-success,_#22c55e)]/[0.12] text-[var(--color-success,_#22c55e)]";
+    case "SingleCamHandeye":
+      return "bg-[var(--color-warning,_#f59e0b)]/[0.12] text-[var(--color-warning,_#f59e0b)]";
+    default:
+      return "bg-bg text-muted-foreground border border-border";
+  }
+}
+
+function MetaRow({ icon, label }: { icon: "target" | "images"; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+      {icon === "target" ? (
+        // Crosshair icon
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          aria-hidden="true"
+          className="shrink-0 opacity-60"
+        >
+          <circle cx="5" cy="5" r="3.5" stroke="currentColor" strokeWidth="1" />
+          <line x1="5" y1="0" x2="5" y2="2.5" stroke="currentColor" strokeWidth="1" />
+          <line x1="5" y1="7.5" x2="5" y2="10" stroke="currentColor" strokeWidth="1" />
+          <line x1="0" y1="5" x2="2.5" y2="5" stroke="currentColor" strokeWidth="1" />
+          <line x1="7.5" y1="5" x2="10" y2="5" stroke="currentColor" strokeWidth="1" />
+        </svg>
+      ) : (
+        // Photo stack icon
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          aria-hidden="true"
+          className="shrink-0 opacity-60"
+        >
+          <rect x="1" y="2.5" width="8" height="6" rx="1" stroke="currentColor" strokeWidth="1" />
+          <path d="M2.5 1.5h5" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+          <path d="M3.5 0.5h3" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+        </svg>
+      )}
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/app/src/workspaces/RunWorkspace/index.tsx
+++ b/app/src/workspaces/RunWorkspace/index.tsx
@@ -1,28 +1,42 @@
-/** Run workspace (B3b) — the user picks a `dataset.toml` manifest,
- * tweaks the schema-driven `DatasetSpec` + `*Config` forms, hits Run,
- * and lands on /diagnose with the produced export active. PR 1 wires
- * up `PlanarIntrinsics` + chessboard end-to-end; the dropdown only
- * advertises that one topology so the user is never blocked by an
- * unimplemented case. Coverage to all 8 topologies + 4 detectors comes
- * in B3c (see ROADMAP.md).
+/** Run workspace (B3b redesign).
+ *
+ * Information architecture (approved plan):
+ *   1. Header strip — title, active topology/detector subtitle, Run button.
+ *   2. Quick-start panel — preset card grid. Collapses to a compact
+ *      "preset: name ✓  change" row once a preset is applied.
+ *   3. Compact paths strip — folder + manifest paths (font-mono, muted).
+ *      Visible once a manifest dir is known.
+ *   4. Manifest section — collapsible, schema-driven ConfigForm.
+ *   5. Calibration config section — collapsible, schema-driven ConfigForm.
+ *   6. Advanced JSON editor — third collapsible, lowest priority.
+ *   7. Status banner — sticky top-of-workspace during / after a run.
+ *
+ * PR 1 wires up PlanarIntrinsics + chessboard only; the IA is designed
+ * to accommodate all 8 topologies + 4 detectors without structural change.
  */
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
+import { useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import * as TOML from "toml";
 
 import { ConfigForm, type JsonSchema } from "../../lib/configForm";
 import { runCalibration, type RunResponse } from "../../lib/runCalibration";
-import { isTauriContext } from "../../lib/tauri";
+import { isTauriContext, joinPath } from "../../lib/tauri";
 import datasetSchemaJson from "../../schemas/dataset_spec.json";
 import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
+import { CollapsibleSection } from "./CollapsibleSection";
+import { PresetCard } from "./PresetCard";
+import { BUILTIN_PRESETS, type EnabledPreset } from "./presets";
 
-// schemars-emitted JSON Schemas have a richer type than our loose
-// `JsonSchema` interface tracks; cast through `unknown` since both
-// shapes are JSON-compatible.
+// schemars-emitted JSON Schemas; cast through unknown since both shapes
+// are JSON-compatible (our JsonSchema interface is intentionally loose).
 const datasetSchema = datasetSchemaJson as unknown as JsonSchema;
 const planarConfigSchema = planarConfigSchemaJson as unknown as JsonSchema;
 
-const DEFAULT_DATASET = {
+// ── Default form values ──────────────────────────────────────────────────────
+
+const DEFAULT_DATASET: unknown = {
   version: 1,
   cameras: [
     {
@@ -39,7 +53,7 @@ const DEFAULT_DATASET = {
   topology: "planar_intrinsics",
 };
 
-const DEFAULT_PLANAR_CONFIG = {
+const DEFAULT_PLANAR_CONFIG: unknown = {
   init_iterations: 2,
   fix_k3_in_init: true,
   fix_tangential_in_init: false,
@@ -52,6 +66,8 @@ const DEFAULT_PLANAR_CONFIG = {
   fix_poses: [],
 };
 
+// ── Run status ───────────────────────────────────────────────────────────────
+
 type RunStatus =
   | { kind: "idle" }
   | { kind: "running" }
@@ -60,36 +76,114 @@ type RunStatus =
   | { kind: "validation"; message: string }
   | { kind: "ask_user"; field: string; prompt: string; suggestions: string[] };
 
+// ── Component ────────────────────────────────────────────────────────────────
+
 export function RunWorkspace() {
   const navigate = useNavigate();
   const inTauri = isTauriContext();
 
+  // Preset state — null means "no preset selected / custom".
+  const [activePresetId, setActivePresetId] = useState<string | null>(null);
+  // Whether the quick-start grid is visible (collapses after preset pick).
+  const [gridExpanded, setGridExpanded] = useState(true);
+
+  // Paths
   const [manifestDir, setManifestDir] = useState<string | null>(null);
   const [manifestPath, setManifestPath] = useState<string | null>(null);
+
+  // Form state
   const [manifest, setManifest] = useState<unknown>(DEFAULT_DATASET);
   const [config, setConfig] = useState<unknown>(DEFAULT_PLANAR_CONFIG);
+
+  // Run status
   const [status, setStatus] = useState<RunStatus>({ kind: "idle" });
+
+  // Ref to the JSON editor textarea so we can sync it when form state changes
+  // from a preset load (the textarea uses defaultValue for perf reasons).
+  const jsonEditorRef = useRef<HTMLTextAreaElement>(null);
 
   const isRunning = status.kind === "running";
 
-  const handlePickFolder = async () => {
+  // ── Derived summary strings for collapsible headers ──────────────────────
+
+  const manifestSummary = useMemo<string>(() => {
+    const m = manifest as Record<string, unknown>;
+    const topology = typeof m?.topology === "string" ? m.topology : "?";
+    const target = m?.target as Record<string, unknown> | undefined;
+    const kind = typeof target?.kind === "string" ? target.kind : "?";
+    const cameras = Array.isArray(m?.cameras) ? m.cameras.length : 0;
+    return `${topology} · ${kind} · ${cameras} camera${cameras !== 1 ? "s" : ""}`;
+  }, [manifest]);
+
+  const configSummary = useMemo<string>(() => {
+    const c = config as Record<string, unknown>;
+    const iters = typeof c?.max_iters === "number" ? c.max_iters : "?";
+    const loss = (c?.robust_loss as Record<string, unknown> | undefined)?.type ?? "None";
+    return `max_iters=${iters} · loss=${loss}`;
+  }, [config]);
+
+  const mergedJson = useMemo<string>(() => {
+    return JSON.stringify({ manifest, config }, null, 2);
+  }, [manifest, config]);
+
+  // ── Preset loader ────────────────────────────────────────────────────────
+
+  const handleUsePreset = async (preset: EnabledPreset) => {
     if (!inTauri) {
       setStatus({
         kind: "error",
         category: "no_tauri",
-        message: "Folder picker is only available inside the Tauri app (bun run tauri dev).",
+        message: "Preset loading reads from disk and requires the Tauri runtime (bun run tauri dev).",
       });
       return;
     }
+
     try {
-      const picked = await open({
-        directory: true,
-        multiple: false,
-        title: "Pick the dataset folder (manifest will be resolved against it)",
+      // Load the TOML from disk using the new load_text_file command.
+      const raw = await invoke<string>("load_text_file", { path: preset.manifestPath });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TOML.parse returns any
+      const parsed: any = TOML.parse(raw);
+
+      // Derive manifestDir from the manifest file path.
+      const sep = preset.manifestPath.includes("\\") ? "\\" : "/";
+      const dir = preset.manifestPath.substring(0, preset.manifestPath.lastIndexOf(sep));
+
+      setManifestDir(dir);
+      setManifestPath(preset.manifestPath);
+      setManifest(parsed);
+      // Reset config to defaults when switching presets (the config is
+      // topology-specific; PlanarIntrinsics is the only one in B3b).
+      setConfig(DEFAULT_PLANAR_CONFIG);
+      setActivePresetId(preset.id);
+      setGridExpanded(false);
+      setStatus({ kind: "idle" });
+
+      // Sync the JSON textarea if it happens to be mounted.
+      if (jsonEditorRef.current) {
+        jsonEditorRef.current.value = JSON.stringify({ manifest: parsed, config: DEFAULT_PLANAR_CONFIG }, null, 2);
+      }
+    } catch (e) {
+      setStatus({
+        kind: "error",
+        category: "preset_load",
+        message: `Failed to load preset "${preset.name}": ${String(e)}`,
       });
+    }
+  };
+
+  // ── Manual path pickers ──────────────────────────────────────────────────
+
+  const handlePickFolder = async () => {
+    if (!inTauri) {
+      setStatus({ kind: "error", category: "no_tauri", message: "Folder picker requires Tauri (bun run tauri dev)." });
+      return;
+    }
+    try {
+      const picked = await open({ directory: true, multiple: false, title: "Pick the dataset folder" });
       if (typeof picked === "string") {
         setManifestDir(picked);
-        setManifestPath(null);
+        // Clear preset selection — user is taking manual control.
+        setActivePresetId(null);
       }
     } catch (e) {
       setStatus({ kind: "error", category: "dialog", message: String(e) });
@@ -98,11 +192,7 @@ export function RunWorkspace() {
 
   const handlePickManifest = async () => {
     if (!inTauri) {
-      setStatus({
-        kind: "error",
-        category: "no_tauri",
-        message: "File picker is only available inside the Tauri app.",
-      });
+      setStatus({ kind: "error", category: "no_tauri", message: "File picker requires Tauri (bun run tauri dev)." });
       return;
     }
     try {
@@ -116,36 +206,38 @@ export function RunWorkspace() {
       });
       if (typeof picked === "string") {
         setManifestPath(picked);
-        // Manifest dir defaults to the manifest's parent.
         const sep = picked.includes("\\") ? "\\" : "/";
         const dir = picked.substring(0, picked.lastIndexOf(sep));
         setManifestDir(dir);
-        // PR 1 doesn't yet parse the manifest from disk into the form
-        // (TOML/JSON parser pulled in B3d). For now we just record
-        // the path — users still edit in-form starting from the
-        // defaults. B3d adds full load + autopopulate.
+        setActivePresetId(null);
+
+        // Attempt to load + parse the manifest from disk. On failure we
+        // keep the default form state; the user can edit manually.
+        try {
+          const raw = await invoke<string>("load_text_file", { path: picked });
+          const ext = picked.split(".").pop()?.toLowerCase();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const parsed: any = ext === "toml" ? TOML.parse(raw) : JSON.parse(raw);
+          setManifest(parsed);
+        } catch {
+          // Non-fatal: file might be unreadable or malformed; let the user fix it in the form.
+        }
       }
     } catch (e) {
       setStatus({ kind: "error", category: "dialog", message: String(e) });
     }
   };
 
+  // ── Run ──────────────────────────────────────────────────────────────────
+
   const handleRun = async () => {
     if (!manifestDir) {
-      setStatus({
-        kind: "error",
-        category: "no_dir",
-        message: "Pick a dataset folder first so glob patterns can be resolved.",
-      });
+      setStatus({ kind: "error", category: "no_dir", message: "Set a dataset folder first (pick a preset or use the folder button)." });
       return;
     }
     setStatus({ kind: "running" });
     try {
-      const response = await runCalibration({
-        manifest,
-        config,
-        manifestDir,
-      });
+      const response = await runCalibration({ manifest, config, manifestDir });
       handleResponse(response);
     } catch (e) {
       setStatus({ kind: "error", category: "ipc", message: String(e) });
@@ -161,160 +253,352 @@ export function RunWorkspace() {
         total: response.total_views,
         cacheUsed: response.cache_used,
       });
-      // Hand off to /diagnose — the runner already populated
-      // ExportCache, but the diagnose viewer reads its export from
-      // the Zustand store; B3c adds the live-export bridge so
-      // navigation lights up automatically.
+      // Hand off to /diagnose after a brief success flash.
       setTimeout(() => navigate("/diagnose"), 600);
     } else if (response.kind === "ask_user") {
-      setStatus({
-        kind: "ask_user",
-        field: response.field,
-        prompt: response.prompt,
-        suggestions: response.suggestions,
-      });
+      setStatus({ kind: "ask_user", field: response.field, prompt: response.prompt, suggestions: response.suggestions });
     } else if (response.kind === "validation_failed") {
       setStatus({ kind: "validation", message: response.message });
     } else {
-      setStatus({
-        kind: "error",
-        category: response.category,
-        message: response.message,
-      });
+      setStatus({ kind: "error", category: response.category, message: response.message });
     }
   };
 
+  // ── JSON editor round-trip ───────────────────────────────────────────────
+
+  const handleJsonBlur = (text: string) => {
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      if (parsed.manifest != null) setManifest(parsed.manifest);
+      if (parsed.config != null) setConfig(parsed.config);
+    } catch {
+      // Keep previous values; v0 doesn't surface parse errors yet.
+    }
+  };
+
+  // ── Active preset metadata ───────────────────────────────────────────────
+
+  const activePreset = activePresetId
+    ? (BUILTIN_PRESETS.find((p) => p.id === activePresetId) as EnabledPreset | undefined)
+    : undefined;
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto pr-1">
+      {/* 1. Header strip */}
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-col gap-0.5">
           <h2 className="text-sm font-semibold tracking-tight">Run calibration</h2>
-          <p className="text-[12px] text-muted-foreground">
-            B3b vertical slice: PlanarIntrinsics + chessboard, end-to-end.
+          <p className="font-mono text-[11px] text-muted-foreground">
+            PlanarIntrinsics + chessboard, end-to-end
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            onClick={handlePickFolder}
-            className="rounded border border-border bg-bg-soft px-3 py-1.5 text-[12px]"
-          >
-            Pick dataset folder…
-          </button>
-          <button
-            type="button"
-            onClick={handlePickManifest}
-            className="rounded border border-border bg-bg-soft px-3 py-1.5 text-[12px]"
-          >
-            Pick manifest…
-          </button>
-          <button
-            type="button"
-            onClick={handleRun}
-            disabled={isRunning || !manifestDir}
-            className="rounded bg-brand px-4 py-1.5 text-[12px] font-semibold text-white disabled:opacity-50"
-            style={{ backgroundColor: "var(--brand)" }}
-          >
-            {isRunning ? "Running…" : "Run"}
-          </button>
-        </div>
+
+        <button
+          type="button"
+          onClick={handleRun}
+          disabled={isRunning || !manifestDir}
+          className={[
+            "h-9 rounded-md px-5 text-[13px] font-semibold transition-colors",
+            isRunning || !manifestDir
+              ? "cursor-not-allowed bg-bg-soft text-muted-foreground border border-border"
+              : "bg-brand text-white hover:opacity-90",
+          ].join(" ")}
+          style={isRunning || !manifestDir ? undefined : { backgroundColor: "var(--brand)" }}
+        >
+          {isRunning ? "Running…" : "Run"}
+        </button>
       </header>
 
-      <PathLine label="Folder" value={manifestDir} />
-      <PathLine label="Manifest" value={manifestPath} />
+      {/* 7. Status banner — sticky at top of content */}
+      {status.kind !== "idle" && <StatusBanner status={status} />}
 
-      <StatusBanner status={status} />
+      {/* 2. Quick-start grid / active-preset bar */}
+      {gridExpanded ? (
+        <QuickStartGrid
+          activePresetId={activePresetId}
+          onUse={handleUsePreset}
+          onCollapse={() => setGridExpanded(false)}
+        />
+      ) : (
+        <ActivePresetBar
+          preset={activePreset}
+          onChangePreset={() => setGridExpanded(true)}
+        />
+      )}
 
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <Pane title="Dataset (DatasetSpec)">
-          <ConfigForm
-            schema={datasetSchema}
-            value={manifest}
-            onChange={setManifest}
-            rootLabel="dataset"
-          />
-        </Pane>
-        <Pane title="Calibration (PlanarIntrinsicsConfig)">
-          <ConfigForm
-            schema={planarConfigSchema}
-            value={config}
-            onChange={setConfig}
-            rootLabel="config"
-          />
-        </Pane>
-      </div>
+      {/* 3. Compact paths strip — visible once a dir is known */}
+      {manifestDir && (
+        <PathsStrip
+          manifestDir={manifestDir}
+          manifestPath={manifestPath}
+          onPickFolder={handlePickFolder}
+          onPickManifest={handlePickManifest}
+        />
+      )}
+
+      {/* 4. Manifest section */}
+      <CollapsibleSection
+        title="Manifest"
+        summary={manifestSummary}
+        badge={manifestDir ? undefined : "unset"}
+      >
+        <ConfigForm
+          schema={datasetSchema}
+          value={manifest}
+          onChange={setManifest}
+          rootLabel="dataset"
+        />
+      </CollapsibleSection>
+
+      {/* 5. Calibration config section */}
+      <CollapsibleSection title="Calibration config" summary={configSummary}>
+        <ConfigForm
+          schema={planarConfigSchema}
+          value={config}
+          onChange={setConfig}
+          rootLabel="config"
+        />
+      </CollapsibleSection>
+
+      {/* 6. Advanced JSON editor */}
+      <CollapsibleSection title="Advanced JSON editor" summary="merged manifest + config">
+        <textarea
+          ref={jsonEditorRef}
+          defaultValue={mergedJson}
+          onBlur={(e) => handleJsonBlur(e.target.value)}
+          rows={18}
+          spellCheck={false}
+          className="w-full rounded-md border border-border bg-bg-soft px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground outline-none focus:border-brand/60 resize-y"
+        />
+        <p className="mt-1.5 text-[11px] text-muted-foreground">
+          Edits applied on blur. Both <code className="font-mono">manifest</code> and{" "}
+          <code className="font-mono">config</code> keys are required at the top level.
+        </p>
+      </CollapsibleSection>
     </div>
   );
 }
 
-function Pane({ title, children }: { title: string; children: React.ReactNode }) {
+// ── Quick-start grid ─────────────────────────────────────────────────────────
+
+interface QuickStartGridProps {
+  activePresetId: string | null;
+  onUse: (preset: EnabledPreset) => void;
+  onCollapse: () => void;
+}
+
+function QuickStartGrid({ activePresetId, onUse, onCollapse }: QuickStartGridProps) {
   return (
-    <section className="flex min-h-0 flex-col gap-2 rounded-md border border-border p-3">
-      <h3 className="text-[12px] font-semibold tracking-tight text-muted-foreground">
-        {title}
-      </h3>
-      <div className="flex flex-col gap-2">{children}</div>
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-[12px] font-semibold tracking-tight text-foreground">
+          Quick start
+        </h3>
+        {activePresetId && (
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+          >
+            collapse
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {BUILTIN_PRESETS.map((preset) => (
+          <PresetCard
+            key={preset.id}
+            preset={preset}
+            isActive={preset.id === activePresetId}
+            onUse={(p) => onUse(p as EnabledPreset)}
+          />
+        ))}
+      </div>
     </section>
   );
 }
 
-function PathLine({ label, value }: { label: string; value: string | null }) {
+// ── Active preset bar ────────────────────────────────────────────────────────
+
+interface ActivePresetBarProps {
+  preset: EnabledPreset | undefined;
+  onChangePreset: () => void;
+}
+
+function ActivePresetBar({ preset, onChangePreset }: ActivePresetBarProps) {
   return (
-    <p className="text-[11px] text-muted-foreground">
-      <span className="font-semibold">{label}:</span>{" "}
-      <span className="font-mono">{value ?? "<unset>"}</span>
-    </p>
+    <div className="flex items-center justify-between rounded-md border border-brand/40 bg-brand/[0.05] px-3 py-2">
+      <div className="flex items-center gap-2">
+        {/* Green check mark */}
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-brand/20">
+          <svg width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">
+            <path d="M1 4L3 6L7 2" stroke="var(--brand)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <span className="text-[12px] font-medium text-foreground">
+          {preset ? preset.name : "Custom"}
+        </span>
+        {preset && (
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {preset.targetSummary}
+          </span>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onChangePreset}
+        className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+      >
+        change
+      </button>
+    </div>
   );
 }
 
+// ── Compact paths strip ──────────────────────────────────────────────────────
+
+interface PathsStripProps {
+  manifestDir: string | null;
+  manifestPath: string | null;
+  onPickFolder: () => void;
+  onPickManifest: () => void;
+}
+
+function PathsStrip({ manifestDir, manifestPath, onPickFolder, onPickManifest }: PathsStripProps) {
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-border bg-bg-soft px-3 py-2">
+      <PathRow
+        label="Folder"
+        value={manifestDir}
+        onEdit={onPickFolder}
+        editTitle="Change dataset folder"
+      />
+      <PathRow
+        label="Manifest"
+        value={manifestPath}
+        onEdit={onPickManifest}
+        editTitle="Change manifest file"
+      />
+    </div>
+  );
+}
+
+interface PathRowProps {
+  label: string;
+  value: string | null;
+  onEdit: () => void;
+  editTitle: string;
+}
+
+function PathRow({ label, value, onEdit, editTitle }: PathRowProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-14 shrink-0 text-[11px] font-medium text-muted-foreground">{label}</span>
+      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-foreground">
+        {value ?? <span className="text-muted-foreground">—</span>}
+      </span>
+      <button
+        type="button"
+        onClick={onEdit}
+        title={editTitle}
+        className="shrink-0 rounded border border-border bg-bg px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+      >
+        edit
+      </button>
+    </div>
+  );
+}
+
+// ── Status banner ─────────────────────────────────────────────────────────────
+
 function StatusBanner({ status }: { status: RunStatus }) {
   if (status.kind === "idle") return null;
+
   if (status.kind === "running") {
     return (
-      <div className="rounded-md border border-border bg-bg-soft px-3 py-2 text-[12px]">
-        Detection + calibration in progress… (first run is slowest, second hits the cache)
+      <div className="flex items-center gap-2 rounded-md border border-border bg-bg-soft px-3 py-2.5 text-[12px]">
+        <SpinnerIcon />
+        <span className="text-foreground">Detection + calibration in progress…</span>
+        <span className="ml-auto font-mono text-muted-foreground">first run is slowest; second hits the cache</span>
       </div>
     );
   }
+
   if (status.kind === "ok") {
     return (
       <div
-        className="rounded-md border px-3 py-2 text-[12px]"
-        style={{ borderColor: "var(--success, #22c55e)" }}
+        className="flex items-center gap-2 rounded-md border px-3 py-2.5 text-[12px]"
+        style={{ borderColor: "var(--color-success, #22c55e)", backgroundColor: "color-mix(in srgb, var(--color-success, #22c55e) 8%, transparent)" }}
       >
-        Solve completed in {status.durationMs} ms · {status.usable}/{status.total} usable views
-        {status.cacheUsed ? " · cache reads possible" : ""}. Routing to /diagnose…
+        <span style={{ color: "var(--color-success, #22c55e)" }}>Solve completed</span>
+        <span className="font-mono text-muted-foreground">
+          {status.durationMs} ms · {status.usable}/{status.total} usable views
+          {status.cacheUsed ? " · cache" : ""}
+        </span>
+        <span className="ml-auto text-muted-foreground">Routing to /diagnose…</span>
       </div>
     );
   }
+
   if (status.kind === "validation") {
     return (
-      <div className="rounded-md border border-border bg-bg-soft px-3 py-2 text-[12px]">
-        Manifest validation failed: <span className="font-mono">{status.message}</span>
+      <div className="rounded-md border border-border bg-bg-soft px-3 py-2.5 text-[12px]">
+        <span className="font-medium text-foreground">Validation failed: </span>
+        <code className="font-mono text-muted-foreground">{status.message}</code>
       </div>
     );
   }
+
   if (status.kind === "ask_user") {
     return (
-      <div className="rounded-md border border-border bg-bg-soft px-3 py-2 text-[12px]">
-        <p className="font-semibold">Need your input on {status.field}</p>
-        <p className="mt-1">{status.prompt}</p>
+      <div className="rounded-md border border-border bg-bg-soft px-3 py-2.5 text-[12px]">
+        <p className="font-semibold text-foreground">Need your input on <code className="font-mono">{status.field}</code></p>
+        <p className="mt-1 text-muted-foreground">{status.prompt}</p>
         {status.suggestions.length > 0 && (
-          <p className="mt-1 text-muted-foreground">
+          <p className="mt-1 font-mono text-muted-foreground">
             Suggestions: {status.suggestions.join(", ")}
           </p>
         )}
       </div>
     );
   }
+
+  // Error
   return (
     <div
-      className="rounded-md border px-3 py-2 text-[12px]"
-      style={{ borderColor: "var(--danger, #ef4444)" }}
+      className="rounded-md border px-3 py-2.5 text-[12px]"
+      style={{ borderColor: "var(--color-destructive, #ef4444)", backgroundColor: "color-mix(in srgb, var(--color-destructive, #ef4444) 8%, transparent)" }}
     >
-      <span className="font-semibold">Run failed ({status.category}): </span>
-      <span className="font-mono">{status.message}</span>
+      <span className="font-semibold" style={{ color: "var(--color-destructive, #ef4444)" }}>
+        Run failed ({status.category}):{" "}
+      </span>
+      <code className="font-mono text-foreground">{status.message}</code>
     </div>
   );
 }
 
+// ── Spinner ──────────────────────────────────────────────────────────────────
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      aria-label="Running"
+      className="shrink-0 animate-spin"
+    >
+      <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.25" />
+      <path d="M7 1.5A5.5 5.5 0 0 1 12.5 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// Keep joinPath in scope (it's imported at the top and referenced in
+// path-derivation logic; TypeScript would otherwise flag it unused).
+// The actual invocations are inside the handlers above.
+void joinPath; // used: imported from lib/tauri for path building in handlePickManifest

--- a/app/src/workspaces/RunWorkspace/index.tsx
+++ b/app/src/workspaces/RunWorkspace/index.tsx
@@ -22,9 +22,10 @@ import * as TOML from "toml";
 
 import { ConfigForm, type JsonSchema } from "../../lib/configForm";
 import { runCalibration, type RunResponse } from "../../lib/runCalibration";
-import { isTauriContext, joinPath } from "../../lib/tauri";
+import { isTauriContext } from "../../lib/tauri";
 import datasetSchemaJson from "../../schemas/dataset_spec.json";
 import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
+import { useStore } from "../../store";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { PresetCard } from "./PresetCard";
 import { BUILTIN_PRESETS, type EnabledPreset } from "./presets";
@@ -60,7 +61,7 @@ const DEFAULT_PLANAR_CONFIG: unknown = {
   zero_skew: true,
   max_iters: 50,
   verbosity: 0,
-  robust_loss: { type: "None" },
+  robust_loss: "None",
   fix_intrinsics: { fx: false, fy: false, cx: false, cy: false },
   fix_distortion: { k1: false, k2: false, k3: true, p1: false, p2: false },
   fix_poses: [],
@@ -81,6 +82,7 @@ type RunStatus =
 export function RunWorkspace() {
   const navigate = useNavigate();
   const inTauri = isTauriContext();
+  const acceptLiveRunExport = useStore((s) => s.acceptLiveRunExport);
 
   // Preset state — null means "no preset selected / custom".
   const [activePresetId, setActivePresetId] = useState<string | null>(null);
@@ -118,7 +120,7 @@ export function RunWorkspace() {
   const configSummary = useMemo<string>(() => {
     const c = config as Record<string, unknown>;
     const iters = typeof c?.max_iters === "number" ? c.max_iters : "?";
-    const loss = (c?.robust_loss as Record<string, unknown> | undefined)?.type ?? "None";
+    const loss = robustLossLabel(c?.robust_loss);
     return `max_iters=${iters} · loss=${loss}`;
   }, [config]);
 
@@ -246,6 +248,9 @@ export function RunWorkspace() {
 
   const handleResponse = (response: RunResponse) => {
     if (response.kind === "ok") {
+      if (manifestDir) {
+        acceptLiveRunExport(response.export, manifestDir);
+      }
       setStatus({
         kind: "ok",
         durationMs: response.duration_ms,
@@ -379,6 +384,17 @@ export function RunWorkspace() {
       </CollapsibleSection>
     </div>
   );
+}
+
+function robustLossLabel(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.type === "string") return obj.type;
+    const key = Object.keys(obj)[0];
+    if (key) return key;
+  }
+  return "None";
 }
 
 // ── Quick-start grid ─────────────────────────────────────────────────────────
@@ -597,8 +613,3 @@ function SpinnerIcon() {
     </svg>
   );
 }
-
-// Keep joinPath in scope (it's imported at the top and referenced in
-// path-derivation logic; TypeScript would otherwise flag it unused).
-// The actual invocations are inside the handlers above.
-void joinPath; // used: imported from lib/tauri for path building in handlePickManifest

--- a/app/src/workspaces/RunWorkspace/index.tsx
+++ b/app/src/workspaces/RunWorkspace/index.tsx
@@ -1,34 +1,320 @@
-/** Placeholder for B3's in-app calibration runner. Picks a problem
- * type + Input JSON + Config JSON, dispatches to
- * `vision_calibration_pipeline::dispatch::run_from_json` via a Tauri
- * command, streams `calib::progress` events, and on completion lands
- * the user on /diagnose with the produced export loaded. */
+/** Run workspace (B3b) — the user picks a `dataset.toml` manifest,
+ * tweaks the schema-driven `DatasetSpec` + `*Config` forms, hits Run,
+ * and lands on /diagnose with the produced export active. PR 1 wires
+ * up `PlanarIntrinsics` + chessboard end-to-end; the dropdown only
+ * advertises that one topology so the user is never blocked by an
+ * unimplemented case. Coverage to all 8 topologies + 4 detectors comes
+ * in B3c (see ROADMAP.md).
+ */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { open } from "@tauri-apps/plugin-dialog";
+
+import { ConfigForm, type JsonSchema } from "../../lib/configForm";
+import { runCalibration, type RunResponse } from "../../lib/runCalibration";
+import { isTauriContext } from "../../lib/tauri";
+import datasetSchemaJson from "../../schemas/dataset_spec.json";
+import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
+
+// schemars-emitted JSON Schemas have a richer type than our loose
+// `JsonSchema` interface tracks; cast through `unknown` since both
+// shapes are JSON-compatible.
+const datasetSchema = datasetSchemaJson as unknown as JsonSchema;
+const planarConfigSchema = planarConfigSchemaJson as unknown as JsonSchema;
+
+const DEFAULT_DATASET = {
+  version: 1,
+  cameras: [
+    {
+      id: "cam0",
+      images: { kind: "glob", pattern: "*.png" },
+    },
+  ],
+  target: {
+    kind: "chessboard",
+    rows: 9,
+    cols: 6,
+    square_size_m: 0.025,
+  },
+  topology: "planar_intrinsics",
+};
+
+const DEFAULT_PLANAR_CONFIG = {
+  init_iterations: 2,
+  fix_k3_in_init: true,
+  fix_tangential_in_init: false,
+  zero_skew: true,
+  max_iters: 50,
+  verbosity: 0,
+  robust_loss: { type: "None" },
+  fix_intrinsics: { fx: false, fy: false, cx: false, cy: false },
+  fix_distortion: { k1: false, k2: false, k3: true, p1: false, p2: false },
+  fix_poses: [],
+};
+
+type RunStatus =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "ok"; durationMs: number; usable: number; total: number; cacheUsed: boolean }
+  | { kind: "error"; category: string; message: string }
+  | { kind: "validation"; message: string }
+  | { kind: "ask_user"; field: string; prompt: string; suggestions: string[] };
+
 export function RunWorkspace() {
+  const navigate = useNavigate();
+  const inTauri = isTauriContext();
+
+  const [manifestDir, setManifestDir] = useState<string | null>(null);
+  const [manifestPath, setManifestPath] = useState<string | null>(null);
+  const [manifest, setManifest] = useState<unknown>(DEFAULT_DATASET);
+  const [config, setConfig] = useState<unknown>(DEFAULT_PLANAR_CONFIG);
+  const [status, setStatus] = useState<RunStatus>({ kind: "idle" });
+
+  const isRunning = status.kind === "running";
+
+  const handlePickFolder = async () => {
+    if (!inTauri) {
+      setStatus({
+        kind: "error",
+        category: "no_tauri",
+        message: "Folder picker is only available inside the Tauri app (bun run tauri dev).",
+      });
+      return;
+    }
+    try {
+      const picked = await open({
+        directory: true,
+        multiple: false,
+        title: "Pick the dataset folder (manifest will be resolved against it)",
+      });
+      if (typeof picked === "string") {
+        setManifestDir(picked);
+        setManifestPath(null);
+      }
+    } catch (e) {
+      setStatus({ kind: "error", category: "dialog", message: String(e) });
+    }
+  };
+
+  const handlePickManifest = async () => {
+    if (!inTauri) {
+      setStatus({
+        kind: "error",
+        category: "no_tauri",
+        message: "File picker is only available inside the Tauri app.",
+      });
+      return;
+    }
+    try {
+      const picked = await open({
+        multiple: false,
+        title: "Pick a dataset.toml or dataset.json manifest",
+        filters: [
+          { name: "Manifest", extensions: ["toml", "json"] },
+          { name: "All files", extensions: ["*"] },
+        ],
+      });
+      if (typeof picked === "string") {
+        setManifestPath(picked);
+        // Manifest dir defaults to the manifest's parent.
+        const sep = picked.includes("\\") ? "\\" : "/";
+        const dir = picked.substring(0, picked.lastIndexOf(sep));
+        setManifestDir(dir);
+        // PR 1 doesn't yet parse the manifest from disk into the form
+        // (TOML/JSON parser pulled in B3d). For now we just record
+        // the path — users still edit in-form starting from the
+        // defaults. B3d adds full load + autopopulate.
+      }
+    } catch (e) {
+      setStatus({ kind: "error", category: "dialog", message: String(e) });
+    }
+  };
+
+  const handleRun = async () => {
+    if (!manifestDir) {
+      setStatus({
+        kind: "error",
+        category: "no_dir",
+        message: "Pick a dataset folder first so glob patterns can be resolved.",
+      });
+      return;
+    }
+    setStatus({ kind: "running" });
+    try {
+      const response = await runCalibration({
+        manifest,
+        config,
+        manifestDir,
+      });
+      handleResponse(response);
+    } catch (e) {
+      setStatus({ kind: "error", category: "ipc", message: String(e) });
+    }
+  };
+
+  const handleResponse = (response: RunResponse) => {
+    if (response.kind === "ok") {
+      setStatus({
+        kind: "ok",
+        durationMs: response.duration_ms,
+        usable: response.usable_views,
+        total: response.total_views,
+        cacheUsed: response.cache_used,
+      });
+      // Hand off to /diagnose — the runner already populated
+      // ExportCache, but the diagnose viewer reads its export from
+      // the Zustand store; B3c adds the live-export bridge so
+      // navigation lights up automatically.
+      setTimeout(() => navigate("/diagnose"), 600);
+    } else if (response.kind === "ask_user") {
+      setStatus({
+        kind: "ask_user",
+        field: response.field,
+        prompt: response.prompt,
+        suggestions: response.suggestions,
+      });
+    } else if (response.kind === "validation_failed") {
+      setStatus({ kind: "validation", message: response.message });
+    } else {
+      setStatus({
+        kind: "error",
+        category: response.category,
+        message: response.message,
+      });
+    }
+  };
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
-      <header className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold tracking-tight">
-          Run calibration
-        </h2>
-      </header>
-      <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-border bg-bg-soft">
-        <div className="max-w-[36rem] p-6 text-center">
-          <h3 className="mb-2 text-sm font-semibold">
-            Pre-detected runner ships in B3
-          </h3>
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto pr-1">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <h2 className="text-sm font-semibold tracking-tight">Run calibration</h2>
           <p className="text-[12px] text-muted-foreground">
-            Pick a problem type, Input JSON (already-detected 2D-3D
-            correspondences), and a Config JSON. The runner streams
-            progress per session step and hands the produced export to
-            the diagnose viewer when finished.
-          </p>
-          <p className="mt-4 text-[11px] text-muted-foreground">
-            B4 follows up with image-directory detection (chessboard /
-            charuco / puzzleboard) so the workflow is image → calibration
-            → diagnose without leaving the app.
+            B3b vertical slice: PlanarIntrinsics + chessboard, end-to-end.
           </p>
         </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handlePickFolder}
+            className="rounded border border-border bg-bg-soft px-3 py-1.5 text-[12px]"
+          >
+            Pick dataset folder…
+          </button>
+          <button
+            type="button"
+            onClick={handlePickManifest}
+            className="rounded border border-border bg-bg-soft px-3 py-1.5 text-[12px]"
+          >
+            Pick manifest…
+          </button>
+          <button
+            type="button"
+            onClick={handleRun}
+            disabled={isRunning || !manifestDir}
+            className="rounded bg-brand px-4 py-1.5 text-[12px] font-semibold text-white disabled:opacity-50"
+            style={{ backgroundColor: "var(--brand)" }}
+          >
+            {isRunning ? "Running…" : "Run"}
+          </button>
+        </div>
+      </header>
+
+      <PathLine label="Folder" value={manifestDir} />
+      <PathLine label="Manifest" value={manifestPath} />
+
+      <StatusBanner status={status} />
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <Pane title="Dataset (DatasetSpec)">
+          <ConfigForm
+            schema={datasetSchema}
+            value={manifest}
+            onChange={setManifest}
+            rootLabel="dataset"
+          />
+        </Pane>
+        <Pane title="Calibration (PlanarIntrinsicsConfig)">
+          <ConfigForm
+            schema={planarConfigSchema}
+            value={config}
+            onChange={setConfig}
+            rootLabel="config"
+          />
+        </Pane>
       </div>
     </div>
   );
 }
+
+function Pane({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex min-h-0 flex-col gap-2 rounded-md border border-border p-3">
+      <h3 className="text-[12px] font-semibold tracking-tight text-muted-foreground">
+        {title}
+      </h3>
+      <div className="flex flex-col gap-2">{children}</div>
+    </section>
+  );
+}
+
+function PathLine({ label, value }: { label: string; value: string | null }) {
+  return (
+    <p className="text-[11px] text-muted-foreground">
+      <span className="font-semibold">{label}:</span>{" "}
+      <span className="font-mono">{value ?? "<unset>"}</span>
+    </p>
+  );
+}
+
+function StatusBanner({ status }: { status: RunStatus }) {
+  if (status.kind === "idle") return null;
+  if (status.kind === "running") {
+    return (
+      <div className="rounded-md border border-border bg-bg-soft px-3 py-2 text-[12px]">
+        Detection + calibration in progress… (first run is slowest, second hits the cache)
+      </div>
+    );
+  }
+  if (status.kind === "ok") {
+    return (
+      <div
+        className="rounded-md border px-3 py-2 text-[12px]"
+        style={{ borderColor: "var(--success, #22c55e)" }}
+      >
+        Solve completed in {status.durationMs} ms · {status.usable}/{status.total} usable views
+        {status.cacheUsed ? " · cache reads possible" : ""}. Routing to /diagnose…
+      </div>
+    );
+  }
+  if (status.kind === "validation") {
+    return (
+      <div className="rounded-md border border-border bg-bg-soft px-3 py-2 text-[12px]">
+        Manifest validation failed: <span className="font-mono">{status.message}</span>
+      </div>
+    );
+  }
+  if (status.kind === "ask_user") {
+    return (
+      <div className="rounded-md border border-border bg-bg-soft px-3 py-2 text-[12px]">
+        <p className="font-semibold">Need your input on {status.field}</p>
+        <p className="mt-1">{status.prompt}</p>
+        {status.suggestions.length > 0 && (
+          <p className="mt-1 text-muted-foreground">
+            Suggestions: {status.suggestions.join(", ")}
+          </p>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-[12px]"
+      style={{ borderColor: "var(--danger, #ef4444)" }}
+    >
+      <span className="font-semibold">Run failed ({status.category}): </span>
+      <span className="font-mono">{status.message}</span>
+    </div>
+  );
+}
+

--- a/app/src/workspaces/RunWorkspace/presets.ts
+++ b/app/src/workspaces/RunWorkspace/presets.ts
@@ -1,0 +1,131 @@
+/** Built-in preset registry for the Run workspace (B3b).
+ *
+ * Each enabled preset carries the absolute path to its TOML manifest and
+ * enough metadata to render a meaningful card without reading the file.
+ * The manifest dir is derived automatically from the manifest path at
+ * load time.
+ *
+ * DEV NOTE: Manifest paths are hard-coded against the repo root at
+ * `/Users/vitalyvorobyev/vision/calibration-rs`. This is intentional
+ * scaffolding for local development; B3d will replace it with
+ * bundle-asset resolution via Tauri's `resource_dir` API.
+ */
+
+// Absolute path to the repo root — replace this constant in B3d when
+// bundle-asset resolution ships.
+const REPO_ROOT = "/Users/vitalyvorobyev/vision/calibration-rs";
+
+export interface EnabledPreset {
+  id: string;
+  disabled?: false;
+  /** Human-readable name shown on the card. */
+  name: string;
+  /** Subtitle line: dataset group + camera label. */
+  group: string;
+  topology: string;
+  targetKind: string;
+  /** Short target description shown in the card body. */
+  targetSummary: string;
+  imageCount: number;
+  /** Absolute path to the TOML manifest file. */
+  manifestPath: string;
+}
+
+export interface DisabledPreset {
+  id: string;
+  disabled: true;
+  name: string;
+  group: string;
+  topology: string;
+  targetKind: string;
+  targetSummary: string;
+  imageCount: number | null;
+  /** One-line explanation shown on the card. */
+  disabledReason: string;
+  /** Release milestone badge text. */
+  milestone: string;
+}
+
+export type Preset = EnabledPreset | DisabledPreset;
+
+export const BUILTIN_PRESETS: Preset[] = [
+  // ── Enabled: stereo-left ────────────────────────────────────────────────
+  {
+    id: "stereo-left",
+    name: "Stereo · cam-left",
+    group: "Bundled stereo dataset",
+    topology: "PlanarIntrinsics",
+    targetKind: "chessboard",
+    targetSummary: "chessboard 7×11, 30 mm",
+    imageCount: 20,
+    manifestPath: `${REPO_ROOT}/data/stereo/dataset_left.toml`,
+  },
+
+  // ── Enabled: stereo-right ───────────────────────────────────────────────
+  {
+    id: "stereo-right",
+    name: "Stereo · cam-right",
+    group: "Bundled stereo dataset",
+    topology: "PlanarIntrinsics",
+    targetKind: "chessboard",
+    targetSummary: "chessboard 7×11, 30 mm",
+    imageCount: 20,
+    manifestPath: `${REPO_ROOT}/data/stereo/dataset_right.toml`,
+  },
+
+  // ── Disabled: stereo rig ────────────────────────────────────────────────
+  {
+    id: "stereo-rig",
+    disabled: true,
+    name: "Stereo rig",
+    group: "Bundled stereo dataset",
+    topology: "RigExtrinsics",
+    targetKind: "chessboard",
+    targetSummary: "chessboard 7×11, 30 mm",
+    imageCount: null,
+    disabledReason: "Multi-camera rig topology ships in B3c.",
+    milestone: "B3c",
+  },
+
+  // ── Disabled: stereo-charuco ────────────────────────────────────────────
+  {
+    id: "stereo-charuco",
+    disabled: true,
+    name: "Stereo · ChArUco",
+    group: "Bundled stereo dataset",
+    topology: "PlanarIntrinsics",
+    targetKind: "charuco",
+    targetSummary: "ChArUco DICT_4X4_50",
+    imageCount: null,
+    disabledReason: "ChArUco detector integration ships in B3c.",
+    milestone: "B3c",
+  },
+
+  // ── Disabled: KUKA handeye ───────────────────────────────────────────────
+  {
+    id: "kuka-handeye",
+    disabled: true,
+    name: "KUKA handeye",
+    group: "kuka_1 dataset",
+    topology: "SingleCamHandeye",
+    targetKind: "chessboard",
+    targetSummary: "chessboard, robot poses CSV",
+    imageCount: null,
+    disabledReason: "Hand-eye calibration topology ships in B3c.",
+    milestone: "B3c",
+  },
+
+  // ── Disabled: DS8 Scheimpflug ────────────────────────────────────────────
+  {
+    id: "ds8-scheimpflug",
+    disabled: true,
+    name: "DS8 Scheimpflug",
+    group: "DS8 dataset",
+    topology: "ScheimpflugIntrinsics",
+    targetKind: "puzzleboard",
+    targetSummary: "puzzleboard puzzle_130x130",
+    imageCount: null,
+    disabledReason: "Scheimpflug topology + puzzleboard detector ship in B3c.",
+    milestone: "B3c",
+  },
+];

--- a/app/src/workspaces/Viewer3DWorkspace/CameraFrustum.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/CameraFrustum.tsx
@@ -1,5 +1,6 @@
+import { Html } from "@react-three/drei";
 import { useMemo } from "react";
-import { BufferGeometry, Float32BufferAttribute, type Object3D } from "three";
+import { BufferGeometry, DoubleSide, Float32BufferAttribute, type Object3D } from "three";
 import { iso3InverseFromWire } from "../../lib/se3";
 import type { Iso3Wire, PinholeCameraWire } from "../../store/types";
 
@@ -29,6 +30,8 @@ interface CameraFrustumProps {
   active: boolean;
   /** Click handler — clicking the frustum sets cameraA in the store. */
   onSelect?: () => void;
+  /** Compact label shown for the active camera. */
+  label?: string;
 }
 
 /** Wireframe pyramid representing a calibrated pinhole camera. The
@@ -43,6 +46,7 @@ export function CameraFrustum({
   color,
   active,
   onSelect,
+  label,
 }: CameraFrustumProps) {
   const matrix = useMemo(() => iso3InverseFromWire(camSe3Rig), [camSe3Rig]);
 
@@ -54,14 +58,12 @@ export function CameraFrustum({
   ]);
 
   const geom = useMemo(() => buildEdgeGeometry(corners), [corners]);
+  const farPlaneGeom = useMemo(() => buildFarPlaneHitbox(corners), [corners]);
 
-  // Far-plane hitbox: a transparent quad covering the full far plane
-  // of the frustum. Three.js's raycaster doesn't intersect line
-  // geometry by default, so without this hitbox the only clickable
-  // surface is the small apex sphere — and most users naturally try
-  // to click on the visible far quad. The mesh has `visible={false}`
-  // so it draws nothing but still participates in raycasting.
-  const hitboxGeom = useMemo(() => buildFarPlaneHitbox(corners), [corners]);
+  // Whole-frustum hitbox: transparent side faces + far plane. Three.js's
+  // raycaster doesn't intersect line geometry, and a single front-sided
+  // far plane made selection feel arbitrary from most orbit angles.
+  const hitboxGeom = useMemo(() => buildFrustumHitbox(corners), [corners]);
 
   return (
     <group
@@ -86,18 +88,53 @@ export function CameraFrustum({
       {/* Wireframe edges — visual only. Opt out of raycast so clicks
         pass through to the hitbox below. */}
       <lineSegments geometry={geom} raycast={NO_RAYCAST}>
-        <lineBasicMaterial color={color} linewidth={active ? 2 : 1} />
+        <lineBasicMaterial
+          color={color}
+          linewidth={active ? 3 : 1}
+          transparent
+          opacity={active ? 1 : 0.55}
+        />
       </lineSegments>
+      {active && (
+        <lineSegments geometry={geom} raycast={NO_RAYCAST}>
+          <lineBasicMaterial color="#ffffff" linewidth={1} transparent opacity={0.55} />
+        </lineSegments>
+      )}
+      <mesh geometry={farPlaneGeom} raycast={NO_RAYCAST}>
+        <meshBasicMaterial
+          color={color}
+          transparent
+          opacity={active ? 0.16 : 0.035}
+          side={DoubleSide}
+          depthWrite={false}
+        />
+      </mesh>
       {/* Apex marker — visual only. */}
       <mesh raycast={NO_RAYCAST}>
-        <sphereGeometry args={[farDepth * 0.06, 12, 8]} />
-        <meshBasicMaterial color={color} transparent opacity={active ? 0.9 : 0.45} />
+        <sphereGeometry args={[farDepth * (active ? 0.095 : 0.06), 16, 10]} />
+        <meshBasicMaterial color={color} transparent opacity={active ? 1 : 0.45} />
       </mesh>
-      {/* Invisible far-plane hitbox. The `visible={false}` flag stops
-        Three from rasterising this mesh, but the raycaster still
-        considers it. */}
-      <mesh geometry={hitboxGeom} visible={false}>
-        <meshBasicMaterial transparent opacity={0} />
+      {active &&
+        corners.map((corner, i) => (
+          <mesh key={`corner-${i}`} position={corner} raycast={NO_RAYCAST}>
+            <sphereGeometry args={[farDepth * 0.05, 12, 8]} />
+            <meshBasicMaterial color={color} transparent opacity={0.95} />
+          </mesh>
+        ))}
+      {active && label && (
+        <Html position={[0, -farDepth * 0.18, 0]} center style={{ pointerEvents: "none" }}>
+          <span className="rounded border border-brand/70 bg-bg-soft/90 px-1.5 py-0.5 font-mono text-[10px] text-brand shadow-sm">
+            {label}
+          </span>
+        </Html>
+      )}
+      {/* Invisible but raycastable camera body. */}
+      <mesh geometry={hitboxGeom}>
+        <meshBasicMaterial transparent opacity={0} side={DoubleSide} depthWrite={false} />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[farDepth * 0.14, 12, 8]} />
+        <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
     </group>
   );
@@ -158,4 +195,41 @@ function buildFarPlaneHitbox(
   const g = new BufferGeometry();
   g.setAttribute("position", new Float32BufferAttribute(verts, 3));
   return g;
+}
+
+/** Build a two-sided transparent frustum hull for picking: four side
+ * triangles plus the far-plane quad. Corners are padded around the
+ * far-plane center so near-edge clicks still feel intentional. */
+function buildFrustumHitbox(
+  corners: [number, number, number][],
+): BufferGeometry {
+  const padded = padCorners(corners, 1.18);
+  const apex: [number, number, number] = [0, 0, 0];
+  const [a, b, c, d] = padded;
+  const verts: number[] = [
+    ...apex, ...a, ...b,
+    ...apex, ...b, ...c,
+    ...apex, ...c, ...d,
+    ...apex, ...d, ...a,
+    ...a, ...b, ...c,
+    ...a, ...c, ...d,
+  ];
+  const g = new BufferGeometry();
+  g.setAttribute("position", new Float32BufferAttribute(verts, 3));
+  return g;
+}
+
+function padCorners(
+  corners: [number, number, number][],
+  scale: number,
+): [number, number, number][] {
+  const center = corners.reduce<[number, number, number]>(
+    (acc, c) => [acc[0] + c[0] / 4, acc[1] + c[1] / 4, acc[2] + c[2] / 4],
+    [0, 0, 0],
+  );
+  return corners.map((c) => [
+    center[0] + (c[0] - center[0]) * scale,
+    center[1] + (c[1] - center[1]) * scale,
+    center[2] + (c[2] - center[2]) * scale,
+  ]);
 }

--- a/app/src/workspaces/Viewer3DWorkspace/CameraFrustum.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/CameraFrustum.tsx
@@ -1,7 +1,14 @@
 import { useMemo } from "react";
-import { BufferGeometry, Float32BufferAttribute } from "three";
+import { BufferGeometry, Float32BufferAttribute, type Object3D } from "three";
 import { iso3InverseFromWire } from "../../lib/se3";
 import type { Iso3Wire, PinholeCameraWire } from "../../store/types";
+
+/** R3F's `raycast={fn}` prop expects a `Object3D['raycast']`. We use
+ * a no-op to opt the visual-only meshes out of the raycaster pipeline,
+ * letting clicks pass through to the dedicated hitbox quad below.
+ * `Object3D['raycast']` returns void, so an empty function is the
+ * canonical "no hit" signal. */
+const NO_RAYCAST: Object3D["raycast"] = () => {};
 
 interface CameraFrustumProps {
   camera: PinholeCameraWire;
@@ -48,15 +55,49 @@ export function CameraFrustum({
 
   const geom = useMemo(() => buildEdgeGeometry(corners), [corners]);
 
+  // Far-plane hitbox: a transparent quad covering the full far plane
+  // of the frustum. Three.js's raycaster doesn't intersect line
+  // geometry by default, so without this hitbox the only clickable
+  // surface is the small apex sphere — and most users naturally try
+  // to click on the visible far quad. The mesh has `visible={false}`
+  // so it draws nothing but still participates in raycasting.
+  const hitboxGeom = useMemo(() => buildFarPlaneHitbox(corners), [corners]);
+
   return (
-    <group matrix={matrix} matrixAutoUpdate={false} onClick={onSelect}>
-      <lineSegments geometry={geom}>
+    <group
+      matrix={matrix}
+      matrixAutoUpdate={false}
+      onClick={(e) => {
+        if (!onSelect) return;
+        // Stop propagation so clicks on overlapping frustums don't
+        // double-fire onto whichever group is rendered next.
+        e.stopPropagation();
+        onSelect();
+      }}
+      onPointerOver={(e) => {
+        if (!onSelect) return;
+        e.stopPropagation();
+        document.body.style.cursor = "pointer";
+      }}
+      onPointerOut={() => {
+        document.body.style.cursor = "";
+      }}
+    >
+      {/* Wireframe edges — visual only. Opt out of raycast so clicks
+        pass through to the hitbox below. */}
+      <lineSegments geometry={geom} raycast={NO_RAYCAST}>
         <lineBasicMaterial color={color} linewidth={active ? 2 : 1} />
       </lineSegments>
-      {/* Solid apex marker so clicks register on a non-edge target. */}
-      <mesh>
+      {/* Apex marker — visual only. */}
+      <mesh raycast={NO_RAYCAST}>
         <sphereGeometry args={[farDepth * 0.06, 12, 8]} />
         <meshBasicMaterial color={color} transparent opacity={active ? 0.9 : 0.45} />
+      </mesh>
+      {/* Invisible far-plane hitbox. The `visible={false}` flag stops
+        Three from rasterising this mesh, but the raycaster still
+        considers it. */}
+      <mesh geometry={hitboxGeom} visible={false}>
+        <meshBasicMaterial transparent opacity={0} />
       </mesh>
     </group>
   );
@@ -97,6 +138,23 @@ function buildEdgeGeometry(
     const b = corners[(i + 1) % 4];
     verts.push(...a, ...b);
   }
+  const g = new BufferGeometry();
+  g.setAttribute("position", new Float32BufferAttribute(verts, 3));
+  return g;
+}
+
+/** Build a two-triangle BufferGeometry covering the four far-plane
+ * corners. Used as an invisible click target — Three.js's raycaster
+ * picks up triangulated meshes by default but skips line geometry. */
+function buildFarPlaneHitbox(
+  corners: [number, number, number][],
+): BufferGeometry {
+  // Triangulate the quad as (0, 1, 2) + (0, 2, 3).
+  const [a, b, c, d] = corners;
+  const verts: number[] = [
+    ...a, ...b, ...c,
+    ...a, ...c, ...d,
+  ];
   const g = new BufferGeometry();
   g.setAttribute("position", new Float32BufferAttribute(verts, 3));
   return g;

--- a/app/src/workspaces/Viewer3DWorkspace/Scene.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/Scene.tsx
@@ -104,6 +104,7 @@ export function Scene({
             color={i === cameraA ? colors.active : colors.inactive}
             active={i === cameraA}
             onSelect={() => setCamera(i, "A")}
+            label={`cam ${i}`}
           />
         );
       })}

--- a/crates/vision-calibration-core/Cargo.toml
+++ b/crates/vision-calibration-core/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 
 [features]
 tracing = ["dep:tracing"]
+schemars = ["dep:schemars"]
 
 [dependencies]
 nalgebra = { workspace = true }
@@ -21,6 +22,7 @@ rand = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional=true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vision-calibration-core/src/models/sensor.rs
+++ b/crates/vision-calibration-core/src/models/sensor.rs
@@ -52,6 +52,7 @@ impl<S: RealField + Copy> SensorModel<S> for HomographySensor<S> {
 
 /// Scheimpflug tilt parameters (OpenCV-compatible).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ScheimpflugParams {
     /// Tilt around X axis in radians (alias: tau_x).
     #[serde(alias = "tau_x")]

--- a/crates/vision-calibration-core/src/types/options.rs
+++ b/crates/vision-calibration-core/src/types/options.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 /// assert!(mask.cx);  // cx is fixed
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IntrinsicsFixMask {
     /// Fix focal length x component.
     pub fx: bool,
@@ -122,6 +123,7 @@ impl IntrinsicsFixMask {
 /// };
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DistortionFixMask {
     /// Fix first radial distortion coefficient.
     pub k1: bool,

--- a/crates/vision-calibration-dataset/Cargo.toml
+++ b/crates/vision-calibration-dataset/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "vision-calibration-dataset"
+description = "Canonical input-data manifest (DatasetSpec) for calibration-rs"
+readme = "README.md"
+keywords = ["camera", "calibration", "computer-vision", "dataset", "manifest"]
+categories = ["computer-vision"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[features]
+schemars = ["dep:schemars"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+schemars = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vision-calibration-dataset/README.md
+++ b/crates/vision-calibration-dataset/README.md
@@ -1,0 +1,10 @@
+# vision-calibration-dataset
+
+Canonical input-data manifest (`DatasetSpec`) for the calibration-rs
+workflow. The manifest is the single on-disk wire format users author
+(by hand or via AI heuristics) to describe a foreign dataset's layout
+without copying or renaming images.
+
+See ADR 0016 for design rationale. Per-problem-type converters
+(`DatasetSpec` → existing `*Input` IR) live in
+`vision-calibration-pipeline`.

--- a/crates/vision-calibration-dataset/src/lib.rs
+++ b/crates/vision-calibration-dataset/src/lib.rs
@@ -1,0 +1,37 @@
+//! Canonical input-data manifest for calibration-rs.
+//!
+//! [`DatasetSpec`] is the single on-disk wire format the user authors —
+//! either by hand or via AI heuristics that inspect a foreign dataset —
+//! describing where images, robot poses, and target metadata live. The
+//! manifest is _descriptive_, never prescriptive: data stays where the
+//! user put it and the manifest just points at it.
+//!
+//! See ADR 0016 for the design rationale, and ADR 0019 for the
+//! fail-fast-on-ambiguity contract that the [`_unresolved`] field
+//! enables.
+//!
+//! # Tiered fields
+//!
+//! Every field is tagged either `infer_from_data` (an AI manifest
+//! generator is expected to populate it from filenames / folder
+//! structure / sample data) or `human_or_doc_required` (the AI is
+//! forbidden from guessing — it must read documentation or ask the
+//! user). When inference fails, the field is left `null` and the
+//! field path is recorded in [`DatasetSpec::_unresolved`]; the runner
+//! refuses to proceed until that list is empty.
+//!
+//! Tier metadata is encoded as the `x-calib-tier` schema extension so
+//! both Rust and TypeScript form generators can render the right UX.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod spec;
+mod validator;
+
+pub use spec::{
+    CameraSource, DatasetSpec, ImagePattern, PoseColumnMap, PoseConvention, PosePairing,
+    RobotPoseFormat, RobotPoseSource, RotationFormat, TargetSpec, Topology, TransformConvention,
+    TranslationUnits,
+};
+pub use validator::{ValidationError, validate};

--- a/crates/vision-calibration-dataset/src/spec.rs
+++ b/crates/vision-calibration-dataset/src/spec.rs
@@ -1,0 +1,347 @@
+//! On-disk manifest types.
+//!
+//! All types here derive `Serialize + Deserialize` (always) and
+//! `JsonSchema` (under the `schemars` feature). The TOML/JSON wire
+//! format is the public contract; the corresponding Rust types may
+//! grow new variants/fields pre-1.0 but additions must remain
+//! backwards-compatible at the serde layer.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Top-level manifest
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Top-level dataset manifest. Authoritative description of where
+/// the user's calibration data lives and how to interpret it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct DatasetSpec {
+    /// Format-version sentinel. Always `1` for now; bumped on
+    /// breaking schema revisions.
+    #[serde(default = "default_version")]
+    pub version: u32,
+
+    /// Per-camera image sources. Length must match the topology's
+    /// expected camera count (e.g. `Topology::Mono` requires exactly
+    /// one entry).
+    pub cameras: Vec<CameraSource>,
+
+    /// Calibration-target specification. Tagged enum on `kind`.
+    pub target: TargetSpec,
+
+    /// Robot-pose source for hand-eye topologies. `None` for
+    /// pure-intrinsics calibrations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub robot_poses: Option<RobotPoseSource>,
+
+    /// Calibration topology — selects which problem type the runner
+    /// will dispatch to.
+    pub topology: Topology,
+
+    /// How per-camera images are paired across views (and optionally
+    /// with robot poses). `None` is permitted only for `Topology::Mono`
+    /// where pose-pairing is irrelevant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pose_pairing: Option<PosePairing>,
+
+    /// Frame conventions for robot poses. **No defaults** — every
+    /// component is required when `robot_poses` is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pose_convention: Option<PoseConvention>,
+
+    /// Field paths the AI manifest generator could not determine.
+    /// Validated to be empty before the runner accepts the manifest.
+    /// Populated as e.g. `["pose_convention.transform"]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "_unresolved")]
+    pub unresolved: Vec<String>,
+
+    /// Free-form human-readable description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+fn default_version() -> u32 {
+    1
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Camera source
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-camera image source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CameraSource {
+    /// Stable camera identifier (e.g. `"cam0"`). Used as a key in
+    /// pose pairings and downstream exports.
+    pub id: String,
+
+    /// Glob pattern (e.g. `"cam0/*.png"`) or explicit list of image
+    /// paths, relative to the manifest's directory unless absolute.
+    pub images: ImagePattern,
+
+    /// Optional rectangular ROI in source-image pixels — `[x, y, w, h]`.
+    /// When set, only the cropped region is fed to the detector and
+    /// stored in the export's image manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub roi_xywh: Option<[u32; 4]>,
+}
+
+/// How image paths for a camera are listed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ImagePattern {
+    /// Single shell-glob pattern, evaluated relative to the manifest
+    /// directory. Example: `"cam0/*.png"`.
+    Glob {
+        /// The glob pattern.
+        pattern: String,
+    },
+    /// Explicit ordered list of paths.
+    List {
+        /// Paths relative to the manifest directory unless absolute.
+        paths: Vec<PathBuf>,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Target specification
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Calibration-target metadata. Tagged on `kind`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum TargetSpec {
+    /// Standard checkerboard. Counts are interior corners
+    /// (i.e. `9x6` ⇒ a 10×7 black-and-white square grid).
+    Chessboard {
+        /// Number of interior corners along the rows axis.
+        rows: u32,
+        /// Number of interior corners along the cols axis.
+        cols: u32,
+        /// Edge length of one square in metres.
+        square_size_m: f64,
+    },
+    /// ChArUco board. Marker IDs and dictionary live here so detection
+    /// is fully deterministic from the manifest.
+    Charuco {
+        /// Number of squares along the rows axis (full grid, not
+        /// interior corners).
+        rows: u32,
+        /// Number of squares along the cols axis.
+        cols: u32,
+        /// Edge length of one square in metres.
+        square_size_m: f64,
+        /// Edge length of an embedded marker in metres.
+        marker_size_m: f64,
+        /// ArUco dictionary identifier (e.g. `"DICT_4X4_50"`). The
+        /// detector validates this against the supported set.
+        dictionary: String,
+    },
+    /// Puzzleboard target (calib-targets crate). Layout is fully
+    /// described by the named variant in calib-targets; the manifest
+    /// just carries the discriminator.
+    Puzzleboard {
+        /// Named layout (e.g. `"puzzle_130x130"`).
+        layout: String,
+        /// Edge length of one cell in metres.
+        cell_size_m: f64,
+    },
+    /// Ringgrid target (ringgrid crate).
+    Ringgrid {
+        /// Number of rings along the rows axis.
+        rows: u32,
+        /// Number of rings along the cols axis.
+        cols: u32,
+        /// Centre-to-centre spacing of adjacent rings in metres.
+        spacing_m: f64,
+        /// Inner ring radius in metres.
+        inner_radius_m: f64,
+        /// Outer ring radius in metres.
+        outer_radius_m: f64,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Robot poses
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Where and how robot poses are stored on disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct RobotPoseSource {
+    /// Path to the pose file, relative to the manifest directory
+    /// unless absolute.
+    pub path: PathBuf,
+    /// File-format selector.
+    pub format: RobotPoseFormat,
+    /// Column / field mapping from the user's file to the canonical
+    /// fields the converter consumes.
+    pub columns: PoseColumnMap,
+}
+
+/// Robot-pose file format.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum RobotPoseFormat {
+    /// Comma-separated values with a header row.
+    Csv,
+    /// JSON array of objects.
+    Json,
+    /// JSONL (one JSON object per line).
+    Jsonl,
+}
+
+/// Mapping from user-defined column / field names to the canonical
+/// pose fields. All seven of `tx, ty, tz, qx, qy, qz, qw` are required
+/// when `rotation_format` is a quaternion; the runner rejects partial
+/// mappings as a fail-fast event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct PoseColumnMap {
+    /// Optional view-id column (string or integer). When absent, the
+    /// pose row index is used as the implicit pose id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pose_id: Option<String>,
+    /// Translation x column.
+    pub tx: String,
+    /// Translation y column.
+    pub ty: String,
+    /// Translation z column.
+    pub tz: String,
+    /// Rotation columns. Length and meaning depend on the
+    /// `pose_convention.rotation_format`.
+    pub rotation: Vec<String>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Topology
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Calibration topology — selects the problem-type dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum Topology {
+    /// Single camera, planar target — `PlanarIntrinsicsProblem`.
+    PlanarIntrinsics,
+    /// Single camera with Scheimpflug tilt — `ScheimpflugIntrinsicsProblem`.
+    ScheimpflugIntrinsics,
+    /// Single camera mounted on a robot — `SingleCamHandeyeProblem`.
+    SingleCamHandeye,
+    /// Camera + laser plane — `LaserlineDeviceProblem`.
+    LaserlineDevice,
+    /// Multi-camera rig, target only — `RigExtrinsicsProblem`.
+    RigExtrinsics,
+    /// Multi-camera rig + robot — `RigHandeyeProblem`.
+    RigHandeye,
+    /// Multi-camera rig + laser planes — `RigLaserlineDeviceProblem`.
+    RigLaserlineDevice,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pose pairing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// How per-camera image lists align across views and (optionally)
+/// align with robot poses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum PosePairing {
+    /// All cameras have the same number of images, paired by index
+    /// (image[i] from cam0 ↔ image[i] from cam1 ↔ pose[i]).
+    ByIndex,
+    /// A regex applied to filenames extracts a shared "view token"
+    /// (e.g. timestamp or pose id). All cameras and the pose file
+    /// must produce the same set of tokens.
+    SharedFilenameToken {
+        /// Regex with at least one named capture group.
+        regex: String,
+        /// Name of the capture group whose value identifies the view.
+        group: String,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pose conventions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Frame conventions for the robot pose stream.
+///
+/// All three components are required (no defaults). Each is a closed
+/// enum so the runtime supports a finite, validated set of conventions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct PoseConvention {
+    /// Which transform the pose row encodes.
+    pub transform: TransformConvention,
+    /// How rotation is parameterised in the file.
+    pub rotation_format: RotationFormat,
+    /// Translation units in the file.
+    pub translation_units: TranslationUnits,
+}
+
+/// Which transform a pose row encodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum TransformConvention {
+    /// `T_base_tcp` — gripper pose in the robot base frame (KUKA, UR
+    /// default).
+    TBaseTcp,
+    /// `T_tcp_base` — base pose in the gripper frame (some ABB exports).
+    TTcpBase,
+    /// `T_world_tcp` — gripper pose in a fixed world frame (less
+    /// common; some lab-frame setups).
+    TWorldTcp,
+    /// `T_tcp_world` — world pose in the gripper frame.
+    TTcpWorld,
+}
+
+/// Rotation parameterisation in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum RotationFormat {
+    /// Hamilton quaternion as `[qx, qy, qz, qw]`.
+    QuatXyzw,
+    /// Hamilton quaternion as `[qw, qx, qy, qz]`.
+    QuatWxyz,
+    /// Intrinsic XYZ Euler angles in degrees.
+    EulerXyzDeg,
+    /// Intrinsic XYZ Euler angles in radians.
+    EulerXyzRad,
+    /// Intrinsic ZYX Euler angles in degrees.
+    EulerZyxDeg,
+    /// Intrinsic ZYX Euler angles in radians.
+    EulerZyxRad,
+    /// Axis-angle vector (length encodes magnitude, radians).
+    AxisAngleRad,
+    /// Row-major 4×4 homogeneous matrix flattened across 16 columns.
+    Matrix4x4RowMajor,
+}
+
+/// Translation units in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum TranslationUnits {
+    /// Metres (SI, preferred).
+    M,
+    /// Millimetres (some ABB / Fanuc exports).
+    Mm,
+}

--- a/crates/vision-calibration-dataset/src/validator.rs
+++ b/crates/vision-calibration-dataset/src/validator.rs
@@ -19,13 +19,19 @@ pub enum ValidationError {
         topology: Topology,
     },
 
-    /// A topology requires multiple cameras but only one was given.
-    #[error("topology {topology:?} requires a multi-camera rig but only {got} camera(s) given")]
-    NotEnoughCameras {
+    /// The number of cameras declared doesn't match what the topology
+    /// expects — either too few (single-cam topology with extras) or
+    /// too many (rig topology with insufficient cameras for stereo).
+    #[error("topology {topology:?} expects {expected_min}..={expected_max} camera(s), got {got}")]
+    WrongCameraCount {
         /// The offending topology.
         topology: Topology,
         /// How many cameras were declared.
         got: usize,
+        /// Inclusive minimum count for the topology.
+        expected_min: usize,
+        /// Inclusive maximum count (`usize::MAX` for unbounded rigs).
+        expected_max: usize,
     },
 
     /// `pose_convention` is missing while `robot_poses` is set.
@@ -77,11 +83,14 @@ pub fn validate(spec: &DatasetSpec) -> Result<(), ValidationError> {
         });
     }
 
-    let min_cams = topology_min_cameras(spec.topology);
-    if spec.cameras.len() < min_cams {
-        return Err(ValidationError::NotEnoughCameras {
+    let (min_cams, max_cams) = topology_camera_range(spec.topology);
+    let got = spec.cameras.len();
+    if got < min_cams || got > max_cams {
+        return Err(ValidationError::WrongCameraCount {
             topology: spec.topology,
-            got: spec.cameras.len(),
+            got,
+            expected_min: min_cams,
+            expected_max: max_cams,
         });
     }
 
@@ -127,13 +136,20 @@ fn topology_needs_robot(t: Topology) -> bool {
     matches!(t, Topology::SingleCamHandeye | Topology::RigHandeye)
 }
 
-fn topology_min_cameras(t: Topology) -> usize {
+fn topology_camera_range(t: Topology) -> (usize, usize) {
     match t {
+        // Single-camera topologies must have exactly one camera; an
+        // extra camera in the manifest is almost always a user mistake
+        // (wrong topology selected, leftover entry from a copy-paste).
         Topology::PlanarIntrinsics
         | Topology::ScheimpflugIntrinsics
         | Topology::SingleCamHandeye
-        | Topology::LaserlineDevice => 1,
-        Topology::RigExtrinsics | Topology::RigHandeye | Topology::RigLaserlineDevice => 2,
+        | Topology::LaserlineDevice => (1, 1),
+        // Rig topologies need at least two cameras; the upper bound is
+        // unconstrained (puzzle 130×130 ships with 6).
+        Topology::RigExtrinsics | Topology::RigHandeye | Topology::RigLaserlineDevice => {
+            (2, usize::MAX)
+        }
     }
 }
 
@@ -235,6 +251,28 @@ mod tests {
         });
         let err = validate(&spec).unwrap_err();
         assert!(matches!(err, ValidationError::MissingRobotPoses { .. }));
+    }
+
+    #[test]
+    fn planar_topology_rejects_extra_camera() {
+        let mut spec = planar_chessboard_minimal();
+        spec.cameras.push(CameraSource {
+            id: "cam1".into(),
+            images: ImagePattern::Glob {
+                pattern: "cam1/*.png".into(),
+            },
+            roi_xywh: None,
+        });
+        let err = validate(&spec).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::WrongCameraCount {
+                expected_min: 1,
+                expected_max: 1,
+                got: 2,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/vision-calibration-dataset/src/validator.rs
+++ b/crates/vision-calibration-dataset/src/validator.rs
@@ -1,0 +1,305 @@
+//! Manifest validation. Catches structural errors that would
+//! otherwise surface as a fail-fast `AskUser` event downstream.
+
+use crate::spec::{DatasetSpec, ImagePattern, RobotPoseSource, RotationFormat, Topology};
+use thiserror::Error;
+
+/// Validation failure modes.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ValidationError {
+    /// The manifest still has unresolved fields. Per ADR 0019 the
+    /// runner refuses to dispatch until they are filled in.
+    #[error("manifest has unresolved fields: {0:?}")]
+    Unresolved(Vec<String>),
+
+    /// A topology requires robot poses but `robot_poses` is `None`.
+    #[error("topology {topology:?} requires robot_poses but none was given")]
+    MissingRobotPoses {
+        /// The offending topology.
+        topology: Topology,
+    },
+
+    /// A topology requires multiple cameras but only one was given.
+    #[error("topology {topology:?} requires a multi-camera rig but only {got} camera(s) given")]
+    NotEnoughCameras {
+        /// The offending topology.
+        topology: Topology,
+        /// How many cameras were declared.
+        got: usize,
+    },
+
+    /// `pose_convention` is missing while `robot_poses` is set.
+    #[error("robot_poses is set but pose_convention is missing")]
+    MissingPoseConvention,
+
+    /// Two cameras share the same id, breaking pairing assumptions.
+    #[error("duplicate camera id {0:?}")]
+    DuplicateCameraId(String),
+
+    /// A glob pattern is empty or a path list is empty.
+    #[error("camera {0:?} has no images")]
+    EmptyImagePattern(String),
+
+    /// The pose-column rotation list has the wrong length for the
+    /// declared rotation format.
+    #[error("rotation columns: format {format:?} expects {expected} columns, got {got}")]
+    BadRotationColumnCount {
+        /// The declared rotation format.
+        format: RotationFormat,
+        /// How many rotation columns the user supplied.
+        got: usize,
+        /// How many were expected.
+        expected: usize,
+    },
+
+    /// An ROI rectangle has zero width or height.
+    #[error("camera {camera_id:?} has degenerate ROI {roi:?}")]
+    DegenerateRoi {
+        /// The offending camera id.
+        camera_id: String,
+        /// The ROI as declared in the manifest (`[x, y, w, h]`).
+        roi: [u32; 4],
+    },
+}
+
+/// Validate the structural invariants of a manifest. Does not touch
+/// the filesystem (e.g. doesn't expand globs). Per ADR 0019, callers
+/// should reject the manifest as soon as any error fires.
+pub fn validate(spec: &DatasetSpec) -> Result<(), ValidationError> {
+    if !spec.unresolved.is_empty() {
+        return Err(ValidationError::Unresolved(spec.unresolved.clone()));
+    }
+
+    let needs_robot = topology_needs_robot(spec.topology);
+    if needs_robot && spec.robot_poses.is_none() {
+        return Err(ValidationError::MissingRobotPoses {
+            topology: spec.topology,
+        });
+    }
+
+    let min_cams = topology_min_cameras(spec.topology);
+    if spec.cameras.len() < min_cams {
+        return Err(ValidationError::NotEnoughCameras {
+            topology: spec.topology,
+            got: spec.cameras.len(),
+        });
+    }
+
+    if spec.robot_poses.is_some() && spec.pose_convention.is_none() {
+        return Err(ValidationError::MissingPoseConvention);
+    }
+
+    let mut seen_ids = std::collections::HashSet::new();
+    for cam in &spec.cameras {
+        if !seen_ids.insert(cam.id.clone()) {
+            return Err(ValidationError::DuplicateCameraId(cam.id.clone()));
+        }
+        match &cam.images {
+            ImagePattern::Glob { pattern } if pattern.is_empty() => {
+                return Err(ValidationError::EmptyImagePattern(cam.id.clone()));
+            }
+            ImagePattern::List { paths } if paths.is_empty() => {
+                return Err(ValidationError::EmptyImagePattern(cam.id.clone()));
+            }
+            _ => {}
+        }
+        if let Some(roi) = cam.roi_xywh
+            && (roi[2] == 0 || roi[3] == 0)
+        {
+            return Err(ValidationError::DegenerateRoi {
+                camera_id: cam.id.clone(),
+                roi,
+            });
+        }
+    }
+
+    if let Some(robot) = &spec.robot_poses {
+        validate_pose_columns(
+            robot,
+            spec.pose_convention.as_ref().map(|c| c.rotation_format),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn topology_needs_robot(t: Topology) -> bool {
+    matches!(t, Topology::SingleCamHandeye | Topology::RigHandeye)
+}
+
+fn topology_min_cameras(t: Topology) -> usize {
+    match t {
+        Topology::PlanarIntrinsics
+        | Topology::ScheimpflugIntrinsics
+        | Topology::SingleCamHandeye
+        | Topology::LaserlineDevice => 1,
+        Topology::RigExtrinsics | Topology::RigHandeye | Topology::RigLaserlineDevice => 2,
+    }
+}
+
+fn validate_pose_columns(
+    robot: &RobotPoseSource,
+    format: Option<RotationFormat>,
+) -> Result<(), ValidationError> {
+    let Some(format) = format else {
+        // Caller has already produced a `MissingPoseConvention` error
+        // if `pose_convention` is `None` while `robot_poses` is set.
+        return Ok(());
+    };
+    let expected = expected_rotation_columns(format);
+    let got = robot.columns.rotation.len();
+    if got != expected {
+        return Err(ValidationError::BadRotationColumnCount {
+            format,
+            got,
+            expected,
+        });
+    }
+    Ok(())
+}
+
+fn expected_rotation_columns(format: RotationFormat) -> usize {
+    match format {
+        RotationFormat::QuatXyzw | RotationFormat::QuatWxyz => 4,
+        RotationFormat::EulerXyzDeg
+        | RotationFormat::EulerXyzRad
+        | RotationFormat::EulerZyxDeg
+        | RotationFormat::EulerZyxRad
+        | RotationFormat::AxisAngleRad => 3,
+        RotationFormat::Matrix4x4RowMajor => 16,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{
+        CameraSource, DatasetSpec, ImagePattern, PoseColumnMap, PoseConvention, RobotPoseFormat,
+        RobotPoseSource, RotationFormat, TargetSpec, Topology, TransformConvention,
+        TranslationUnits,
+    };
+
+    fn planar_chessboard_minimal() -> DatasetSpec {
+        DatasetSpec {
+            version: 1,
+            cameras: vec![CameraSource {
+                id: "cam0".into(),
+                images: ImagePattern::Glob {
+                    pattern: "cam0/*.png".into(),
+                },
+                roi_xywh: None,
+            }],
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: None,
+            topology: Topology::PlanarIntrinsics,
+            pose_pairing: None,
+            pose_convention: None,
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    #[test]
+    fn minimal_planar_chessboard_validates() {
+        let spec = planar_chessboard_minimal();
+        validate(&spec).unwrap();
+    }
+
+    #[test]
+    fn unresolved_fields_block_validation() {
+        let mut spec = planar_chessboard_minimal();
+        spec.unresolved.push("pose_convention.transform".into());
+        let err = validate(&spec).unwrap_err();
+        match err {
+            ValidationError::Unresolved(fields) => {
+                assert_eq!(fields, vec!["pose_convention.transform".to_string()]);
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rig_handeye_requires_robot_poses() {
+        let mut spec = planar_chessboard_minimal();
+        spec.topology = Topology::RigHandeye;
+        spec.cameras.push(CameraSource {
+            id: "cam1".into(),
+            images: ImagePattern::Glob {
+                pattern: "cam1/*.png".into(),
+            },
+            roi_xywh: None,
+        });
+        let err = validate(&spec).unwrap_err();
+        assert!(matches!(err, ValidationError::MissingRobotPoses { .. }));
+    }
+
+    #[test]
+    fn duplicate_camera_id_rejected() {
+        let mut spec = planar_chessboard_minimal();
+        spec.topology = Topology::RigExtrinsics;
+        spec.cameras.push(CameraSource {
+            id: "cam0".into(),
+            images: ImagePattern::Glob {
+                pattern: "cam_dup/*.png".into(),
+            },
+            roi_xywh: None,
+        });
+        let err = validate(&spec).unwrap_err();
+        assert!(matches!(err, ValidationError::DuplicateCameraId(_)));
+    }
+
+    #[test]
+    fn rotation_column_count_must_match_format() {
+        let robot = RobotPoseSource {
+            path: "poses.csv".into(),
+            format: RobotPoseFormat::Csv,
+            columns: PoseColumnMap {
+                pose_id: None,
+                tx: "x".into(),
+                ty: "y".into(),
+                tz: "z".into(),
+                // QuatXyzw needs 4 columns; supply 3 to trigger.
+                rotation: vec!["rx".into(), "ry".into(), "rz".into()],
+            },
+        };
+        let convention = PoseConvention {
+            transform: TransformConvention::TBaseTcp,
+            rotation_format: RotationFormat::QuatXyzw,
+            translation_units: TranslationUnits::M,
+        };
+        let mut spec = planar_chessboard_minimal();
+        spec.topology = Topology::SingleCamHandeye;
+        spec.robot_poses = Some(robot);
+        spec.pose_convention = Some(convention);
+        let err = validate(&spec).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::BadRotationColumnCount {
+                expected: 4,
+                got: 3,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn degenerate_roi_rejected() {
+        let mut spec = planar_chessboard_minimal();
+        spec.cameras[0].roi_xywh = Some([0, 0, 0, 480]);
+        let err = validate(&spec).unwrap_err();
+        assert!(matches!(err, ValidationError::DegenerateRoi { .. }));
+    }
+
+    #[test]
+    fn json_roundtrip_minimal() {
+        let spec = planar_chessboard_minimal();
+        let s = serde_json::to_string(&spec).unwrap();
+        let back: DatasetSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.cameras.len(), 1);
+        assert!(back.unresolved.is_empty());
+    }
+}

--- a/crates/vision-calibration-detect/Cargo.toml
+++ b/crates/vision-calibration-detect/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "vision-calibration-detect"
+description = "Calibration-target feature detectors (chessboard, charuco, puzzleboard, ringgrid) with content-addressed cache"
+readme = "README.md"
+keywords = ["camera", "calibration", "computer-vision", "detection", "chessboard"]
+categories = ["computer-vision"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[features]
+default = ["chessboard"]
+chessboard = ["dep:chess-corners", "dep:calib-targets"]
+schemars = ["dep:schemars"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+image = { workspace = true }
+schemars = { workspace = true, optional = true }
+chess-corners = { workspace = true, optional = true }
+calib-targets = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/vision-calibration-detect/Cargo.toml
+++ b/crates/vision-calibration-detect/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 [features]
 default = ["chessboard"]
-chessboard = ["dep:chess-corners", "dep:calib-targets"]
+chessboard = ["dep:calib-targets"]
 schemars = ["dep:schemars"]
 
 [dependencies]
@@ -23,7 +23,6 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 image = { workspace = true }
 schemars = { workspace = true, optional = true }
-chess-corners = { workspace = true, optional = true }
 calib-targets = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/vision-calibration-detect/README.md
+++ b/crates/vision-calibration-detect/README.md
@@ -1,0 +1,9 @@
+# vision-calibration-detect
+
+Calibration-target feature detectors (chessboard, charuco, puzzleboard,
+ringgrid) plus a content-addressed [`DetectionCache`] keyed on
+`(image_content_hash, detector_name, canonical_config_hash)`. The cache
+makes solver iteration sub-second on cache hit; see ADR 0017.
+
+PR 1 ships the chessboard detector only (wrapping `chess-corners` +
+`calib-targets`). PR 2 adds charuco / puzzleboard / ringgrid.

--- a/crates/vision-calibration-detect/src/cache.rs
+++ b/crates/vision-calibration-detect/src/cache.rs
@@ -1,0 +1,228 @@
+//! Content-addressed detection cache (ADR 0017).
+//!
+//! The cache is keyed on
+//! `(image_content_hash, detector_name, canonical_config_hash)` where:
+//!
+//! * `image_content_hash` is the BLAKE-style 64-bit FNV-1a digest of
+//!   the raw image bytes. We deliberately avoid file mtime — moving an
+//!   image around shouldn't invalidate the cached detection of its
+//!   contents.
+//! * `detector_name` is the `Detector::name()` string (e.g.
+//!   `"chessboard"`).
+//! * `canonical_config_hash` is the hash of the detector config
+//!   serialized to JSON with sorted keys, so semantically equal
+//!   configs produce identical keys regardless of struct field order.
+//!
+//! The default [`FsDetectionCache`] persists entries as JSON files
+//! under `<root>/<key>.json`. Tests can use it with a `tempfile::tempdir()`
+//! root; production code points it at `~/.cache/calibration-rs/<dataset_id>/`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+use crate::Feature;
+
+/// Errors raised by [`DetectionCache`] implementations.
+#[derive(Debug, Error)]
+pub enum CacheError {
+    /// I/O failure inside the cache backend.
+    #[error("cache I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Serde failure (de)serializing a cache entry.
+    #[error("cache serde error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// Composite cache key. Cheap to compute, hex-encoded for filesystem
+/// safety.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CacheKey {
+    /// FNV-1a digest of the raw image bytes.
+    pub image_hash: u64,
+    /// Stable detector name (e.g. `"chessboard"`).
+    pub detector: String,
+    /// Hash of the canonical (sorted-key) JSON of the detector config.
+    pub config_hash: u64,
+}
+
+impl CacheKey {
+    /// Build a key from raw image bytes + detector name + config JSON.
+    /// Uses canonical (sorted-key) serialization for the config so
+    /// `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` collide as intended.
+    pub fn from_inputs(image_bytes: &[u8], detector: &str, config: &Value) -> Self {
+        Self {
+            image_hash: hash_image_bytes(image_bytes),
+            detector: detector.to_string(),
+            config_hash: hash_canonical_json(config),
+        }
+    }
+
+    /// Filename-safe encoding (`<image>-<detector>-<config>.json`).
+    pub fn file_name(&self) -> String {
+        format!(
+            "{:016x}-{}-{:016x}.json",
+            self.image_hash, self.detector, self.config_hash
+        )
+    }
+}
+
+/// Hash raw image bytes with FNV-1a (64-bit). Cheap, allocation-free,
+/// good enough for content-addressed cache keys (we're not defending
+/// against adversarial collisions, only against accidental ones).
+pub fn hash_image_bytes(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = FNV_OFFSET;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+fn hash_canonical_json(value: &Value) -> u64 {
+    let canonical = canonicalize(value.clone());
+    let bytes = serde_json::to_vec(&canonical).expect("canonical JSON is serializable");
+    hash_image_bytes(&bytes)
+}
+
+fn canonicalize(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sorted: std::collections::BTreeMap<String, Value> =
+                std::collections::BTreeMap::new();
+            for (k, v) in map {
+                sorted.insert(k, canonicalize(v));
+            }
+            Value::Object(sorted.into_iter().collect())
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(canonicalize).collect()),
+        other => other,
+    }
+}
+
+/// Cached detection result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedFeatures {
+    /// The features that were originally produced by the detector.
+    pub features: Vec<Feature>,
+}
+
+/// Detection cache backend.
+///
+/// Implementations need only be `Send + Sync` so the runner can share
+/// one instance across the per-image detection loop on a tokio
+/// blocking task.
+pub trait DetectionCache: Send + Sync {
+    /// Try to read a cache entry. `Ok(None)` means cache miss.
+    fn get(&self, key: &CacheKey) -> Result<Option<CachedFeatures>, CacheError>;
+
+    /// Store a cache entry.
+    fn put(&self, key: &CacheKey, value: &CachedFeatures) -> Result<(), CacheError>;
+}
+
+/// Filesystem-backed cache writing one JSON file per entry under
+/// [`Self::root`]. Stable across crashes; safe under concurrent
+/// readers/writers as long as the underlying filesystem provides
+/// atomic rename (ext4, APFS, NTFS — all do).
+#[derive(Debug, Clone)]
+pub struct FsDetectionCache {
+    root: PathBuf,
+}
+
+impl FsDetectionCache {
+    /// Create a cache rooted at `root`. The directory is created on
+    /// first write; reads from a missing directory return cache miss.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Return the on-disk root.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl DetectionCache for FsDetectionCache {
+    fn get(&self, key: &CacheKey) -> Result<Option<CachedFeatures>, CacheError> {
+        let path = self.root.join(key.file_name());
+        match std::fs::read(&path) {
+            Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn put(&self, key: &CacheKey, value: &CachedFeatures) -> Result<(), CacheError> {
+        std::fs::create_dir_all(&self.root)?;
+        let final_path = self.root.join(key.file_name());
+        let tmp_path = self.root.join(format!("{}.tmp", key.file_name()));
+        let bytes = serde_json::to_vec_pretty(value)?;
+        std::fs::write(&tmp_path, bytes)?;
+        std::fs::rename(tmp_path, final_path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    #[test]
+    fn key_is_deterministic_under_field_reordering() {
+        let img = b"image bytes";
+        let cfg_a = json!({ "rows": 9, "cols": 6 });
+        let cfg_b = json!({ "cols": 6, "rows": 9 });
+        let a = CacheKey::from_inputs(img, "chessboard", &cfg_a);
+        let b = CacheKey::from_inputs(img, "chessboard", &cfg_b);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn key_changes_when_config_changes() {
+        let img = b"image bytes";
+        let cfg_a = json!({ "rows": 9, "cols": 6 });
+        let cfg_b = json!({ "rows": 9, "cols": 7 });
+        let a = CacheKey::from_inputs(img, "chessboard", &cfg_a);
+        let b = CacheKey::from_inputs(img, "chessboard", &cfg_b);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn key_changes_when_image_changes() {
+        let cfg = json!({ "rows": 9, "cols": 6 });
+        let a = CacheKey::from_inputs(b"image A", "chessboard", &cfg);
+        let b = CacheKey::from_inputs(b"image B", "chessboard", &cfg);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fs_cache_roundtrip() {
+        let dir = tempdir().unwrap();
+        let cache = FsDetectionCache::new(dir.path());
+        let key = CacheKey::from_inputs(b"img", "chessboard", &json!({"x": 1}));
+        assert!(cache.get(&key).unwrap().is_none(), "expected miss");
+        let entry = CachedFeatures {
+            features: vec![Feature {
+                image_xy: [10.0, 20.0],
+                world_xyz: [0.0, 0.0, 0.0],
+            }],
+        };
+        cache.put(&key, &entry).unwrap();
+        let back = cache.get(&key).unwrap().expect("cache hit expected");
+        assert_eq!(back.features.len(), 1);
+        assert_eq!(back.features[0].image_xy, [10.0, 20.0]);
+    }
+
+    #[test]
+    fn fs_cache_returns_miss_for_unknown_root() {
+        let cache =
+            FsDetectionCache::new(std::env::temp_dir().join("definitely-does-not-exist-xxxx"));
+        let key = CacheKey::from_inputs(b"img", "chessboard", &json!({}));
+        assert!(cache.get(&key).unwrap().is_none());
+    }
+}

--- a/crates/vision-calibration-detect/src/chessboard.rs
+++ b/crates/vision-calibration-detect/src/chessboard.rs
@@ -1,0 +1,113 @@
+//! Chessboard detector wrapping `chess-corners` + `calib-targets`.
+//!
+//! The detector returns one [`Feature`] per detected interior corner
+//! whose grid-coordinate disambiguation succeeded. Corners without a
+//! grid index are filtered out — calibration consumes 2D-3D
+//! correspondences, so an unindexed corner is unusable.
+
+use anyhow::{Result, anyhow};
+use calib_targets::chessboard::DetectorParams as ChessboardDetectorParams;
+use calib_targets::detect;
+use chess_corners::ChessConfig;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
+use crate::{Detector, Feature};
+
+/// Chessboard detector configuration. Mirrors the shape of the
+/// chessboard variant in
+/// [`vision_calibration_dataset::TargetSpec`] so the dispatcher can
+/// translate one to the other directly.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct ChessboardConfig {
+    /// Number of interior corners along the rows axis.
+    pub rows: u32,
+    /// Number of interior corners along the cols axis.
+    pub cols: u32,
+    /// Edge length of one square in metres. Used to lift each detected
+    /// corner from grid index `(i, j)` to its 3D point
+    /// `(i * square_size_m, j * square_size_m, 0)`.
+    pub square_size_m: f64,
+}
+
+/// Stateless chessboard detector instance.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ChessboardDetector;
+
+impl Detector for ChessboardDetector {
+    fn name(&self) -> &'static str {
+        "chessboard"
+    }
+
+    fn detect_json(&self, image: &image::DynamicImage, config: &Value) -> Result<Vec<Feature>> {
+        let cfg: ChessboardConfig = serde_json::from_value(config.clone())
+            .map_err(|e| anyhow!("invalid chessboard config: {e}"))?;
+        let luma = image.to_luma8();
+
+        // The underlying detector auto-labels corners from
+        // intersection clustering — `rows`/`cols` from our config are
+        // used only for output validation, not as input parameters.
+        // `chess-corners` provides defaults tuned for typical
+        // 5–13 mm calibration boards.
+        let _chess_config = ChessConfig::default();
+        let board_params = ChessboardDetectorParams::default();
+
+        let detection = detect::detect_chessboard(&luma, &board_params);
+        let Some(detection) = detection else {
+            return Ok(Vec::new());
+        };
+
+        // Filter to corners whose grid index falls inside the expected
+        // `rows × cols` range, then lift to 3D using the supplied
+        // square size.
+        let max_i = cfg.rows as i32;
+        let max_j = cfg.cols as i32;
+        let mut features = Vec::new();
+        for corner in detection.target.corners {
+            let Some(grid) = corner.grid else { continue };
+            if grid.i < 0 || grid.j < 0 || grid.i >= max_i || grid.j >= max_j {
+                continue;
+            }
+            features.push(Feature {
+                image_xy: [corner.position.x as f64, corner.position.y as f64],
+                world_xyz: [
+                    grid.i as f64 * cfg.square_size_m,
+                    grid.j as f64 * cfg.square_size_m,
+                    0.0,
+                ],
+            });
+        }
+        Ok(features)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn invalid_config_rejected() {
+        let img = image::DynamicImage::new_luma8(8, 8);
+        let det = ChessboardDetector;
+        let err = det
+            .detect_json(&img, &json!({"rows": 9})) // missing cols, square_size_m
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid chessboard config"), "got: {msg}");
+    }
+
+    #[test]
+    fn empty_image_returns_no_features() {
+        let img = image::DynamicImage::new_luma8(64, 64);
+        let det = ChessboardDetector;
+        let cfg = json!({ "rows": 9, "cols": 6, "square_size_m": 0.025 });
+        let features = det.detect_json(&img, &cfg).unwrap();
+        assert!(features.is_empty(), "blank image should yield no features");
+    }
+}

--- a/crates/vision-calibration-detect/src/chessboard.rs
+++ b/crates/vision-calibration-detect/src/chessboard.rs
@@ -8,7 +8,6 @@
 use anyhow::{Result, anyhow};
 use calib_targets::chessboard::DetectorParams as ChessboardDetectorParams;
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -52,9 +51,9 @@ impl Detector for ChessboardDetector {
         // The underlying detector auto-labels corners from
         // intersection clustering — `rows`/`cols` from our config are
         // used only for output validation, not as input parameters.
-        // `chess-corners` provides defaults tuned for typical
-        // 5–13 mm calibration boards.
-        let _chess_config = ChessConfig::default();
+        // ChESS corner config is fixed inside `detect::detect_chessboard`
+        // (uses `default_chess_config()`); callers needing custom ChESS
+        // parameters must drop down to `chessboard::Detector::detect`.
         let board_params = ChessboardDetectorParams::default();
 
         let detection = detect::detect_chessboard(&luma, &board_params);

--- a/crates/vision-calibration-detect/src/feature.rs
+++ b/crates/vision-calibration-detect/src/feature.rs
@@ -1,0 +1,22 @@
+//! Detector output: 2D image points paired with their 3D world points
+//! in the target frame.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
+/// Single 2D-3D feature correspondence in canonical units.
+///
+/// `image_xy` is in source-image pixels (pre-ROI-crop if a ROI is
+/// declared in the manifest, the converter adjusts as needed).
+/// `world_xyz` is in metres, expressed in the calibration target's
+/// own frame (target origin at `(0, 0, 0)`, target plane at `z = 0`).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct Feature {
+    /// Pixel coordinates `[x, y]` (column, row).
+    pub image_xy: [f64; 2],
+    /// World coordinates `[x, y, z]` in metres in the target frame.
+    pub world_xyz: [f64; 3],
+}

--- a/crates/vision-calibration-detect/src/lib.rs
+++ b/crates/vision-calibration-detect/src/lib.rs
@@ -1,0 +1,58 @@
+//! Calibration-target feature detectors plus a content-addressed
+//! detection cache.
+//!
+//! Every detector exposes the same minimal interface:
+//!
+//! ```ignore
+//! pub trait Detector {
+//!     fn name(&self) -> &'static str;
+//!     fn detect_json(&self, image: &DynamicImage, config: &Value) -> Result<Vec<Feature>>;
+//! }
+//! ```
+//!
+//! The dispatcher (in `vision-calibration-pipeline`) maps a
+//! [`vision_calibration_dataset::TargetSpec`] to a `(name, config_json)`
+//! pair and calls into a registered detector. Cached features are keyed
+//! on `(image_content_hash, detector_name, canonical_config_hash)` so
+//! re-running with the same images and same detector params is free
+//! (filesystem read only, no detection re-run); changing detector
+//! params auto-invalidates that detector's entries while leaving
+//! others intact.
+//!
+//! See ADR 0017 for the cache contract.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod cache;
+mod feature;
+
+#[cfg(feature = "chessboard")]
+mod chessboard;
+
+pub use cache::{
+    CacheError, CacheKey, CachedFeatures, DetectionCache, FsDetectionCache, hash_image_bytes,
+};
+pub use feature::Feature;
+
+#[cfg(feature = "chessboard")]
+pub use chessboard::{ChessboardConfig, ChessboardDetector};
+
+use serde_json::Value;
+
+/// Minimal detector interface used by the runner. Configs are passed
+/// in type-erased JSON form so dispatch (and the cache key derivation)
+/// can be data-driven from the dataset manifest without monomorphising
+/// over every detector.
+pub trait Detector: Send + Sync {
+    /// Stable, lowercase name (`"chessboard"`, `"charuco"`, …).
+    fn name(&self) -> &'static str;
+
+    /// Detect calibration-target features in `image`. The `config`
+    /// must deserialize into the detector-specific config struct.
+    fn detect_json(
+        &self,
+        image: &image::DynamicImage,
+        config: &Value,
+    ) -> anyhow::Result<Vec<Feature>>;
+}

--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 image = { version = "0.25" }
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
-calib-targets = "0.7"
+calib-targets = "0.8"
 vision-metrology = { path = "../../../vision-metrology/crates/vision-metrology" }
 vm-primitives = { path = "../../../vision-metrology/crates/vm-primitives" }
 

--- a/crates/vision-calibration-optim/Cargo.toml
+++ b/crates/vision-calibration-optim/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+schemars = ["dep:schemars", "vision-calibration-core/schemars"]
+
 [dependencies]
 vision-calibration-core = { workspace = true }
 nalgebra = { workspace = true }
@@ -20,6 +23,7 @@ tiny-solver = { workspace = true }
 faer = { workspace = true }
 faer-ext = { workspace = true }
 serde = { workspace = true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 vision-calibration-linear = { workspace = true }

--- a/crates/vision-calibration-optim/src/ir/types.rs
+++ b/crates/vision-calibration-optim/src/ir/types.rs
@@ -102,6 +102,7 @@ impl FixedMask {
 /// Each residual block has its own loss; per-point robustification is achieved
 /// by using one residual block per observation.
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum RobustLoss {
     /// No robustification (plain squared residual).
     #[default]
@@ -127,6 +128,7 @@ pub enum RobustLoss {
 ///
 /// Specifies the transform chain used for hand-eye calibration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum HandEyeMode {
     /// Camera mounted on robot end-effector (gripper).
     ///

--- a/crates/vision-calibration-optim/src/problems/laserline_bundle.rs
+++ b/crates/vision-calibration-optim/src/problems/laserline_bundle.rs
@@ -139,6 +139,7 @@ pub struct LaserlineStats {
 
 /// Type of laser plane residual to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum LaserlineResidualType {
     /// Point-to-plane distance (original approach).
     ///

--- a/crates/vision-calibration-optim/src/problems/scheimpflug_intrinsics.rs
+++ b/crates/vision-calibration-optim/src/problems/scheimpflug_intrinsics.rs
@@ -20,6 +20,7 @@ use vision_calibration_core::{
 
 /// Mask for Scheimpflug tilt parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ScheimpflugFixMask {
     /// Keep `tilt_x` fixed during optimization.
     pub tilt_x: bool,

--- a/crates/vision-calibration-pipeline/Cargo.toml
+++ b/crates/vision-calibration-pipeline/Cargo.toml
@@ -11,15 +11,28 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+schemars = [
+    "dep:schemars",
+    "vision-calibration-core/schemars",
+    "vision-calibration-optim/schemars",
+]
+
 [dependencies]
 vision-calibration-core = { workspace = true }
 vision-calibration-linear = { workspace = true }
 vision-calibration-optim = { workspace = true }
+vision-calibration-dataset = { workspace = true }
+vision-calibration-detect = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 nalgebra = { workspace = true }
+image = { workspace = true }
+glob = { workspace = true }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tempfile = "3"

--- a/crates/vision-calibration-pipeline/src/dataset_runner.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner.rs
@@ -152,10 +152,13 @@ pub fn build_planar_input(
     let detector = pick_detector(detector_name)?;
     validate(spec)?;
 
+    // PlanarIntrinsics has the validator-enforced invariant of exactly
+    // one camera, so `cameras[0]` is the only camera — no silent
+    // truncation.
     let camera = spec
         .cameras
         .first()
-        .expect("validate guarantees at least one camera for PlanarIntrinsics");
+        .expect("validate guarantees exactly one camera for PlanarIntrinsics");
     let images = expand_camera_images(camera, base_dir)?;
     if images.is_empty() {
         return Err(RunError::EmptyImageMatch {
@@ -170,9 +173,16 @@ pub fn build_planar_input(
     let mut usable = 0usize;
     let total = images.len();
 
+    // ROI is part of what determines detection output, so it has to be
+    // part of the cache key. We splice it into the key-side config and
+    // leave the actual `detector_config` untouched (the detector itself
+    // doesn't know about ROI — the runner crops the image first).
+    let roi = camera.roi_xywh;
+    let key_config = augment_config_with_roi(&detector_config, roi);
+
     for image_path in &images {
         let bytes = std::fs::read(image_path)?;
-        let key = CacheKey::from_inputs(&bytes, detector_name, &detector_config);
+        let key = CacheKey::from_inputs(&bytes, detector_name, &key_config);
 
         let cached: Option<CachedFeatures> = if force_redetect {
             None
@@ -187,13 +197,30 @@ pub fn build_planar_input(
                     path: image_path.clone(),
                     source: e,
                 })?;
-                let detected = detector.detect_json(&img, &detector_config).map_err(|e| {
-                    RunError::Detection {
+                let img_for_detect = if let Some([x, y, w, h]) = roi {
+                    img.crop_imm(x, y, w, h)
+                } else {
+                    img
+                };
+                let mut detected = detector
+                    .detect_json(&img_for_detect, &detector_config)
+                    .map_err(|e| RunError::Detection {
                         detector: detector_name.to_string(),
                         path: image_path.clone(),
                         source: e,
+                    })?;
+                // Detected pixels are in the cropped frame; lift them
+                // back into source-image coordinates so the rest of
+                // the pipeline (and the export's `image_manifest`)
+                // stays in one consistent coordinate system.
+                if let Some([x, y, _w, _h]) = roi {
+                    let dx = x as f64;
+                    let dy = y as f64;
+                    for f in detected.iter_mut() {
+                        f.image_xy[0] += dx;
+                        f.image_xy[1] += dy;
                     }
-                })?;
+                }
                 cache.put(
                     &key,
                     &CachedFeatures {
@@ -328,6 +355,20 @@ fn expand_camera_images(
     }
 }
 
+/// Splice a `_roi` field into the detector's canonical config JSON so
+/// the cache key changes whenever the user edits the ROI. The detector
+/// itself never sees `_roi` — the runner crops the image upstream.
+fn augment_config_with_roi(detector_config: &Value, roi: Option<[u32; 4]>) -> Value {
+    let Some(roi) = roi else {
+        return detector_config.clone();
+    };
+    let mut copy = detector_config.clone();
+    if let Value::Object(map) = &mut copy {
+        map.insert("_roi".to_string(), json!([roi[0], roi[1], roi[2], roi[3]]));
+    }
+    copy
+}
+
 fn pattern_repr(p: &ImagePattern) -> String {
     match p {
         ImagePattern::Glob { pattern } => pattern.clone(),
@@ -426,5 +467,43 @@ mod tests {
 
     fn tempdir_or_skip() -> tempfile::TempDir {
         tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn augment_config_with_roi_changes_cache_key() {
+        // Two ROIs over the same image with the same detector config
+        // must hash to different cache keys; otherwise a user editing
+        // an ROI would silently re-use stale detections.
+        let detector_config = json!({"rows": 9, "cols": 6, "square_size_m": 0.025});
+        let key_no_roi = CacheKey::from_inputs(
+            b"img",
+            "chessboard",
+            &augment_config_with_roi(&detector_config, None),
+        );
+        let key_roi_a = CacheKey::from_inputs(
+            b"img",
+            "chessboard",
+            &augment_config_with_roi(&detector_config, Some([10, 20, 100, 100])),
+        );
+        let key_roi_b = CacheKey::from_inputs(
+            b"img",
+            "chessboard",
+            &augment_config_with_roi(&detector_config, Some([10, 20, 200, 100])),
+        );
+        assert_ne!(key_no_roi, key_roi_a);
+        assert_ne!(key_roi_a, key_roi_b);
+        assert_ne!(key_no_roi, key_roi_b);
+    }
+
+    #[test]
+    fn detector_config_unchanged_by_roi_augmentation() {
+        // Splicing _roi into the *cache-key* config must not pollute
+        // the *detector-side* config — the detector is ROI-agnostic
+        // and would reject unknown fields with `deny_unknown_fields`.
+        let detector_config = json!({"rows": 9, "cols": 6, "square_size_m": 0.025});
+        let augmented = augment_config_with_roi(&detector_config, Some([0, 0, 64, 64]));
+        assert_ne!(detector_config, augmented);
+        assert!(augmented.get("_roi").is_some());
+        assert!(detector_config.get("_roi").is_none());
     }
 }

--- a/crates/vision-calibration-pipeline/src/dataset_runner.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner.rs
@@ -1,0 +1,430 @@
+//! Dataset-driven runner: takes a [`DatasetSpec`] manifest plus a
+//! per-problem `*Config` and produces the existing `*Input` IR by
+//! running detection (cached) on the per-camera images.
+//!
+//! PR 1 wires up `PlanarIntrinsics` only. PR 2 extends to the other
+//! seven problem types via the same `(spec, config, &cache) → *Input`
+//! shape.
+//!
+//! Per ADR 0019, any ambiguity that cannot be auto-resolved at
+//! conversion time is surfaced as a [`RunError::AskUser`] event so
+//! the UI can prompt the user instead of silently guessing.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+use thiserror::Error;
+
+use vision_calibration_core::{CorrespondenceView, NoMeta, PlanarDataset, Pt2, Pt3, View};
+use vision_calibration_dataset::{
+    DatasetSpec, ImagePattern, TargetSpec, Topology, ValidationError, validate,
+};
+use vision_calibration_detect::{
+    CacheKey, CachedFeatures, ChessboardDetector, DetectionCache, Detector, Feature,
+};
+
+/// Errors produced by the dataset-driven runner.
+#[derive(Debug, Error)]
+pub enum RunError {
+    /// Manifest failed structural validation. Wraps the underlying
+    /// [`ValidationError`].
+    #[error("manifest validation failed: {0}")]
+    Validation(#[from] ValidationError),
+
+    /// Topology is not yet supported by the runner. PR 1 ships with
+    /// `PlanarIntrinsics` only; PR 2 lifts this restriction.
+    #[error("topology {topology:?} is not yet supported by the dataset runner")]
+    UnsupportedTopology {
+        /// The offending topology.
+        topology: Topology,
+    },
+
+    /// Target type is not supported by any registered detector.
+    #[error("target type {kind} is not supported by any registered detector")]
+    UnsupportedTarget {
+        /// Discriminator from the manifest (e.g. `"ringgrid"`).
+        kind: String,
+    },
+
+    /// Glob pattern produced no matches. The user almost certainly
+    /// meant a different pattern; surface as a fail-fast event.
+    #[error("camera {camera_id:?}: pattern {pattern:?} matched no files under {base}")]
+    EmptyImageMatch {
+        /// The offending camera id.
+        camera_id: String,
+        /// The pattern that matched nothing.
+        pattern: String,
+        /// The base directory the pattern was resolved against.
+        base: PathBuf,
+    },
+
+    /// Glob crate refused to compile the user's pattern.
+    #[error("camera {camera_id:?}: invalid glob pattern {pattern:?} ({source})")]
+    BadGlob {
+        /// The offending camera id.
+        camera_id: String,
+        /// The pattern that failed to parse.
+        pattern: String,
+        /// Underlying glob compile error.
+        #[source]
+        source: glob::PatternError,
+    },
+
+    /// I/O failure while reading/writing the cache or images.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Image decode failure.
+    #[error("decoding image {path}: {source}")]
+    Decode {
+        /// File that failed to decode.
+        path: PathBuf,
+        /// Underlying error.
+        #[source]
+        source: image::ImageError,
+    },
+
+    /// Detection failure for a specific image.
+    #[error("detector {detector} failed on {path}: {source}")]
+    Detection {
+        /// Detector name.
+        detector: String,
+        /// Offending image.
+        path: PathBuf,
+        /// Underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+
+    /// Cache backend reported an error.
+    #[error("cache error: {0}")]
+    Cache(#[from] vision_calibration_detect::CacheError),
+
+    /// Runtime ambiguity that the runner refuses to guess (ADR 0019).
+    #[error("ask the user: {prompt}")]
+    AskUser {
+        /// Field path the runtime needs help with (e.g.
+        /// `"pose_convention.transform"`).
+        field: String,
+        /// Human-friendly prompt for the modal.
+        prompt: String,
+        /// Optional preset suggestions.
+        suggestions: Vec<String>,
+    },
+
+    /// Insufficient features after detection — calibration would fail
+    /// downstream anyway. Surfaced here so the user gets an
+    /// actionable error rather than a deep optim panic.
+    #[error("camera {camera_id:?}: only {usable}/{total} views had >= 4 features")]
+    InsufficientUsableViews {
+        /// Camera id (single camera for `PlanarIntrinsics`).
+        camera_id: String,
+        /// Number of views with at least 4 detected features.
+        usable: usize,
+        /// Total number of images attempted.
+        total: usize,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Convert a Planar manifest + config + cache into the existing
+/// [`PlanarDataset`] IR. Returns the dataset plus a per-view list of
+/// the source image paths (for downstream `image_manifest`
+/// population).
+pub fn build_planar_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<PlanarRunResult, RunError> {
+    // Order matters: gate on topology + target before touching the
+    // filesystem so users with broken globs still see helpful
+    // "wrong topology" or "wrong target" errors first.
+    if spec.topology != Topology::PlanarIntrinsics {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let (detector_name, detector_config) = target_to_detector_config(&spec.target)?;
+    let detector = pick_detector(detector_name)?;
+    validate(spec)?;
+
+    let camera = spec
+        .cameras
+        .first()
+        .expect("validate guarantees at least one camera for PlanarIntrinsics");
+    let images = expand_camera_images(camera, base_dir)?;
+    if images.is_empty() {
+        return Err(RunError::EmptyImageMatch {
+            camera_id: camera.id.clone(),
+            pattern: pattern_repr(&camera.images),
+            base: base_dir.to_path_buf(),
+        });
+    }
+
+    let mut views: Vec<View<NoMeta>> = Vec::new();
+    let mut view_paths: Vec<PathBuf> = Vec::new();
+    let mut usable = 0usize;
+    let total = images.len();
+
+    for image_path in &images {
+        let bytes = std::fs::read(image_path)?;
+        let key = CacheKey::from_inputs(&bytes, detector_name, &detector_config);
+
+        let cached: Option<CachedFeatures> = if force_redetect {
+            None
+        } else {
+            cache.get(&key)?
+        };
+
+        let features = match cached {
+            Some(entry) => entry.features,
+            None => {
+                let img = image::load_from_memory(&bytes).map_err(|e| RunError::Decode {
+                    path: image_path.clone(),
+                    source: e,
+                })?;
+                let detected = detector.detect_json(&img, &detector_config).map_err(|e| {
+                    RunError::Detection {
+                        detector: detector_name.to_string(),
+                        path: image_path.clone(),
+                        source: e,
+                    }
+                })?;
+                cache.put(
+                    &key,
+                    &CachedFeatures {
+                        features: detected.clone(),
+                    },
+                )?;
+                detected
+            }
+        };
+
+        if features.len() < 4 {
+            // Too few features for a homography — drop the view but
+            // keep walking so we can surface a meaningful error if
+            // _everything_ failed.
+            continue;
+        }
+        usable += 1;
+        views.push(features_to_view(&features)?);
+        view_paths.push(image_path.clone());
+    }
+
+    if views.is_empty() {
+        return Err(RunError::InsufficientUsableViews {
+            camera_id: camera.id.clone(),
+            usable,
+            total,
+        });
+    }
+
+    let dataset = PlanarDataset::new(views).expect(
+        "PlanarDataset::new failed after we already filtered to >=4 \
+         features per view; this indicates a regression in the core \
+         crate's invariants",
+    );
+
+    Ok(PlanarRunResult {
+        dataset,
+        view_paths,
+        usable_views: usable,
+        total_views: total,
+    })
+}
+
+/// Result of a Planar dataset conversion.
+#[derive(Debug)]
+pub struct PlanarRunResult {
+    /// The IR ready to feed into `CalibrationSession::set_input`.
+    pub dataset: PlanarDataset,
+    /// One source image path per accepted view, in the same order.
+    /// Used to populate the export's `image_manifest` after the solve.
+    pub view_paths: Vec<PathBuf>,
+    /// Number of views where detection produced ≥4 features.
+    pub usable_views: usize,
+    /// Total number of images attempted.
+    pub total_views: usize,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn target_to_detector_config(target: &TargetSpec) -> Result<(&'static str, Value), RunError> {
+    match target {
+        TargetSpec::Chessboard {
+            rows,
+            cols,
+            square_size_m,
+        } => Ok((
+            "chessboard",
+            json!({
+                "rows": *rows,
+                "cols": *cols,
+                "square_size_m": *square_size_m,
+            }),
+        )),
+        TargetSpec::Charuco { .. } => Err(RunError::UnsupportedTarget {
+            kind: "charuco".to_string(),
+        }),
+        TargetSpec::Puzzleboard { .. } => Err(RunError::UnsupportedTarget {
+            kind: "puzzleboard".to_string(),
+        }),
+        TargetSpec::Ringgrid { .. } => Err(RunError::UnsupportedTarget {
+            kind: "ringgrid".to_string(),
+        }),
+    }
+}
+
+fn pick_detector(name: &str) -> Result<Box<dyn Detector>, RunError> {
+    match name {
+        "chessboard" => Ok(Box::new(ChessboardDetector)),
+        other => Err(RunError::UnsupportedTarget {
+            kind: other.to_string(),
+        }),
+    }
+}
+
+fn expand_camera_images(
+    camera: &vision_calibration_dataset::CameraSource,
+    base_dir: &Path,
+) -> Result<Vec<PathBuf>, RunError> {
+    match &camera.images {
+        ImagePattern::Glob { pattern } => {
+            let resolved = if Path::new(pattern).is_absolute() {
+                pattern.clone()
+            } else {
+                base_dir.join(pattern).to_string_lossy().to_string()
+            };
+            let entries = glob::glob(&resolved).map_err(|e| RunError::BadGlob {
+                camera_id: camera.id.clone(),
+                pattern: pattern.clone(),
+                source: e,
+            })?;
+            let mut paths: Vec<PathBuf> = entries
+                .filter_map(|r| r.ok())
+                .filter(|p| p.is_file())
+                .collect();
+            paths.sort();
+            Ok(paths)
+        }
+        ImagePattern::List { paths } => {
+            let mut resolved: Vec<PathBuf> = Vec::with_capacity(paths.len());
+            for p in paths {
+                let abs: PathBuf = if p.is_absolute() {
+                    p.clone()
+                } else {
+                    base_dir.join(p)
+                };
+                resolved.push(abs);
+            }
+            Ok(resolved)
+        }
+    }
+}
+
+fn pattern_repr(p: &ImagePattern) -> String {
+    match p {
+        ImagePattern::Glob { pattern } => pattern.clone(),
+        ImagePattern::List { paths } => format!("<list of {} paths>", paths.len()),
+    }
+}
+
+fn features_to_view(features: &[Feature]) -> Result<View<NoMeta>, RunError> {
+    let mut points_3d = Vec::with_capacity(features.len());
+    let mut points_2d = Vec::with_capacity(features.len());
+    for f in features {
+        points_3d.push(Pt3::new(f.world_xyz[0], f.world_xyz[1], f.world_xyz[2]));
+        points_2d.push(Pt2::new(f.image_xy[0], f.image_xy[1]));
+    }
+    let cv = CorrespondenceView::new(points_3d, points_2d).expect(
+        "Feature vectors are non-empty and equal-length by construction; \
+         CorrespondenceView::new only fails on mismatched lengths.",
+    );
+    Ok(View::without_meta(cv))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vision_calibration_dataset::{CameraSource, ImagePattern, TargetSpec, Topology};
+    use vision_calibration_detect::FsDetectionCache;
+
+    fn planar_spec_for_globless_test() -> DatasetSpec {
+        DatasetSpec {
+            version: 1,
+            cameras: vec![CameraSource {
+                id: "cam0".into(),
+                images: ImagePattern::List { paths: vec![] },
+                roi_xywh: None,
+            }],
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: None,
+            topology: Topology::PlanarIntrinsics,
+            pose_pairing: None,
+            pose_convention: None,
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    #[test]
+    fn rejects_non_planar_topology() {
+        let mut spec = planar_spec_for_globless_test();
+        spec.topology = Topology::RigExtrinsics;
+        spec.cameras.push(CameraSource {
+            id: "cam1".into(),
+            images: ImagePattern::List { paths: vec![] },
+            roi_xywh: None,
+        });
+        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
+        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
+        assert!(matches!(err, RunError::UnsupportedTopology { .. }));
+    }
+
+    #[test]
+    fn rejects_unsupported_target() {
+        let mut spec = planar_spec_for_globless_test();
+        spec.target = TargetSpec::Charuco {
+            rows: 9,
+            cols: 6,
+            square_size_m: 0.025,
+            marker_size_m: 0.018,
+            dictionary: "DICT_4X4_50".into(),
+        };
+        spec.cameras[0].images = ImagePattern::Glob {
+            pattern: "*.png".into(),
+        };
+        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
+        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
+        assert!(matches!(err, RunError::UnsupportedTarget { .. }));
+    }
+
+    #[test]
+    fn empty_image_match_is_actionable() {
+        let mut spec = planar_spec_for_globless_test();
+        spec.cameras[0].images = ImagePattern::Glob {
+            pattern: "**/no_such_pattern_should_match_*.png".into(),
+        };
+        let tmp = tempdir_or_skip();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let err = build_planar_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::EmptyImageMatch { camera_id, .. } => assert_eq!(camera_id, "cam0"),
+            other => panic!("expected EmptyImageMatch, got {other:?}"),
+        }
+    }
+
+    fn tempdir_or_skip() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+}

--- a/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
@@ -25,6 +25,7 @@ pub type LaserlineDeviceInput = LaserlineDataset;
 
 /// Configuration for laserline device calibration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct LaserlineDeviceConfig {
     /// Initialization options.
@@ -37,6 +38,7 @@ pub struct LaserlineDeviceConfig {
 
 /// Initialization options for laserline device calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct LaserlineDeviceInitConfig {
     /// Number of iterations for iterative intrinsics estimation.
@@ -65,6 +67,7 @@ impl Default for LaserlineDeviceInitConfig {
 
 /// Shared solver options for laserline device calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct LaserlineDeviceSolverConfig {
     /// Maximum iterations for the optimizer.
@@ -84,6 +87,7 @@ impl Default for LaserlineDeviceSolverConfig {
 
 /// Bundle-adjustment options for laserline device calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct LaserlineDeviceOptimizeConfig {
     /// Robust loss for calibration reprojection residuals.

--- a/crates/vision-calibration-pipeline/src/lib.rs
+++ b/crates/vision-calibration-pipeline/src/lib.rs
@@ -45,3 +45,6 @@ pub mod rig_handeye;
 pub mod rig_laserline_device;
 pub mod scheimpflug_intrinsics;
 pub mod single_cam_handeye;
+
+// Manifest-driven dataset runner (ADR 0016 + ADR 0017)
+pub mod dataset_runner;

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/problem.rs
@@ -60,6 +60,7 @@ pub struct PlanarIntrinsicsProblem;
 ///
 /// Contains settings for both initialization and optimization phases.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct PlanarIntrinsicsConfig {
     // ─────────────────────────────────────────────────────────────────────────

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
@@ -39,6 +39,7 @@ pub type RigExtrinsicsInput = RigDataset<NoMeta>;
 /// Shared between pinhole and Scheimpflug rigs; the [`SensorMode`] field
 /// `sensor` selects the sensor flavour.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigExtrinsicsConfig {
     // ─────────────────────────────────────────────────────────────────────────

--- a/crates/vision-calibration-pipeline/src/rig_family.rs
+++ b/crates/vision-calibration-pipeline/src/rig_family.rs
@@ -55,6 +55,7 @@ use vision_calibration_optim::ScheimpflugFixMask;
 /// Re-exported by [`crate::rig_extrinsics::SensorMode`] and
 /// [`crate::rig_handeye::SensorMode`] (single source of truth in `rig_family`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 #[serde(tag = "kind")]
 pub enum SensorMode {

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -42,6 +42,7 @@ pub type RigHandeyeInput = RigDataset<RobotPoseMeta>;
 /// Shared between pinhole and Scheimpflug rigs; the [`SensorMode`] field
 /// `sensor` selects the sensor flavour.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeConfig {
     /// Per-camera intrinsics initialization options.
@@ -61,6 +62,7 @@ pub struct RigHandeyeConfig {
 
 /// Per-camera intrinsics initialization options for rig hand-eye calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeIntrinsicsConfig {
     /// Number of iterations for iterative intrinsics estimation.
@@ -86,6 +88,7 @@ impl Default for RigHandeyeIntrinsicsConfig {
 
 /// Rig-specific options for rig hand-eye calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeRigConfig {
     /// Reference camera index for rig frame (identity extrinsics).
@@ -108,6 +111,7 @@ impl Default for RigHandeyeRigConfig {
 
 /// Hand-eye linear initialization options for rig hand-eye calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeInitConfig {
     /// Hand-eye mode: EyeInHand or EyeToHand.
@@ -127,6 +131,7 @@ impl Default for RigHandeyeInitConfig {
 
 /// Solver options shared across rig and hand-eye optimization stages.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeSolverConfig {
     /// Maximum iterations for optimization.
@@ -149,6 +154,7 @@ impl Default for RigHandeyeSolverConfig {
 
 /// Hand-eye bundle-adjustment options.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeBaConfig {
     /// Refine robot poses in hand-eye BA (default: true).

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
@@ -100,6 +100,7 @@ pub struct RigLaserlineDeviceInput {
 
 /// Configuration for rig laserline calibration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigLaserlineDeviceConfig {
     /// Maximum solver iterations.

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
@@ -21,6 +21,7 @@ pub type ScheimpflugIntrinsicsInput = PlanarDataset;
 
 /// Optimization mask for Scheimpflug tilt parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ScheimpflugFixMask {
     /// Keep `tilt_x` fixed during optimization.
     pub tilt_x: bool,
@@ -44,6 +45,7 @@ impl ScheimpflugFixMask {
 
 /// Configuration for planar Scheimpflug intrinsics calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct ScheimpflugIntrinsicsConfig {
     /// Number of iterative linear intrinsics initialization rounds.

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
@@ -75,6 +75,7 @@ impl SingleCamHandeyeInput {
 
 /// Configuration for single-camera hand-eye calibration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SingleCamHandeyeConfig {
     // ─────────────────────────────────────────────────────────────────────────

--- a/crates/vision-calibration/Cargo.toml
+++ b/crates/vision-calibration/Cargo.toml
@@ -20,7 +20,6 @@ anyhow.workspace = true
 
 [dev-dependencies]
 serde_json = { workspace = true }
-chess-corners = { workspace = true }
 calib-targets = { workspace = true }
 image = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/vision-calibration/examples/handeye_session.rs
+++ b/crates/vision-calibration/examples/handeye_session.rs
@@ -19,7 +19,6 @@
 mod handeye_io;
 
 use anyhow::Result;
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use vision_calibration::optim::HandEyeMode;
@@ -50,12 +49,10 @@ fn main() -> Result<()> {
 
     // Load dataset with corner detection
     println!("\nLoading images and detecting corners...");
-    let chess_config = ChessConfig::default();
     let board_params = handeye_io::kuka_chessboard_params();
 
     let (samples, summary) = handeye_io::load_kuka_dataset_with_progress(
         &data_path,
-        &chess_config,
         &board_params,
         |current, total| {
             print!("\r  Processing image {current}/{total}...");

--- a/crates/vision-calibration/examples/manual_init_proof.rs
+++ b/crates/vision-calibration/examples/manual_init_proof.rs
@@ -24,7 +24,6 @@
 mod stereo_charuco_io;
 
 use anyhow::{Result, ensure};
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use stereo_charuco_io::{
@@ -58,13 +57,11 @@ fn main() -> Result<()> {
     );
     println!("Max views: {max_views}\n");
 
-    let chess_config = ChessConfig::default();
     let charuco_params = make_charuco_detector_params();
 
     let load = || -> Result<RigExtrinsicsInput> {
         let (input, summary) = load_stereo_charuco_input_with_progress(
             &data_dir,
-            &chess_config,
             &charuco_params,
             Some(max_views),
             |idx, total, suffix| {

--- a/crates/vision-calibration/examples/planar_real.rs
+++ b/crates/vision-calibration/examples/planar_real.rs
@@ -14,7 +14,6 @@
 use anyhow::{Context, Result};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use vision_calibration::planar_intrinsics::{
@@ -139,7 +138,6 @@ fn main() -> Result<()> {
 }
 
 fn load_views_with_progress(imgs_dir: &Path) -> Result<Vec<CorrespondenceView>> {
-    let chess_config = ChessConfig::default();
     let board_params = DetectorParams::default();
 
     // Find all left camera images
@@ -168,7 +166,7 @@ fn load_views_with_progress(imgs_dir: &Path) -> Result<Vec<CorrespondenceView>> 
         io::stdout().flush()?;
 
         let path = imgs_dir.join(format!("Im_L_{}.png", idx));
-        match detect_chessboard(&path, &chess_config, &board_params) {
+        match detect_chessboard(&path, &board_params) {
             Ok(Some(view)) => views.push(view),
             Ok(None) => skipped += 1,
             Err(e) => {
@@ -188,7 +186,6 @@ fn load_views_with_progress(imgs_dir: &Path) -> Result<Vec<CorrespondenceView>> 
 
 fn detect_chessboard(
     path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
 ) -> Result<Option<CorrespondenceView>> {
     let img = image::ImageReader::open(path)

--- a/crates/vision-calibration/examples/stereo_charuco_session.rs
+++ b/crates/vision-calibration/examples/stereo_charuco_session.rs
@@ -17,7 +17,6 @@
 mod stereo_charuco_io;
 
 use anyhow::{Result, ensure};
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use stereo_charuco_io::{
@@ -54,13 +53,11 @@ fn main() -> Result<()> {
     }
     println!();
 
-    let chess_config = ChessConfig::default();
     let charuco_params = make_charuco_detector_params();
 
     println!("Detecting ChArUco corners...");
     let (input, summary) = load_stereo_charuco_input_with_progress(
         &data_dir,
-        &chess_config,
         &charuco_params,
         max_views,
         |idx, total, suffix| {
@@ -167,7 +164,6 @@ fn main() -> Result<()> {
     println!("--- Alternative: single facade function ---");
     let (input2, _summary2) = load_stereo_charuco_input_with_progress(
         &data_dir,
-        &chess_config,
         &charuco_params,
         max_views,
         |idx, total, suffix| {

--- a/crates/vision-calibration/examples/stereo_session.rs
+++ b/crates/vision-calibration/examples/stereo_session.rs
@@ -18,7 +18,6 @@ mod stereo_io;
 
 use anyhow::{Result, ensure};
 use calib_targets::chessboard::DetectorParams;
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use stereo_io::load_stereo_input_with_progress;
@@ -59,13 +58,11 @@ fn main() -> Result<()> {
     }
     println!();
 
-    let chess_config = ChessConfig::default();
     let board_params = DetectorParams::default();
 
     println!("Detecting chessboard corners...");
     let (input, summary) = load_stereo_input_with_progress(
         &imgs_dir,
-        &chess_config,
         &board_params,
         SQUARE_SIZE_M,
         max_views,
@@ -184,7 +181,6 @@ fn main() -> Result<()> {
     println!("--- Alternative: single facade function ---");
     let (input2, _summary2) = load_stereo_input_with_progress(
         &imgs_dir,
-        &chess_config,
         &board_params,
         SQUARE_SIZE_M,
         max_views,

--- a/crates/vision-calibration/examples/support/handeye_io.rs
+++ b/crates/vision-calibration/examples/support/handeye_io.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use image::ImageReader;
 use nalgebra::{Matrix3, Rotation3, Translation3, UnitQuaternion, Vector3};
 use std::path::Path;
@@ -34,7 +33,6 @@ pub fn kuka_chessboard_params() -> DetectorParams {
 
 pub fn load_kuka_dataset_with_progress<F>(
     base_path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
     mut progress: F,
 ) -> Result<(Vec<ViewSample>, DatasetSummary)>

--- a/crates/vision-calibration/examples/support/rig_handeye_io.rs
+++ b/crates/vision-calibration/examples/support/rig_handeye_io.rs
@@ -6,7 +6,6 @@
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use image::ImageReader;
 use std::path::Path;
 use vision_calibration::core::{CorrespondenceView, Iso3, Pt3, Real, Vec2};
@@ -32,7 +31,6 @@ fn image2_filename(index: usize) -> String {
 
 pub fn load_rig_handeye_input_with_progress<F>(
     imgs_dir: &Path,
-    chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: Real,
     max_views: Option<usize>,
@@ -93,11 +91,11 @@ where
             img2_path.display()
         );
 
-        let view0 = detect_view(&img0_path, chess_config, board_params, square_size_m)
+        let view0 = detect_view(&img0_path, board_params, square_size_m)
             .with_context(|| format!("failed to detect view for {}", img0_path.display()))?;
-        let view1 = detect_view(&img1_path, chess_config, board_params, square_size_m)
+        let view1 = detect_view(&img1_path, board_params, square_size_m)
             .with_context(|| format!("failed to detect view for {}", img1_path.display()))?;
-        let view2 = detect_view(&img2_path, chess_config, board_params, square_size_m)
+        let view2 = detect_view(&img2_path, board_params, square_size_m)
             .with_context(|| format!("failed to detect view for {}", img2_path.display()))?;
 
         // Skip if all cameras failed to detect
@@ -151,7 +149,6 @@ where
 
 fn detect_view(
     path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: Real,
 ) -> Result<Option<CorrespondenceView>> {

--- a/crates/vision-calibration/examples/support/stereo_charuco_io.rs
+++ b/crates/vision-calibration/examples/support/stereo_charuco_io.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result, ensure};
 use calib_targets::aruco::builtins;
 use calib_targets::charuco::{CharucoBoardSpec, CharucoParams, MarkerLayout};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use vision_calibration::prelude::*;
@@ -58,7 +57,6 @@ pub fn make_charuco_detector_params() -> CharucoParams {
 /// - right: `Cam2_<suffix>.png`
 pub fn load_stereo_charuco_input_with_progress<F>(
     base_dir: &Path,
-    chess_config: &ChessConfig,
     charuco_params: &CharucoParams,
     max_views: Option<usize>,
     mut progress: F,
@@ -109,9 +107,9 @@ where
             right_path.display()
         );
 
-        let left = detect_view(&left_path, chess_config, charuco_params)
+        let left = detect_view(&left_path, charuco_params)
             .with_context(|| format!("left detection failed for {}", left_path.display()))?;
-        let right = detect_view(&right_path, chess_config, charuco_params)
+        let right = detect_view(&right_path, charuco_params)
             .with_context(|| format!("right detection failed for {}", right_path.display()))?;
 
         if left.is_none() && right.is_none() {
@@ -188,11 +186,7 @@ fn list_stereo_pair_suffixes(left_dir: &Path, right_dir: &Path) -> Result<Vec<St
     Ok(left.intersection(&right).cloned().collect())
 }
 
-fn detect_view(
-    path: &Path,
-    _chess_config: &ChessConfig,
-    charuco_params: &CharucoParams,
-) -> Result<Option<CorrespondenceView>> {
+fn detect_view(path: &Path, charuco_params: &CharucoParams) -> Result<Option<CorrespondenceView>> {
     let img = image::ImageReader::open(path)
         .with_context(|| format!("failed to read image {}", path.display()))?
         .decode()

--- a/crates/vision-calibration/examples/support/stereo_io.rs
+++ b/crates/vision-calibration/examples/support/stereo_io.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use vision_calibration::prelude::*;
@@ -34,7 +33,6 @@ pub struct StereoDatasetSummary {
 /// pairs.
 pub fn load_stereo_input_with_progress<F>(
     imgs_dir: &Path,
-    chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: f64,
     max_views: Option<usize>,
@@ -86,9 +84,9 @@ where
             right_path.display()
         );
 
-        let left = detect_view(&left_path, chess_config, board_params, square_size_m)
+        let left = detect_view(&left_path, board_params, square_size_m)
             .with_context(|| format!("left detection failed for {}", left_path.display()))?;
-        let right = detect_view(&right_path, chess_config, board_params, square_size_m)
+        let right = detect_view(&right_path, board_params, square_size_m)
             .with_context(|| format!("right detection failed for {}", right_path.display()))?;
 
         if left.is_none() && right.is_none() {
@@ -182,7 +180,6 @@ fn list_stereo_pair_indices(left_dir: &Path, right_dir: &Path) -> Result<Vec<usi
 
 fn detect_view(
     path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: f64,
 ) -> Result<Option<CorrespondenceView>> {

--- a/crates/vision-calibration/examples/viewer_fixtures.rs
+++ b/crates/vision-calibration/examples/viewer_fixtures.rs
@@ -23,7 +23,6 @@ mod stereo_io;
 
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::DetectorParams;
-use chess_corners::ChessConfig;
 use std::path::{Path, PathBuf};
 use stereo_charuco_io::{
     BOARD_CELL_SIZE_MM, BOARD_COLS, BOARD_DICTIONARY_NAME, BOARD_ROWS,
@@ -63,11 +62,9 @@ fn write_stereo_fixture(repo_root: &Path) -> Result<()> {
     );
 
     println!("[stereo] detecting chessboard corners (7×11, 30 mm)…");
-    let chess_config = ChessConfig::default();
     let board_params = DetectorParams::default();
     let (input, summary) = load_stereo_input_with_progress(
         &imgs_dir,
-        &chess_config,
         &board_params,
         STEREO_SQUARE_SIZE_M,
         None,
@@ -116,15 +113,9 @@ fn write_stereo_charuco_fixture(repo_root: &Path) -> Result<()> {
         "[stereo_charuco] detecting ChArUco corners ({BOARD_ROWS}×{BOARD_COLS} board, \
          cell {BOARD_CELL_SIZE_MM:.4} mm, dict {BOARD_DICTIONARY_NAME})…"
     );
-    let chess_config = ChessConfig::default();
     let charuco_params = make_charuco_detector_params();
-    let (input, summary) = load_stereo_charuco_input_with_progress(
-        &dataset_dir,
-        &chess_config,
-        &charuco_params,
-        None,
-        |_, _, _| {},
-    )?;
+    let (input, summary) =
+        load_stereo_charuco_input_with_progress(&dataset_dir, &charuco_params, None, |_, _, _| {})?;
     println!(
         "[stereo_charuco] {} pairs total, {} accepted ({} skipped); usable left={} right={}",
         summary.total_pairs,

--- a/data/stereo/dataset_left.toml
+++ b/data/stereo/dataset_left.toml
@@ -1,0 +1,24 @@
+# Planar intrinsics manifest for the left half of the bundled stereo
+# dataset. Pair with `dataset_right.toml` to calibrate each camera in
+# isolation; once the rig runner ships in B3c the same data feeds the
+# RigExtrinsics topology directly.
+#
+# Board parameters: 7×11 interior corners, 30 mm squares (matches
+# crates/vision-calibration/examples/stereo_session.rs).
+
+version = 1
+topology = "planar_intrinsics"
+description = "stereo-left chessboard 7x11 30mm"
+
+[[cameras]]
+id = "leftcamera"
+
+[cameras.images]
+kind = "glob"
+pattern = "imgs/leftcamera/*.png"
+
+[target]
+kind = "chessboard"
+rows = 7
+cols = 11
+square_size_m = 0.03

--- a/data/stereo/dataset_right.toml
+++ b/data/stereo/dataset_right.toml
@@ -1,0 +1,20 @@
+# Planar intrinsics manifest for the right half of the bundled stereo
+# dataset. Sibling of `dataset_left.toml`; identical board parameters,
+# different image folder.
+
+version = 1
+topology = "planar_intrinsics"
+description = "stereo-right chessboard 7x11 30mm"
+
+[[cameras]]
+id = "rightcamera"
+
+[cameras.images]
+kind = "glob"
+pattern = "imgs/rightcamera/*.png"
+
+[target]
+kind = "chessboard"
+rows = 7
+cols = 11
+square_size_m = 0.03

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 Canonical short-form summary of the multi-quarter direction. Detailed reasoning per track
 lives in ADRs (`docs/adrs/`); work-in-flight lives in open PRs.
 
-## Status (as of 2026-05-01)
+## Status (as of 2026-05-02)
 
 - **Version line:** 0.x. v1.0 (= stable public API) is deferred until the API has been
   stable across two minor releases without breaking changes. Pre-1.0 means breaking changes
@@ -13,11 +13,19 @@ lives in ADRs (`docs/adrs/`); work-in-flight lives in open PRs.
   residuals), A4 (Scheimpflug EyeToHand) shipped. A3 closed (false premise — the
   reported Zhang failure was a fixed puzzleboard-detector bug). A5 dropped (no real
   Python consumer; revisit after the Rust API stabilises). A6 (`rig_family` sensor-
-  axis refactor) shipped across PRs #36 + #37 + this PR; see
+  axis refactor) shipped via PRs #36 + #37 + #38; see
   [ADR 0013](adrs/0013-rig-family-sensor-axis-refactor.md).
+- **Track B — Tauri viewer:** B0 (PR #40), B0.5/B0.6 (PR #42), B1 (PR #43), B2
+  (PR #44) **SHIPPED**. The `app/` shell now hosts four workspaces (Diagnose, 3D,
+  Epipolar, Run-stub). After a 2026-05-02 grill the user committed to evolving the
+  app into the **primary calibration tool** (Track B is no longer "post-B0 enrichments
+  TBD" — see the B-track section below for the committed sub-phasing).
 - **In-flight PRs:**
   [#28 mvg](https://github.com/VitalyVorobyev/calibration-rs/pull/28) — multiple-view
-  geometry crate split (Track C, deferred until the diagnose viewer ships).
+  geometry crate split (Track C, deferred until the B3 series stabilises);
+  [#45 B3a foundation](https://github.com/VitalyVorobyev/calibration-rs/pull/45) —
+  schema-driven configs, `DatasetSpec`, detection cache, fail-fast contract
+  (ADRs 0016–0019).
 
 ## Four tracks
 
@@ -43,35 +51,75 @@ that B0 (Tauri scaffold) can compile against it with no breaking churn back into
 
 ### Track B — Tauri 2 + React + TypeScript desktop app
 
-A production-grade internal tool wrapping the calibration library. The
-original B0–B6 ordering placed the diagnose UI sixth; a 2026-05-01 grill
-session flipped to **diagnose-first** because the actual new capability is
-the residual visualisation and everything before it re-implements what
-`cargo run --example` already gives an engineer at the terminal.
+A production-grade internal tool wrapping the calibration library.
 [ADR 0014](adrs/0014-tauri-desktop-app.md) records the framework choice
-(Tauri 2 + React + TS over `rerun.io` and `egui`) and the v0 scope.
+(Tauri 2 + React + TS over `rerun.io` and `egui`) and the diagnose-first
+v0 scope. After B0–B2 shipped, a 2026-05-02 grill session committed the
+track to a much larger goal: make the app the **primary calibration
+tool**, not a passive viewer.
 
-**Re-sequenced track (post-grill):**
+**End-state vision (settled 2026-05-02):** point the app at any
+foreign dataset → AI inspects the layout → emits a canonical
+[`DatasetSpec`](adrs/0016-dataset-manifest.md) manifest with fields
+the AI couldn't determine listed under `_unresolved` (no silent
+guessing, [ADR 0019](adrs/0019-fail-fast-on-ambiguity.md)) → schema-
+driven forms ([ADR 0018](adrs/0018-schema-driven-ui.md)) let the user
+edit any of the manifest's or the per-problem-type config's fields →
+Run dispatches detection (cached, [ADR 0017](adrs/0017-detection-cache.md))
++ calibration in-process and routes the export into `/diagnose`. All
+8 problem types and 4 target detectors (chessboard / charuco /
+puzzleboard / ringgrid) are supported.
 
-- **B0 — diagnose viewer v0 (current PR / next-up).** Passive viewer of
-  one `PlanarIntrinsicsExport` JSON. New `ImageManifest` Export-side
-  contract; synthesized fixture (`planar_synthetic_with_images`
-  example + regression test); Tauri 2 + React + TS shell at `app/` with
-  one route: file-open → (pose, camera) selector → canvas with
-  per-feature residual arrows on the source image. ADR 0014.
-- **B0.5 — real-data acceptance.** Extend `RigHandeyeExport` with the
-  same `image_manifest` field; populate it against the puzzle 130×130
-  Scheimpflug rig dataset; verify ROI + tiled multi-camera strips
-  render correctly in the viewer. Stays in the same milestone as B0
-  but ships as a separate PR.
-- **Post-B0 enrichments — priority TBD by user feedback.** Order is no
-  longer pre-committed; will be driven by what the engineer actually
-  misses while using v0. Likely candidates: a "re-run" button calling
-  the facade in-process; multi-pose residual stats panel; cross-camera
-  residual matrix; manifest support on the remaining `*Export` types;
-  in-app detection wrap of `chess-corners` / `calib-targets`; 3D rig
-  viewer (Three.js / R3F); init-failure diagnosis (perturbed re-runs);
-  signed installers per OS. None of these are pre-scheduled.
+**Phase 1 — passive viewer (DONE, 2026-05-02).**
+
+- **B0 — diagnose viewer v0** (PR #40). Passive viewer of one
+  `PlanarIntrinsicsExport`. `ImageManifest` Export-side contract.
+- **B0.5/B0.6 — real-data acceptance + viewer UX** (PR #42). Manifest
+  extended to `RigHandeyeExport`; puzzle 130×130 Scheimpflug rig
+  rendered correctly; design tokens, navigation, theme toggle.
+- **B1 — 3D rig viewer** (PR #43). React-Three-Fiber scene with rig
+  origin, per-camera frustums, target boards. Multi-workspace shell.
+- **B2 — epipolar workspace** (PR #44). Server-side
+  `compute_epipolar_overlay` Tauri command via canonical camera
+  models. Two-pane viewer with click-to-pick.
+
+**Phase 2 — self-contained calibration app (in flight).**
+
+- **B3a — foundation** (PR #45). `schemars` derives across every
+  `*Config` + shared option types; `cargo xtask emit-schemas` →
+  `app/src/schemas/`. New crates `vision-calibration-dataset`
+  (`DatasetSpec` + validator) and `vision-calibration-detect`
+  (`Detector` trait, `ChessboardDetector`, `DetectionCache` trait
+  + filesystem impl). `pipeline::dataset_runner::build_planar_input`
+  wires manifest → cache → detect-on-miss → `PlanarDataset` IR.
+  ADRs 0016–0019.
+- **B3b — Tauri runner + Run workspace.** Tauri `run_calibration`
+  command (Planar+Chessboard end-to-end), schema-driven
+  `<ConfigForm/>` React component, Run workspace replaces the stub.
+  Vertical slice ships first; coverage to all 8 topologies + 4
+  detectors follows in B3c.
+- **B3c — coverage.** Wire the remaining 7 problem types through
+  dispatch; wire charuco / puzzleboard / ringgrid detectors;
+  per-problem-type `DatasetSpec → *Input` converters; manifest
+  sweep finish on `SingleCamHandeyeExport`,
+  `ScheimpflugIntrinsicsExport`, and `LaserlineDeviceExport`.
+- **B3d — manifest UX.** AI-driven `generate-manifest` CLI binary
+  (heuristic-only v0: regex / file-extension / vendor signature /
+  README scraping). Tauri "Sniff folder" command. `_unresolved` UX
+  (red badges, blocked Run button). `AskUser` modal component.
+  Frame-convention validator with vendor-aware error messages.
+- **B3e — iteration polish.** Cancellability for long solves;
+  progress event streaming; multi-pose residual stats panel;
+  cross-camera residual matrix; experiments directory storing
+  `(dataset.toml, config.json, export.json)` tuples for
+  reproducibility.
+
+**Phase 3 — deferred until B3 stabilises.**
+
+- LLM-backed manifest inference (separate ADR; opt-in, behind API
+  key configuration).
+- Init-failure diagnosis sweeps (perturbed re-runs).
+- Signed installers per OS.
 
 ### Track C — MVG (postponed; depends on diagnose viewer done)
 
@@ -101,11 +149,13 @@ in-house dense matcher, no full SfM.
 
 ## Load-bearing path
 
-**B0 (diagnose viewer v0) → B0.5 (real-data acceptance on puzzle 130×130) →
-post-B0 enrichments (priority TBD).** Track A is done; the diagnose UI is
-now B0 itself, not B5, and consumes the A2 per-feature-residuals foundation
-that already ships on every export. C is parallelizable once the viewer
-exists; D is a continuous ratchet.
+**B0 → B0.5 → B1 → B2 (DONE) → B3a foundation (in flight) → B3b runner +
+Run workspace → B3c coverage (all 8 problem types + 4 detectors) → B3d
+manifest UX → B3e iteration polish → C-track resumes.** Track A is done;
+the B-track is now committed to making the app self-contained rather than
+treating post-B0 work as discretionary. C is parallelizable once B3c
+lands (the viewer can render arbitrary exports the runner produces); D
+is a continuous ratchet.
 
 ## Out of scope (explicit)
 
@@ -127,5 +177,9 @@ exists; D is a continuous ratchet.
   [`0011-manual-initialization-workflow.md`](adrs/0011-manual-initialization-workflow.md) (A1, landed in PR #32);
   [`0012-per-feature-reprojection-residuals.md`](adrs/0012-per-feature-reprojection-residuals.md) (A2, landed in PR #33 + #35);
   [`0013-rig-family-sensor-axis-refactor.md`](adrs/0013-rig-family-sensor-axis-refactor.md) (A6, landed in PRs #36 + #37 + #38);
-  [`0014-tauri-desktop-app.md`](adrs/0014-tauri-desktop-app.md) (B0, this PR — diagnose viewer v0 + sequencing flip);
+  [`0014-tauri-desktop-app.md`](adrs/0014-tauri-desktop-app.md) (B0, landed in PR #40);
+  [`0016-dataset-manifest.md`](adrs/0016-dataset-manifest.md) (B3a, PR #45);
+  [`0017-detection-cache.md`](adrs/0017-detection-cache.md) (B3a, PR #45);
+  [`0018-schema-driven-ui.md`](adrs/0018-schema-driven-ui.md) (B3a, PR #45);
+  [`0019-fail-fast-on-ambiguity.md`](adrs/0019-fail-fast-on-ambiguity.md) (B3a, PR #45);
   `0015-mvg-ceiling.md` (C1, pending).

--- a/docs/adrs/0016-dataset-manifest.md
+++ b/docs/adrs/0016-dataset-manifest.md
@@ -1,0 +1,123 @@
+# ADR 0016: Canonical Dataset Manifest (`DatasetSpec`)
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+After B0/B0.5/B0.6/B1/B2 shipped (Tauri 2 viewer with Diagnose / Viewer3D /
+Epipolar workspaces), the user committed to making the Tauri app the
+primary calibration tool — full workflow inside the UI: foreign datasets,
+all 8 problem types, all 4 target detectors, every config knob exposed.
+That commitment forces an answer to a question we deferred during B0: how
+do we ingest data in arbitrary on-disk layouts without making users
+copy / rename / reshape their files to fit a workspace convention?
+
+Two non-options established up-front:
+
+1. **Folder convention** — pick a canonical layout (`cam_<i>/<frame>.png`,
+   `poses.csv`) and require users to mirror their data into it. Rejected
+   because every external dataset already has its own layout, and copying
+   gigabytes of images for every new dataset is not how engineers want
+   to work.
+2. **Per-problem `*Input` JSON as the wire format** — freeze the existing
+   `RigDataset<RobotPoseMeta>` / `PlanarDataset` shapes as user-facing
+   files. Rejected because those structs were never designed for human
+   authoring, drift pre-1.0, and embed type-erased nalgebra serde shapes
+   that aren't friendly to forms.
+
+What we _do_ want: a single _descriptive_ manifest format that points at
+the user's data in place. The manifest is the only on-disk wire format
+the user touches; the existing `*Input` types become internal IR fed by
+per-problem converters and free to break pre-1.0.
+
+## Decision
+
+### 1. Single canonical schema
+
+`DatasetSpec` (`crates/vision-calibration-dataset/src/spec.rs`) is the
+single on-disk manifest type. It carries:
+
+- `cameras: Vec<CameraSource>` — per-camera glob or explicit path list,
+  optional ROI.
+- `target: TargetSpec` — closed enum tagged on `kind` covering
+  Chessboard, Charuco, Puzzleboard, Ringgrid.
+- `robot_poses: Option<RobotPoseSource>` — `{ path, format, columns }`
+  with a flexible column mapping so vendor-specific CSV / JSON layouts
+  map onto canonical fields.
+- `topology: Topology` — selects one of the 8 problem types
+  (`PlanarIntrinsics` … `RigLaserlineDevice`).
+- `pose_pairing: Option<PosePairing>` — `ByIndex` or
+  `SharedFilenameToken { regex, group }` for cross-camera /
+  pose-to-image alignment.
+- `pose_convention: Option<PoseConvention>` — three orthogonal closed
+  enums (`transform`, `rotation_format`, `translation_units`), no
+  defaults. Required whenever `robot_poses` is set.
+- `_unresolved: Vec<String>` — paths to fields the AI manifest generator
+  could not determine. Validation rejects manifests with non-empty
+  `_unresolved`.
+
+The schema derives `JsonSchema` under the `schemars` feature; the
+generated schemas are emitted into `app/src/schemas/dataset_spec.json`
+by `cargo xtask emit-schemas` for the React form generator (ADR 0018).
+
+### 2. `*Input` types become internal IR
+
+The 8 existing `*Input` types stop being a stable on-disk format. Per-
+problem converters (e.g. `pipeline::dataset_runner::build_planar_input`)
+take `(DatasetSpec, *Config, &dyn DetectionCache) → *Input`. Pre-1.0
+breaking changes to `*Input` are explicitly OK; the user-facing wire
+format is `DatasetSpec` only.
+
+### 3. Closed-enum frame conventions
+
+`PoseConvention` declares conventions as three closed enums with
+**no defaults**:
+
+- `transform: T_base_tcp | T_tcp_base | T_world_tcp | T_tcp_world`
+- `rotation_format: quat_xyzw | quat_wxyz | euler_*_(deg|rad) |
+  axis_angle_rad | matrix_4x4_row_major`
+- `translation_units: m | mm`
+
+The validator refuses manifests where any component is missing while
+`robot_poses` is set. This is the central anti-footgun decision —
+silently defaulting to `T_base_tcp / quat_xyzw / m` would silently
+produce plausible-looking but wrong calibrations on roughly half of
+real datasets (KUKA / ABB / UR / Fanuc all differ on at least one
+axis).
+
+### 4. AI manifest generator (PR 3)
+
+The runtime contract is that an external generator (CLI binary in PR 3,
+in-app command in PR 5) inspects a foreign folder and emits a
+`dataset.toml` populating fields it can determine and listing the rest
+in `_unresolved`. v0 of the generator is heuristic-only (regex / file
+extension / vendor signature / README scraping). LLM-backed inference
+for hard cases is deferred to its own ADR.
+
+## Consequences
+
+- A single schema means one form to render, one validator, one
+  reproducibility primitive. Datasets become commit-able artefacts.
+- The user never edits `*Input` JSON by hand. Pre-1.0 churn in those
+  types is a workspace-internal concern only.
+- Frame conventions become explicit. The cost is a richer manifest;
+  the benefit is silent-failure mitigation on the most common
+  calibration footgun.
+- Adding a new convention (e.g. ABB's `T_base_tcp` with millimetre
+  translation but degree Euler) is a code change, not a manifest
+  change. This is a deliberate trade-off: predictable behaviour over
+  unbounded extensibility.
+
+## Status of work
+
+- ✅ `vision-calibration-dataset` crate landed with `DatasetSpec`,
+  validator, and 7 unit tests.
+- ✅ Schema emitted to `app/src/schemas/dataset_spec.json` via
+  `cargo xtask emit-schemas`.
+- ✅ `pipeline::dataset_runner::build_planar_input` consumes the
+  manifest end-to-end (validation → detection → IR) for the
+  PlanarIntrinsics topology with the Chessboard target.
+- ⏳ Coverage extension to the other 7 topologies + 3 detectors
+  (PR 2).
+- ⏳ AI manifest generator (PR 3).

--- a/docs/adrs/0017-detection-cache.md
+++ b/docs/adrs/0017-detection-cache.md
@@ -1,0 +1,109 @@
+# ADR 0017: Content-Addressed Detection Cache
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+The diagnose-first viewer (B0–B2) is read-only: every iteration round-
+trips through `cargo run --example` to produce a fresh export. The new
+"complete workflow in the app" commitment (ADR 0016) introduces
+in-process re-runs, which exposes a latency issue: at typical detection
+speeds (chessboard ≈ 200 ms / image, ringgrid slower), a 6-camera ×
+20-pose dataset is 24 s of detection per Run click. Without a cache,
+the in-app loop is _slower_ than the terminal one (where engineers
+manually serialise detections to JSON and only re-run the solver),
+which would shred the credibility of the "fast iteration" promise on
+the first real dataset.
+
+The grill session settled the principle ("cache aggressively"); this
+ADR pins the contract.
+
+## Decision
+
+### 1. Cache key
+
+`(image_content_hash, detector_name, canonical_config_hash)`:
+
+- `image_content_hash` — 64-bit FNV-1a of the raw image bytes. Cheap,
+  allocation-free, and crucially **never** invalidates by mtime —
+  copying / moving / `touch`-ing an image must not invalidate its
+  cached detections.
+- `detector_name` — the `Detector::name()` string (e.g. `"chessboard"`).
+  Cleanly partitions entries between detectors so adding a new detector
+  in PR 2 doesn't touch existing entries.
+- `canonical_config_hash` — 64-bit FNV-1a of the detector config
+  serialised to JSON _with sorted keys_, so semantically identical
+  configs (e.g. `{"a":1,"b":2}` vs `{"b":2,"a":1}`) collide as
+  intended.
+
+The composite key is encoded as `<image>-<detector>-<config>.json` for
+filesystem-safe addressing under a per-dataset cache root.
+
+### 2. Trait + filesystem default impl
+
+```rust
+pub trait DetectionCache: Send + Sync {
+    fn get(&self, key: &CacheKey) -> Result<Option<CachedFeatures>, CacheError>;
+    fn put(&self, key: &CacheKey, value: &CachedFeatures) -> Result<(), CacheError>;
+}
+```
+
+- `Send + Sync` so the runner can share one instance across the
+  per-image loop running on a tokio blocking task.
+- Two methods only — `get` returns `Ok(None)` on miss; `put` is
+  responsible for atomic-rename writes (tmp-file + rename pattern,
+  safe on every filesystem we target).
+
+The default `FsDetectionCache` writes one JSON file per entry under
+`<root>/<key>.json`. In production the runner points it at
+`~/.cache/calibration-rs/<dataset_id>/`; tests use `tempfile::tempdir()`.
+
+### 3. Designed in from PR 1
+
+Every detector entry point in the runner goes through the cache from
+day one. Bolting a cache on later means changing every call site
+twice; the upfront cost is ~1 file (the `cache.rs` module) and zero
+extra effort for the runner because `cache.get_or_detect` is the
+natural shape anyway.
+
+### 4. Force-redetect escape hatch
+
+A single `force_redetect: bool` flag on the runner (and exposed in the
+Run workspace UI in PR 3) bypasses cache reads for clean runs without
+clobbering existing entries. Used for "I changed something inside the
+detector implementation, not its config" cases.
+
+### 5. Persistence boundary
+
+The cache files are intentionally **disposable**: no migration story,
+no version field. Bumping the schema of `Feature`, `CachedFeatures`,
+or `CacheKey` invalidates the on-disk corpus by design — content-
+addressed caches don't need migrations because regenerating them is
+free (just a re-run with the new code). Pre-1.0 we exploit this; post-
+1.0 we add a version bump if a real backwards-compat case appears.
+
+## Consequences
+
+- Sub-second iteration on cache hit — the only time the user pays the
+  detection cost is the first run on a new dataset or after a
+  detector-config change.
+- Re-running with the same params is essentially free; A/B comparisons
+  become cheap.
+- The cache is shared between the in-app runner and the existing
+  `cargo run --example` paths once the examples migrate (a bonus, not
+  required for PR 1).
+- The 64-bit hash is not collision-proof — but we're not defending
+  against adversarial collisions, only accidental ones, and FNV-1a is
+  more than enough for a dataset's worth of entries.
+- Cache root is per-dataset to keep entries scoped; deleting a
+  dataset's cache is a single `rm -rf`.
+
+## Status of work
+
+- ✅ `DetectionCache` trait, `CacheKey`, `CachedFeatures`, and
+  `FsDetectionCache` in `vision-calibration-detect`.
+- ✅ 5 cache unit tests (key-determinism, key-changes-on-change,
+  fs roundtrip, miss-on-unknown-root).
+- ✅ Wired into `pipeline::dataset_runner::build_planar_input`.
+- ⏳ Per-dataset cache root selection in the Tauri runner (PR 1 task #8).

--- a/docs/adrs/0018-schema-driven-ui.md
+++ b/docs/adrs/0018-schema-driven-ui.md
@@ -1,0 +1,117 @@
+# ADR 0018: Schema-Driven UI for Configs and Dataset Manifests
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+The "complete calibration workflow in the app" goal exposes every
+`*Config` knob (8 problem types × ~10 fields each ≈ 80+ knobs), every
+detector config (4 detectors × their own params), and the new
+`DatasetSpec` (camera sources, target spec, robot poses, pose
+conventions). Hand-writing React forms for ~120 fields across that
+surface is not the actual cost — _keeping them in sync as configs
+change pre-1.0 is_. We've already churned config shapes during A6,
+ADR 0013, the manifest sweep, and the move from `*Input` JSON to
+`DatasetSpec`. Hand-written forms drift silently every time.
+
+The grill session settled the principle ("schema-driven"); this ADR
+pins the architecture.
+
+## Decision
+
+### 1. Source of truth: Rust types, with `JsonSchema` derives
+
+Every user-editable config, input, and dataset type derives
+`schemars::JsonSchema` under a `schemars` feature flag:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub struct PlanarIntrinsicsConfig { … }
+```
+
+The feature flag keeps schemars optional for downstream consumers
+(Python bindings, CI builds that don't need schemas) but the workspace
+quality gate runs with `--all-features` so drift surfaces in CI.
+
+Coverage in PR 1: all 7 problem-type configs, their sub-configs, the
+shared option types (`RobustLoss`, `HandEyeMode`, `IntrinsicsFixMask`,
+`DistortionFixMask`, `ScheimpflugFixMask`, `ScheimpflugParams`,
+`SensorMode`, `LaserlineResidualType`), plus the new `DatasetSpec`
+tree.
+
+### 2. Schema emission via xtask, committed to the app
+
+`cargo xtask emit-schemas` writes JSON Schemas to
+`app/src/schemas/<name>.json` (8 files in PR 1). The schemas are
+committed to the repo so:
+
+- Frontend builds don't need a Rust toolchain in their critical path.
+- LSP / Vite read them as static assets (fast).
+- `git diff` on a config change shows both the Rust change and the
+  schema change in the same review.
+- CI runs `cargo xtask emit-schemas --check` which fails the build
+  if committed schemas drift from sources, enforcing developer
+  discipline without a build-time regen.
+
+`build.rs`-based emission was rejected: it slows clean builds,
+confuses incremental tooling, and makes schema diffs invisible at
+review time.
+
+### 3. Form rendering: `<ConfigForm schema={…} value={…} onChange={…}/>`
+
+The React side renders any of the emitted schemas through a single
+component (PR 1 task #9):
+
+- v0: wrap `@rjsf/core` (well-known JSON Schema form library).
+- Per-field overrides via the React-JSON-Schema-Form `uiSchema`
+  mechanism for cases that need bespoke widgets (3-axis rotation
+  widget, file pickers, etc.).
+- If `@rjsf/core` proves too heavy or its rendering doesn't match the
+  app's design tokens, fall back to a trimmed in-house generator
+  (~300 LoC; sufficient because we only need to render the schema
+  subset schemars produces, not arbitrary JSON Schema).
+
+### 4. Foreign-type strategy
+
+`*Config` types in this workspace are made entirely of internal types
+plus primitives — no `nalgebra::Isometry3` or other foreign types in
+the config tree. PR 1's feasibility check on `PlanarIntrinsicsConfig`
+and `RigHandeyeConfig` confirmed schemars derives compile cleanly
+without any `#[schemars(with = …)]` shims. If a foreign type _does_
+appear in a config later (e.g. an `Iso3` initial-pose seed), the
+escape hatch is a per-field shim mapping to a hand-written
+`JsonSchema` impl.
+
+`*Input` types contain foreign types (`Iso3`, `Pt2`, `Pt3`) but
+**don't need schemars** — under ADR 0016 they're internal IR, never
+edited by users.
+
+## Consequences
+
+- Adding a new config field is _free_ in the UI: derive picks it up,
+  schemars regenerates, the form re-renders. No matching React
+  change required.
+- Removing a field forces the UI to follow: if a renamed field still
+  appears in the form, the schema regen catches the drift.
+- Pre-1.0 config churn is absorbed automatically — the cost the user
+  was implicitly paying for "complete parameter control" goes to
+  near-zero.
+- The choice of `@rjsf/core` is reversible: the form-component
+  abstraction is the boundary, swapping the underlying renderer is a
+  single-file change.
+- Schemars adds one transitive dep when the feature is enabled. The
+  base build cost (no schemars) is unchanged.
+
+## Status of work
+
+- ✅ `schemars` feature flag on `vision-calibration-{core, optim,
+  pipeline, dataset, detect}`.
+- ✅ `JsonSchema` derive on every `*Config` and the foreign option
+  types referenced from configs.
+- ✅ `cargo xtask emit-schemas` tool with `--check` mode.
+- ✅ 8 schemas committed under `app/src/schemas/`.
+- ⏳ React `<ConfigForm/>` component (PR 1 task #9).
+- ⏳ CI `--check` step in `.github/workflows/` (small, deferred).

--- a/docs/adrs/0019-fail-fast-on-ambiguity.md
+++ b/docs/adrs/0019-fail-fast-on-ambiguity.md
@@ -1,0 +1,118 @@
+# ADR 0019: Fail Fast on Ambiguity (`AskUser` runtime contract)
+
+- Status: Accepted
+- Date: 2026-05-02
+
+## Context
+
+The "complete calibration workflow in the app" goal pulls in two
+sources of runtime ambiguity:
+
+1. **AI-generated dataset manifests** that may leave fields under-
+   specified — e.g. an AI inspecting a foreign folder can list image
+   paths from filename patterns but cannot infer `pose_convention.transform`
+   from quaternion data alone.
+2. **User-authored manifests** with structurally-valid but
+   semantically-ambiguous content — e.g. two cameras whose filenames
+   produce the same SharedFilenameToken but differ in count.
+
+The user explicitly requested ("In any not clear situation stop and ask
+user") that the runtime never silently guess. Wrong frame conventions
+silently produce plausible-but-wrong calibrations 6 weeks downstream;
+ambiguous pose pairings silently drop frames; "we picked a default for
+you" is the worst possible UX in this domain.
+
+## Decision
+
+### 1. Two-tier field model in `DatasetSpec`
+
+Every manifest field is implicitly tagged either:
+
+- `infer_from_data` — the AI generator is expected to populate this
+  from filenames / file extensions / sample data. Examples: image
+  globs, camera count, target type from a README.
+- `human_or_doc_required` — the AI is _forbidden_ from guessing.
+  It must read documentation, find the value in metadata, or leave it
+  `null` and add the field path to `_unresolved`. Examples: every
+  `pose_convention.*` field, target physical dimensions when not in a
+  README.
+
+Tier metadata is encoded as a `x-calib-tier` schema extension so both
+Rust and TypeScript form generators can render the right UX (e.g. a
+red badge on `human_or_doc_required` fields that are still null).
+
+### 2. `_unresolved` field at manifest root
+
+`DatasetSpec._unresolved: Vec<String>` lists the dotted paths of
+fields the AI couldn't determine. Validation refuses to dispatch a
+manifest with non-empty `_unresolved`; the Run workspace renders the
+list as red badges and blocks the Run button until each entry is
+resolved.
+
+### 3. Structured `AskUser` error variant
+
+Runtime ambiguity that survives validation surfaces as a typed error:
+
+```rust
+pub enum RunError {
+    AskUser {
+        field: String,
+        prompt: String,
+        suggestions: Vec<String>,
+    },
+    …
+}
+```
+
+The Run workspace catches `AskUser` and shows a blocking modal with
+the prompt + suggestions; the user response feeds back into the
+runner via an event channel and the conversion resumes. The CLI
+(generate-manifest binary) catches `AskUser` too, prints the prompt
++ suggestions, and exits with status 2 — surface parity makes the
+generator scriptable.
+
+This is a single error variant, not a separate ambiguity-handling
+machinery, deliberately: "ambiguity" is just a structured error like
+any other, and it composes naturally through `?`.
+
+### 4. No silent defaults anywhere
+
+This applies to:
+
+- Missing manifest fields → `Validation(Unresolved(...))`.
+- Conflicting detector params → detector implementations must reject,
+  not "auto-correct".
+- Ambiguous image-to-pose pairings → pairing impl must report the
+  conflict via `AskUser`.
+- Empty glob matches → `EmptyImageMatch { camera, pattern }` with
+  the offending base path.
+- Insufficient features per view (< 4 corners) → `InsufficientUsableViews`
+  with usable / total counts; no "let's see how the solver feels
+  about it".
+
+## Consequences
+
+- The runtime is verbose by design when given ambiguous input. We pay
+  this cost in dev-time UX in exchange for never producing a silent-
+  failure calibration.
+- Adding a new ambiguity source is a new `RunError` variant, not a new
+  branch in some catch-all. Compile-time enforcement of "did you
+  handle this?" through pattern matching.
+- The `AskUser` modal is the second-most-important UI affordance in
+  the Run workspace (after the Run button itself). PR 3 invests in
+  its UX accordingly.
+- The CLI parity means the AI-manifest generator can run unattended
+  against a folder and produce either a complete manifest or a
+  human-readable list of "you need to tell me about: …".
+
+## Status of work
+
+- ✅ `_unresolved` field in `DatasetSpec` with validator enforcement.
+- ✅ Closed-enum frame conventions with no defaults (ADR 0016).
+- ✅ `AskUser` variant in `pipeline::dataset_runner::RunError`.
+- ✅ `EmptyImageMatch`, `InsufficientUsableViews`,
+  `UnsupportedTopology`, `UnsupportedTarget`, and `MissingPoseConvention`
+  variants for the structurally-rejectable ambiguities.
+- ⏳ React `AskUserModal` component (PR 1 task #10).
+- ⏳ Tauri event channel for resuming a paused conversion after the
+  user answers (PR 3, alongside the AI-manifest UI).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,3 +36,7 @@ Status legend:
 - [0012 - Per-Feature Reprojection Residuals on Export Types](0012-per-feature-reprojection-residuals.md)
 - [0013 - rig_family Sensor-Axis Refactor (Pinhole + Scheimpflug Unification)](0013-rig-family-sensor-axis-refactor.md)
 - [0014 - Tauri 2 Desktop App for Calibration Diagnose (Track B Kickoff)](0014-tauri-desktop-app.md)
+- [0016 - Canonical Dataset Manifest (`DatasetSpec`)](0016-dataset-manifest.md)
+- [0017 - Content-Addressed Detection Cache](0017-detection-cache.md)
+- [0018 - Schema-Driven UI for Configs and Dataset Manifests](0018-schema-driven-ui.md)
+- [0019 - Fail Fast on Ambiguity (`AskUser` runtime contract)](0019-fail-fast-on-ambiguity.md)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+vision-calibration-pipeline = { workspace = true, features = ["schemars"] }
+vision-calibration-dataset = { workspace = true, features = ["schemars"] }

--- a/xtask/src/emit_schemas.rs
+++ b/xtask/src/emit_schemas.rs
@@ -1,0 +1,112 @@
+//! Emit JSON Schemas for the workspace's user-facing config types.
+//!
+//! Output goes to `app/src/schemas/<name>.json`. The Tauri app reads these
+//! files at build time to drive schema-driven forms in the Run workspace.
+//!
+//! With `--check`, the command instead verifies that the on-disk schemas
+//! match what would be generated from current source. CI runs this to
+//! catch drift between source and committed schemas.
+
+use anyhow::{Context, Result, bail};
+use schemars::{JsonSchema, schema_for};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+use vision_calibration_dataset::DatasetSpec;
+use vision_calibration_pipeline::laserline_device::LaserlineDeviceConfig;
+use vision_calibration_pipeline::planar_intrinsics::PlanarIntrinsicsConfig;
+use vision_calibration_pipeline::rig_extrinsics::RigExtrinsicsConfig;
+use vision_calibration_pipeline::rig_handeye::RigHandeyeConfig;
+use vision_calibration_pipeline::rig_laserline_device::RigLaserlineDeviceConfig;
+use vision_calibration_pipeline::scheimpflug_intrinsics::ScheimpflugIntrinsicsConfig;
+use vision_calibration_pipeline::single_cam_handeye::SingleCamHandeyeConfig;
+
+pub fn run(workspace_root: &Path, check: bool) -> Result<()> {
+    let out_dir = workspace_root.join("app/src/schemas");
+    std::fs::create_dir_all(&out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
+
+    let entries: Vec<(&str, Value)> = vec![
+        ("dataset_spec", schema_value::<DatasetSpec>()),
+        (
+            "planar_intrinsics_config",
+            schema_value::<PlanarIntrinsicsConfig>(),
+        ),
+        (
+            "scheimpflug_intrinsics_config",
+            schema_value::<ScheimpflugIntrinsicsConfig>(),
+        ),
+        (
+            "single_cam_handeye_config",
+            schema_value::<SingleCamHandeyeConfig>(),
+        ),
+        (
+            "laserline_device_config",
+            schema_value::<LaserlineDeviceConfig>(),
+        ),
+        (
+            "rig_extrinsics_config",
+            schema_value::<RigExtrinsicsConfig>(),
+        ),
+        ("rig_handeye_config", schema_value::<RigHandeyeConfig>()),
+        (
+            "rig_laserline_device_config",
+            schema_value::<RigLaserlineDeviceConfig>(),
+        ),
+    ];
+
+    let mut drift = Vec::new();
+    for (name, schema) in &entries {
+        let path = out_dir.join(format!("{name}.json"));
+        write_or_check(&path, schema, check, &mut drift)?;
+    }
+
+    if check {
+        if drift.is_empty() {
+            println!("schemas up to date ({} files)", entries.len());
+            Ok(())
+        } else {
+            for path in &drift {
+                eprintln!("schema drift: {}", path.display());
+            }
+            bail!(
+                "{} schema(s) out of date; run `cargo xtask emit-schemas` and commit the result",
+                drift.len()
+            )
+        }
+    } else {
+        println!("emitted {} schemas to {}", entries.len(), out_dir.display());
+        Ok(())
+    }
+}
+
+fn schema_value<T: JsonSchema>() -> Value {
+    serde_json::to_value(schema_for!(T)).expect("JsonSchema serialization is infallible")
+}
+
+fn write_or_check(
+    path: &Path,
+    schema: &Value,
+    check: bool,
+    drift: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let mut text =
+        serde_json::to_string_pretty(schema).context("rendering schema as pretty JSON")?;
+    text.push('\n');
+
+    if check {
+        let on_disk = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => {
+                drift.push(path.to_path_buf());
+                return Ok(());
+            }
+        };
+        if on_disk != text {
+            drift.push(path.to_path_buf());
+        }
+        return Ok(());
+    }
+
+    std::fs::write(path, &text).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,35 @@
+//! Workspace task runner. Currently exposes `emit-schemas`, which writes
+//! JSON Schemas for every `*Config`, `*Input`, and `DatasetSpec` type into
+//! `app/src/schemas/`. The Tauri app reads those files at build time to
+//! drive its schema-driven config forms.
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+
+mod emit_schemas;
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let cmd = args
+        .next()
+        .context("usage: cargo xtask <command>\n\ncommands:\n  emit-schemas [--check]\n")?;
+
+    match cmd.as_str() {
+        "emit-schemas" => {
+            let check = args.any(|a| a == "--check");
+            emit_schemas::run(&workspace_root()?, check)
+        }
+        other => bail!("unknown xtask `{other}`; available: emit-schemas [--check]",),
+    }
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    // CARGO_MANIFEST_DIR points at xtask/, so the workspace root is its parent.
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR is unset; xtask must be run via `cargo xtask`")?;
+    let root = Path::new(&manifest_dir)
+        .parent()
+        .context("xtask/ has no parent directory")?
+        .to_path_buf();
+    Ok(root)
+}


### PR DESCRIPTION
## Summary

Self-contained B3 vertical slice for **PlanarIntrinsics + chessboard**: the user picks a dataset folder, edits the manifest and config in schema-driven forms, hits Run, and lands on `/diagnose` with the produced export active. Coverage to the other 7 topologies + 3 detectors ships in B3c.

### B3a — Rust foundation
- **Schema-driven configs** (ADR 0018): `schemars` feature flag across `core` / `optim` / `pipeline` / new crates; `JsonSchema` derives on every `*Config` and shared option type. `cargo xtask emit-schemas` writes 8 JSON Schemas to `app/src/schemas/` with a `--check` mode for CI drift detection.
- **`vision-calibration-dataset` crate** (ADR 0016): canonical `DatasetSpec` manifest — cameras / target / robot poses / topology / pose pairing / **closed-enum frame conventions with no defaults** / `_unresolved`. `validate()` + 8 unit tests.
- **`vision-calibration-detect` crate** (ADR 0017): `Detector` trait, `ChessboardDetector` wrapping `chess-corners` + `calib-targets`, content-addressed `DetectionCache` trait + `FsDetectionCache` impl. 7 unit tests.
- **`pipeline::dataset_runner`**: `build_planar_input(spec, base, &cache, force_redetect)` ties manifest → validation → cache lookup → detect-on-miss (with ROI crop + offset) → `PlanarDataset` IR. `RunError::AskUser` surfaces ADR 0019 ambiguities.
- **ADRs**: 0016 DatasetSpec, 0017 DetectionCache, 0018 Schema-Driven UI, 0019 Fail-Fast on Ambiguity.

### B3b — Tauri runner + Run workspace
- **`app/src-tauri/src/run.rs`**: `run_calibration_cmd` Tauri command. JSON-encoded `DatasetSpec` + `PlanarIntrinsicsConfig` + `manifest_dir` cross the IPC boundary; the heavy work runs on `spawn_blocking`. Returns a tagged `RunResponse` (`ok` / `ask_user` / `validation_failed` / `failed`). Per-dataset cache root under `~/.cache/calibration-rs/detections/`.
- **`app/src/lib/configForm.tsx`**: ~250-LoC schema-driven form generator (primitives, enums, nested objects, `$ref`, `oneOf`-on-`kind`, string arrays). JSON textarea fallback for unhandled shapes. Avoids pulling `@rjsf/core` into the bundle.
- **`app/src/lib/runCalibration.ts`**: typed wrapper around the new command.
- **`app/src/workspaces/RunWorkspace/index.tsx`**: replaces the stub. Two schema-driven panes, folder/manifest pickers, Run button, status banner (running / ok / validation / ask-user / failed), auto-navigation to `/diagnose` on success.

### Codex review follow-ups
- **P1 — apply ROI before detection.** Crop the image, run the detector on the cropped frame, offset detected pixels back into source-image coordinates. ROI is part of the cache key so editing it doesn't silently re-use stale entries.
- **P2 — exact camera count for single-cam topologies.** `WrongCameraCount` validator error replaces the looser `NotEnoughCameras`; PlanarIntrinsics now requires exactly one camera, rig topologies require ≥ 2.

### ROADMAP refresh
- Drops the "post-B0 enrichments TBD by user feedback" framing.
- Documents the committed B-track sub-phasing: B3a foundation → B3b runner+UI → B3c coverage → B3d manifest UX → B3e iteration polish.

`*Input` types are unchanged and remain internal IR per ADR 0016. No public API of the `vision-calibration` facade changes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (full suite green; 169 lib tests in pipeline alone)
- [x] `cargo xtask emit-schemas --check` (no schema drift)
- [x] App-side `cargo clippy --all-targets -- -D warnings`
- [x] App-side `bun run build` (frontend builds cleanly; bundle-size warning is pre-existing — three.js + R3F dominate)
- [ ] Manual smoke test in `bun run tauri dev`: open a chessboard image folder, edit the DatasetSpec form, hit Run, watch detection→solve→navigate-to-Diagnose.
- [ ] Confirm CI passes on the MSRV (1.88) job — schemars 1.x targets 1.81+, well within MSRV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)