### PR TITLE
[codex] Fix Tauri calibration viewer issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b98343f595652ccc4da8ba4bb349ed9ce9c77b0472bad0e9d0858295dd092e"
+checksum = "87aa24dde918ca16f7456406a93fe76918ba55cc78fbd7b8aac42cf41810afc5"
 dependencies = [
  "rayon",
 ]
@@ -333,9 +333,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calib-targets"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d18cb135ca3684dc821f8713ff9ecad0fe9c6211ae6c6ebc49cd08f202fe52"
+checksum = "1db8d8448709b972efa2ef7efd8b4738cf06971713c837bc9c0082a98f57b4d5"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267668023ae49191eb6d7f6698cf7c82654492de83dcea5ccc53485e2f6123fe"
+checksum = "d990b6bd5696a0ab2b322a81d2e4d5148dc84d629e57977638637afd8991fc88"
 dependencies = [
  "calib-targets-core",
  "log",
@@ -367,14 +367,14 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d170181c2a3b9d025b7a96fb2989fc735188c7a1c0d0ecdd7d53d831f7f09faa"
+checksum = "7af66c739d481175bdd12e7d16ee7aadc67165b0d2c7bcebe5456eb240c6789b"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7463ec9e1e56f83622706212795752f9880a3c0f73cadab78d033c31c28a0ebf"
+checksum = "163b2769a687f46e681dafccb409d21feec422b098f63398e184a6630842e780"
 dependencies = [
  "calib-targets-core",
  "kiddo",
@@ -400,10 +400,11 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482c2ffa582b89e72417a544a8d2987f03a7b7eb8a5aa7ac204a6341643f4dc8"
+checksum = "92f9ad4b23e73fdb29124d26d74267f34686648181a919867431d2c89ea5eeea"
 dependencies = [
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -414,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac261ca1d918b7169bf7f61e6fe8c36eadea2390f857b39caeadfa4d1ec067e4"
+checksum = "4d74422dd07522178073cf222ed491e22064b1c03391aea4bd9c4b2b52a17c84"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -429,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ec99dee6408b1ac45b0dadd1d10b101292c635921c8422d22285072d80e6b9"
+checksum = "533ee6c6ba56e730254dc811a7099397e9d9c0c3b021f6ae8ccf80d8610d717f"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -446,13 +447,12 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3d29bff36af73f138aab4df9b01f36da913ba282e9ef8b6cd44ea5c2ceb106"
+checksum = "7edd0b32560c320d657250e9907b4bcdc1a0f88da95a40865a09a7dbb1b9f9fe"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
  "nalgebra",
  "projective-grid",
  "serde",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48621dcb7fc750c0c56563b604af9a9c4c74f482d1c81b004dbb86c67aafec04"
+checksum = "ec0f69e08802e9ec95a13a51f883c774d999d004fd866a1c4c14655edbd524af"
 dependencies = [
  "box-image-pyramid",
  "chess-corners-core",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c484dc3dc9736d59400c6439d27a81bdee9fcaa22bc8796f0ec573cf412e7d7"
+checksum = "c71f1f26caffa180c4574c220746db2655b77825cb8b34aaa6fe2f3a9b87a7b1"
 dependencies = [
  "log",
  "rayon",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-ml"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a943392ba88f9e418976030f720801b6e7268527a7ef1f9e22c7d907acd154e1"
+checksum = "b709a0831849b936ae970515c000cfa0ede4a2410db08263d4402d5aa79156ce"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -688,6 +688,15 @@ name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
+name = "delaunator"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1ee323c1275374f7e612d3724d12707079fb6a2117349fe144def656f5a880"
+dependencies = [
+ "robust",
+]
 
 [[package]]
 name = "deranged"
@@ -923,23 +932,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -952,13 +947,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1117,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "generativity"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5881e4c3c2433fe4905bb19cfd2b5d49d4248274862b68c27c33d9ba4e13f9ec"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
 name = "generator"
@@ -1340,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1398,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -1409,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1554,18 +1548,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1873,9 +1855,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -1948,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2054,7 +2036,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2125,12 +2107,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -2221,18 +2197,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2240,10 +2216,11 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b7ceeb3adc61de9a9cbf1e61952678e271a1e255f02872cb9166fcdfc5a8d6"
+checksum = "4821fcfd313fe1fbb525a156a0ee5360b7dcf89245348f1061ef89e7c127246b"
 dependencies = [
+ "delaunator",
  "kiddo",
  "nalgebra",
  "serde",
@@ -2619,15 +2596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2649,12 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rustfft"
@@ -3007,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3448,7 +3422,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "calib-targets",
- "chess-corners",
  "image",
  "nalgebra",
  "serde_json",
@@ -3488,7 +3461,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "calib-targets",
- "chess-corners",
  "image",
  "schemars",
  "serde",
@@ -3595,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3608,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3618,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3631,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ schemars = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 log = "0.4"
 image = { version = "0.25" }
-chess-corners = { version = "0.6", features = ["rayon", "ml-refiner"] }
-calib-targets = "0.7"
+calib-targets = "0.8"
 glob = "0.3"
 rand = { version = "0.10" }
 tracing = { version = "0.1" }

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "dirs 5.0.1",
+ "image",
  "nalgebra",
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "box-image-pyramid"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b98343f595652ccc4da8ba4bb349ed9ce9c77b0472bad0e9d0858295dd092e"
+checksum = "87aa24dde918ca16f7456406a93fe76918ba55cc78fbd7b8aac42cf41810afc5"
 dependencies = [
  "rayon",
 ]
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ebcdd8eb12711dd4342f2b3d22e6b4a98a17eec53a2e6e6cb25aafcd6f47ea"
+checksum = "1db8d8448709b972efa2ef7efd8b4738cf06971713c837bc9c0082a98f57b4d5"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-aruco"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63cc01177982500442017ad4e8b7066bdf0901f2409f0d95abe5d5999215e75"
+checksum = "d990b6bd5696a0ab2b322a81d2e4d5148dc84d629e57977638637afd8991fc88"
 dependencies = [
  "calib-targets-core",
  "log",
@@ -514,14 +514,14 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-charuco"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5faafed15f2c114f7430d326f1913a3b68ddf6892d4a2867842302420b524bc0"
+checksum = "7af66c739d481175bdd12e7d16ee7aadc67165b0d2c7bcebe5456eb240c6789b"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-chessboard"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d722baba1ddbe0c6b239b3054a7b593e66b560e4c831ed89a9b175fd9cff8268"
+checksum = "163b2769a687f46e681dafccb409d21feec422b098f63398e184a6630842e780"
 dependencies = [
  "calib-targets-core",
  "kiddo",
@@ -547,10 +547,11 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-core"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f87430c0973312d043b80d4bff03a1da37574239d3778640cff67509b90b3d"
+checksum = "92f9ad4b23e73fdb29124d26d74267f34686648181a919867431d2c89ea5eeea"
 dependencies = [
+ "chess-corners",
  "log",
  "nalgebra",
  "projective-grid",
@@ -561,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-marker"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4de16719bde92eab612d90a16733e404f04879b761994b60a396317c1335ca"
+checksum = "4d74422dd07522178073cf222ed491e22064b1c03391aea4bd9c4b2b52a17c84"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
@@ -576,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-print"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52d8a8aed0aa2dad4f8555b5ee75665ab4d78a89fdcf2a67eda4c9a0bfea2ac"
+checksum = "533ee6c6ba56e730254dc811a7099397e9d9c0c3b021f6ae8ccf80d8610d717f"
 dependencies = [
  "calib-targets-aruco",
  "calib-targets-charuco",
@@ -593,13 +594,12 @@ dependencies = [
 
 [[package]]
 name = "calib-targets-puzzleboard"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3290a2606df3c51300a36dff255bda5897d2545f846cc6df35f8eb24cd00a36c"
+checksum = "7edd0b32560c320d657250e9907b4bcdc1a0f88da95a40865a09a7dbb1b9f9fe"
 dependencies = [
  "calib-targets-chessboard",
  "calib-targets-core",
- "chess-corners-core",
  "nalgebra",
  "projective-grid",
  "serde",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48621dcb7fc750c0c56563b604af9a9c4c74f482d1c81b004dbb86c67aafec04"
+checksum = "ec0f69e08802e9ec95a13a51f883c774d999d004fd866a1c4c14655edbd524af"
 dependencies = [
  "box-image-pyramid",
  "chess-corners-core",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-core"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c484dc3dc9736d59400c6439d27a81bdee9fcaa22bc8796f0ec573cf412e7d7"
+checksum = "c71f1f26caffa180c4574c220746db2655b77825cb8b34aaa6fe2f3a9b87a7b1"
 dependencies = [
  "log",
  "rayon",
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "chess-corners-ml"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a943392ba88f9e418976030f720801b6e7268527a7ef1f9e22c7d907acd154e1"
+checksum = "b709a0831849b936ae970515c000cfa0ede4a2410db08263d4402d5aa79156ce"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1081,6 +1081,15 @@ name = "defer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
+name = "delaunator"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1ee323c1275374f7e612d3724d12707079fb6a2117349fe144def656f5a880"
+dependencies = [
+ "robust",
+]
 
 [[package]]
 name = "deranged"
@@ -4166,10 +4175,11 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d68e7e2b69d64b7e6a552dd98684d16d49e8dc468a0ad9badeccf51877a6b3"
+checksum = "4821fcfd313fe1fbb525a156a0ee5360b7dcf89245348f1061ef89e7c127246b"
 dependencies = [
+ "delaunator",
  "kiddo",
  "nalgebra",
  "serde",
@@ -4634,6 +4644,12 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rustc-hash"
@@ -6388,7 +6404,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "calib-targets",
- "chess-corners",
  "image",
  "serde",
  "serde_json",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 base64 = "0.22"
 anyhow = "1"
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
+image = "0.25"
 vision-calibration = { path = "../../crates/vision-calibration" }
 vision-calibration-core = { path = "../../crates/vision-calibration-core" }
 vision-calibration-pipeline = { path = "../../crates/vision-calibration-pipeline" }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -10,6 +10,7 @@ use base64::Engine;
 use serde::Serialize;
 use std::path::PathBuf;
 use tauri::State;
+use vision_calibration_core::PixelRect;
 
 use crate::epipolar::{self, EpipolarOverlay};
 use crate::export_cache::ExportCache;
@@ -91,6 +92,37 @@ pub async fn load_image(path: String) -> Result<String, String> {
     Ok(format!("data:{mime};base64,{b64}"))
 }
 
+/// Read an image file and render it into a camera's undistorted pixel
+/// frame. This is only used by the Epipolar workspace; Diagnose keeps
+/// showing the raw source image.
+#[tauri::command]
+pub async fn load_undistorted_image(
+    path: String,
+    camera: usize,
+    roi: Option<PixelRect>,
+    cache: State<'_, ExportCache>,
+) -> Result<String, String> {
+    let path_buf = PathBuf::from(&path);
+    let bytes = cache
+        .read(|cached| epipolar::undistort_image_png(&cached.value, &path_buf, camera, roi))
+        .ok_or_else(|| "no export loaded yet".to_string())??;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:image/png;base64,{b64}"))
+}
+
+/// Map raw/distorted camera pixels into the undistorted pixel frame
+/// used by the Epipolar workspace.
+#[tauri::command]
+pub async fn undistort_points(
+    camera: usize,
+    points_px: Vec<[f64; 2]>,
+    cache: State<'_, ExportCache>,
+) -> Result<Vec<[f64; 2]>, String> {
+    cache
+        .read(|cached| epipolar::undistort_points(&cached.value, camera, points_px))
+        .ok_or_else(|| "no export loaded yet".to_string())?
+}
+
 /// Compute the epipolar polyline + epipole for a click in pane A.
 ///
 /// Reads the most recently loaded export from [`ExportCache`] (no disk
@@ -109,6 +141,31 @@ pub async fn compute_epipolar_overlay(
 ) -> Result<EpipolarOverlay, String> {
     cache
         .read(|cached| epipolar::compute_overlay(&cached.value, cam_a, cam_b, point_px))
+        .ok_or_else(|| "no export loaded yet".to_string())?
+}
+
+/// Compute a clipped straight epipolar segment in cam-B's undistorted
+/// image frame. `point_px` is in cam-A's undistorted pixel frame.
+#[tauri::command]
+pub async fn compute_epipolar_overlay_undistorted(
+    cam_a: usize,
+    cam_b: usize,
+    point_px: [f64; 2],
+    image_width_b: f64,
+    image_height_b: f64,
+    cache: State<'_, ExportCache>,
+) -> Result<EpipolarOverlay, String> {
+    cache
+        .read(|cached| {
+            epipolar::compute_overlay_undistorted(
+                &cached.value,
+                cam_a,
+                cam_b,
+                point_px,
+                image_width_b,
+                image_height_b,
+            )
+        })
         .ok_or_else(|| "no export loaded yet".to_string())?
 }
 

--- a/app/src-tauri/src/epipolar.rs
+++ b/app/src-tauri/src/epipolar.rs
@@ -9,10 +9,12 @@
 //! "is the calibration wrong or is the viz wrong" moment becomes a
 //! science fair.
 
+use image::{DynamicImage, Rgba, RgbaImage};
 use nalgebra::{Point2, Point3, Vector3};
 use serde::Serialize;
+use std::{io::Cursor, path::Path};
 use vision_calibration::core::{
-    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams, Iso3,
+    BrownConrady5, CameraParams, DistortionParams, FxFyCxCySkew, IntrinsicsParams, Iso3, PixelRect,
     ProjectionParams, ScheimpflugParams, SensorParams,
 };
 use vision_calibration_core::CameraModel;
@@ -141,6 +143,149 @@ pub fn compute_overlay(
     })
 }
 
+/// Convert raw/distorted pixel coordinates into the undistorted pixel
+/// frame used by the epipolar workspace. The output keeps the camera's
+/// original `K` scale/center but removes distortion and sensor warping.
+pub fn undistort_points(
+    export: &serde_json::Value,
+    camera: usize,
+    points_px: Vec<[f64; 2]>,
+) -> Result<Vec<[f64; 2]>, String> {
+    let geometry = camera_geometry(export, camera)?;
+    Ok(points_px
+        .iter()
+        .map(|p| raw_pixel_to_undistorted_pixel(&geometry, *p))
+        .collect())
+}
+
+/// Decode an image and render it into the undistorted pixel frame for
+/// `camera`. If `roi` is present, the source image is sampled from that
+/// source rectangle while the output dimensions remain ROI-local.
+pub fn undistort_image_png(
+    export: &serde_json::Value,
+    path: &Path,
+    camera: usize,
+    roi: Option<PixelRect>,
+) -> Result<Vec<u8>, String> {
+    let geometry = camera_geometry(export, camera)?;
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let src = image::load_from_memory(&bytes)
+        .map_err(|e| format!("decode {}: {e}", path.display()))?
+        .to_rgba8();
+    let (out_w, out_h) = match roi {
+        Some(r) => (r.w, r.h),
+        None => (src.width(), src.height()),
+    };
+    if out_w == 0 || out_h == 0 {
+        return Err("undistorted image dimensions must be non-zero".to_string());
+    }
+
+    let mut out = RgbaImage::new(out_w, out_h);
+    let offset_x = roi.map_or(0.0, |r| r.x as f64);
+    let offset_y = roi.map_or(0.0, |r| r.y as f64);
+    for y in 0..out_h {
+        for x in 0..out_w {
+            let raw = undistorted_pixel_to_raw_pixel(&geometry, [x as f64, y as f64]);
+            let Some(raw) = raw else {
+                out.put_pixel(x, y, Rgba([0, 0, 0, 255]));
+                continue;
+            };
+            let sample = sample_bilinear(&src, raw[0] + offset_x, raw[1] + offset_y);
+            out.put_pixel(x, y, sample);
+        }
+    }
+
+    let mut cursor = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(out)
+        .write_to(&mut cursor, image::ImageFormat::Png)
+        .map_err(|e| format!("encode undistorted PNG: {e}"))?;
+    Ok(cursor.into_inner())
+}
+
+/// Compute a straight epipolar line in cam-B's undistorted pixel frame.
+///
+/// `point_px` is already in cam-A's undistorted pixel frame. Returned
+/// `line_b` contains zero or two clipped endpoints in cam-B's
+/// undistorted pixel frame.
+pub fn compute_overlay_undistorted(
+    export: &serde_json::Value,
+    cam_a: usize,
+    cam_b: usize,
+    point_px: [f64; 2],
+    image_width_b: f64,
+    image_height_b: f64,
+) -> Result<EpipolarOverlay, String> {
+    if !(image_width_b.is_finite() && image_height_b.is_finite())
+        || image_width_b <= 0.0
+        || image_height_b <= 0.0
+    {
+        return Err("cam-B image dimensions must be finite and positive".to_string());
+    }
+
+    let cameras = export
+        .get("cameras")
+        .and_then(|v| v.as_array())
+        .ok_or("export has no `cameras` array (rig exports only)")?;
+    let cam_se3_rig: Vec<Iso3> = serde_json::from_value(
+        export
+            .get("cam_se3_rig")
+            .ok_or("export has no `cam_se3_rig`")?
+            .clone(),
+    )
+    .map_err(|e| format!("cam_se3_rig decode: {e}"))?;
+    let n = cameras.len();
+    if cam_a >= n || cam_b >= n {
+        return Err(format!(
+            "camera index out of range (cam_a={cam_a}, cam_b={cam_b}, num_cameras={n})"
+        ));
+    }
+    if cam_se3_rig.len() != n {
+        return Err(format!(
+            "cam_se3_rig length {} does not match cameras length {n}",
+            cam_se3_rig.len()
+        ));
+    }
+
+    let cam_a_geometry = camera_geometry(export, cam_a)?;
+    let cam_b_geometry = camera_geometry(export, cam_b)?;
+    let ray_a = undistorted_pixel_to_ray(&cam_a_geometry.k, point_px);
+    let t_b_a = cam_se3_rig[cam_b] * cam_se3_rig[cam_a].inverse();
+
+    let mut samples_clipped = 0usize;
+    let mut first: Option<[f64; 2]> = None;
+    let mut last: Option<[f64; 2]> = None;
+    for d in log_depths() {
+        let p_a = Point3::from(ray_a * d);
+        let p_b = t_b_a * p_a;
+        if p_b.z < CAM_B_Z_MIN_M {
+            samples_clipped += 1;
+            continue;
+        }
+        let Some(px) = project_undistorted_camera_point(&cam_b_geometry.k, &p_b.coords) else {
+            samples_clipped += 1;
+            continue;
+        };
+        if first.is_none() {
+            first = Some(px);
+        }
+        last = Some(px);
+    }
+
+    let line_b = match (first, last) {
+        (Some(a), Some(b)) => clip_line_to_image(a, b, image_width_b, image_height_b),
+        _ => Vec::new(),
+    };
+
+    let origin_b = t_b_a * Point3::<f64>::origin();
+    let epipole_b = project_undistorted_camera_point(&cam_b_geometry.k, &origin_b.coords);
+
+    Ok(EpipolarOverlay {
+        line_b,
+        epipole_b,
+        samples_clipped,
+    })
+}
+
 /// Logarithmically-spaced depths from `DEPTH_MIN_M` to `DEPTH_MAX_M`.
 fn log_depths() -> impl Iterator<Item = f64> {
     let ratio = DEPTH_MAX_M / DEPTH_MIN_M;
@@ -156,6 +301,36 @@ fn build_camera(
     camera_json: &serde_json::Value,
     sensor: Option<&ScheimpflugParams>,
 ) -> Result<CameraModel, String> {
+    Ok(build_camera_geometry(camera_json, sensor)?.model)
+}
+
+#[derive(Clone, Debug)]
+struct CameraGeometry {
+    model: CameraModel,
+    k: FxFyCxCySkew<f64>,
+}
+
+fn camera_geometry(export: &serde_json::Value, camera: usize) -> Result<CameraGeometry, String> {
+    let cameras = export
+        .get("cameras")
+        .and_then(|v| v.as_array())
+        .ok_or("export has no `cameras` array (rig exports only)")?;
+    let n = cameras.len();
+    if camera >= n {
+        return Err(format!(
+            "camera index out of range (camera={camera}, num_cameras={n})"
+        ));
+    }
+    let sensors = parse_sensors(export)?;
+    let sensor_for =
+        |idx: usize| -> Option<&ScheimpflugParams> { sensors.as_ref()?.get(idx)?.as_ref() };
+    build_camera_geometry(&cameras[camera], sensor_for(camera))
+}
+
+fn build_camera_geometry(
+    camera_json: &serde_json::Value,
+    sensor: Option<&ScheimpflugParams>,
+) -> Result<CameraGeometry, String> {
     let k: FxFyCxCySkew<f64> = serde_json::from_value(
         camera_json
             .get("k")
@@ -182,7 +357,10 @@ fn build_camera(
         sensor: sensor_params,
         intrinsics: IntrinsicsParams::FxFyCxCySkew { params: k },
     };
-    Ok(params.build())
+    Ok(CameraGeometry {
+        model: params.build(),
+        k,
+    })
 }
 
 /// Parse the optional `sensors` array. None when the export is a pinhole
@@ -217,6 +395,124 @@ fn parse_sensors(
 /// the current single-call shape.
 #[allow(dead_code)]
 type V3 = Vector3<f64>;
+
+fn raw_pixel_to_undistorted_pixel(geometry: &CameraGeometry, px: [f64; 2]) -> [f64; 2] {
+    let ray = geometry.model.backproject_pixel(&Point2::new(px[0], px[1]));
+    normalized_to_pixel(&geometry.k, ray.point.x, ray.point.y)
+}
+
+fn undistorted_pixel_to_raw_pixel(geometry: &CameraGeometry, px: [f64; 2]) -> Option<[f64; 2]> {
+    let ray = undistorted_pixel_to_ray(&geometry.k, px);
+    geometry
+        .model
+        .project_point_c(&ray)
+        .map(|p| [p.x, p.y])
+        .filter(|p| p[0].is_finite() && p[1].is_finite())
+}
+
+fn undistorted_pixel_to_ray(k: &FxFyCxCySkew<f64>, px: [f64; 2]) -> Vector3<f64> {
+    let y = (px[1] - k.cy) / k.fy;
+    let x = (px[0] - k.cx - k.skew * y) / k.fx;
+    Vector3::new(x, y, 1.0)
+}
+
+fn project_undistorted_camera_point(k: &FxFyCxCySkew<f64>, p_c: &Vector3<f64>) -> Option<[f64; 2]> {
+    if p_c.z <= 0.0 {
+        return None;
+    }
+    let x = p_c.x / p_c.z;
+    let y = p_c.y / p_c.z;
+    let px = normalized_to_pixel(k, x, y);
+    if px[0].is_finite() && px[1].is_finite() {
+        Some(px)
+    } else {
+        None
+    }
+}
+
+fn normalized_to_pixel(k: &FxFyCxCySkew<f64>, x: f64, y: f64) -> [f64; 2] {
+    [k.fx * x + k.skew * y + k.cx, k.fy * y + k.cy]
+}
+
+fn clip_line_to_image(a: [f64; 2], b: [f64; 2], w: f64, h: f64) -> Vec<[f64; 2]> {
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    let mut pts: Vec<[f64; 2]> = Vec::with_capacity(4);
+    let eps = 1e-9;
+
+    if dx.abs() > eps {
+        for x in [0.0, w] {
+            let t = (x - a[0]) / dx;
+            let y = a[1] + t * dy;
+            if y >= -eps && y <= h + eps {
+                push_unique(&mut pts, [x, y.clamp(0.0, h)]);
+            }
+        }
+    }
+    if dy.abs() > eps {
+        for y in [0.0, h] {
+            let t = (y - a[1]) / dy;
+            let x = a[0] + t * dx;
+            if x >= -eps && x <= w + eps {
+                push_unique(&mut pts, [x.clamp(0.0, w), y]);
+            }
+        }
+    }
+
+    if pts.len() <= 2 {
+        return pts;
+    }
+
+    let mut best = (0usize, 1usize, -1.0f64);
+    for i in 0..pts.len() {
+        for j in (i + 1)..pts.len() {
+            let d2 = (pts[i][0] - pts[j][0]).powi(2) + (pts[i][1] - pts[j][1]).powi(2);
+            if d2 > best.2 {
+                best = (i, j, d2);
+            }
+        }
+    }
+    vec![pts[best.0], pts[best.1]]
+}
+
+fn push_unique(pts: &mut Vec<[f64; 2]>, p: [f64; 2]) {
+    if pts
+        .iter()
+        .any(|q| (q[0] - p[0]).abs() < 1e-7 && (q[1] - p[1]).abs() < 1e-7)
+    {
+        return;
+    }
+    pts.push(p);
+}
+
+fn sample_bilinear(src: &RgbaImage, x: f64, y: f64) -> Rgba<u8> {
+    if !x.is_finite()
+        || !y.is_finite()
+        || x < 0.0
+        || y < 0.0
+        || x > (src.width().saturating_sub(1)) as f64
+        || y > (src.height().saturating_sub(1)) as f64
+    {
+        return Rgba([0, 0, 0, 255]);
+    }
+    let x0 = x.floor() as u32;
+    let y0 = y.floor() as u32;
+    let x1 = (x0 + 1).min(src.width() - 1);
+    let y1 = (y0 + 1).min(src.height() - 1);
+    let tx = x - x0 as f64;
+    let ty = y - y0 as f64;
+    let p00 = src.get_pixel(x0, y0).0;
+    let p10 = src.get_pixel(x1, y0).0;
+    let p01 = src.get_pixel(x0, y1).0;
+    let p11 = src.get_pixel(x1, y1).0;
+    let mut out = [0u8; 4];
+    for c in 0..4 {
+        let top = p00[c] as f64 * (1.0 - tx) + p10[c] as f64 * tx;
+        let bottom = p01[c] as f64 * (1.0 - tx) + p11[c] as f64 * tx;
+        out[c] = (top * (1.0 - ty) + bottom * ty).round().clamp(0.0, 255.0) as u8;
+    }
+    Rgba(out)
+}
 
 #[cfg(test)]
 mod tests {
@@ -354,5 +650,151 @@ mod tests {
             "expected a usable polyline after the cutoff; got {}",
             overlay.line_b.len()
         );
+    }
+
+    #[test]
+    fn undistorted_pixel_roundtrip_matches_raw_camera_frame() {
+        let export = stereo_like_export();
+        let geometry = camera_geometry(&export, 1).unwrap();
+
+        for raw in [[575.3, 108.2], [345.0, 500.0], [900.0, 220.0]] {
+            let undistorted = raw_pixel_to_undistorted_pixel(&geometry, raw);
+            let raw_roundtrip = undistorted_pixel_to_raw_pixel(&geometry, undistorted).unwrap();
+            let err =
+                ((raw_roundtrip[0] - raw[0]).powi(2) + (raw_roundtrip[1] - raw[1]).powi(2)).sqrt();
+            assert!(
+                err < 0.1,
+                "raw→undistorted→raw roundtrip drifted by {err:.4} px for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn raw_distorted_overlay_can_fold_but_undistorted_overlay_is_clipped_line() {
+        let export = stereo_like_export();
+        let raw_left_px = [358.4, 126.9];
+        let raw_right_px = [575.3, 108.2];
+
+        let raw = compute_overlay(&export, 0, 1, raw_left_px).unwrap();
+        let raw_runs = in_bounds_runs(&raw.line_b, 1024.0, 768.0, 192.0);
+        assert!(
+            raw_runs >= 2,
+            "expected raw distorted depth samples to split into multiple visible runs"
+        );
+
+        let point_a = undistort_points(&export, 0, vec![raw_left_px]).unwrap()[0];
+        let point_b = undistort_points(&export, 1, vec![raw_right_px]).unwrap()[0];
+        let undistorted =
+            compute_overlay_undistorted(&export, 0, 1, point_a, 1024.0, 768.0).unwrap();
+        assert_eq!(
+            undistorted.line_b.len(),
+            2,
+            "undistorted overlay should be represented by clipped endpoints"
+        );
+        for p in &undistorted.line_b {
+            assert!(
+                p[0] >= 0.0 && p[0] <= 1024.0 && p[1] >= 0.0 && p[1] <= 768.0,
+                "endpoint outside image bounds: {p:?}"
+            );
+        }
+        let dist = distance_to_segment(point_b, undistorted.line_b[0], undistorted.line_b[1]);
+        assert!(
+            dist < 3.0,
+            "corresponding feature should remain close to the undistorted epipolar line; got {dist:.3} px"
+        );
+    }
+
+    fn stereo_like_export() -> serde_json::Value {
+        serde_json::json!({
+            "cameras": [
+                {
+                    "k": {
+                        "fx": 713.8456995546412,
+                        "fy": 724.6690645729575,
+                        "cx": 523.4129016186437,
+                        "cy": 285.9522601918888,
+                        "skew": 0.0
+                    },
+                    "dist": {
+                        "k1": 0.015021094581498156,
+                        "k2": -0.07151318797378012,
+                        "k3": 0.0,
+                        "p1": 0.0006183511614000294,
+                        "p2": 0.0002526916716399372,
+                        "iters": 8
+                    }
+                },
+                {
+                    "k": {
+                        "fx": 724.7966090646895,
+                        "fy": 735.5984809398797,
+                        "cx": 513.9329313241342,
+                        "cy": 292.95508592356225,
+                        "skew": 0.0
+                    },
+                    "dist": {
+                        "k1": 0.00113846407979313,
+                        "k2": -0.0525607289860634,
+                        "k3": 0.0,
+                        "p1": -0.0014292429046042455,
+                        "p2": 0.0014269862041345035,
+                        "iters": 8
+                    }
+                }
+            ],
+            "cam_se3_rig": [
+                {
+                    "rotation": [0.0, 0.0, 0.0, 1.0],
+                    "translation": [0.0, 0.0, 0.0]
+                },
+                {
+                    "rotation": [
+                        0.013175949007657478,
+                        -0.01753553695143165,
+                        -0.004069965919389522,
+                        0.9997511363779427
+                    ],
+                    "translation": [
+                        0.1892859214228441,
+                        -0.004507939830404787,
+                        0.010062154737396994
+                    ]
+                }
+            ]
+        })
+    }
+
+    fn in_bounds_runs(pts: &[[f64; 2]], w: f64, h: f64, jump_px: f64) -> usize {
+        let mut runs = 0usize;
+        let mut prev: Option<[f64; 2]> = None;
+        for p in pts {
+            let in_bounds = p[0] >= 0.0 && p[0] <= w && p[1] >= 0.0 && p[1] <= h;
+            if !in_bounds {
+                prev = None;
+                continue;
+            }
+            if let Some(prev_p) = prev {
+                let jump = ((p[0] - prev_p[0]).powi(2) + (p[1] - prev_p[1]).powi(2)).sqrt();
+                if jump > jump_px {
+                    runs += 1;
+                }
+            } else {
+                runs += 1;
+            }
+            prev = Some(*p);
+        }
+        runs
+    }
+
+    fn distance_to_segment(p: [f64; 2], a: [f64; 2], b: [f64; 2]) -> f64 {
+        let abx = b[0] - a[0];
+        let aby = b[1] - a[1];
+        let len_sq = abx * abx + aby * aby;
+        if len_sq == 0.0 {
+            return ((p[0] - a[0]).powi(2) + (p[1] - a[1]).powi(2)).sqrt();
+        }
+        let t = (((p[0] - a[0]) * abx + (p[1] - a[1]) * aby) / len_sq).clamp(0.0, 1.0);
+        let q = [a[0] + t * abx, a[1] + t * aby];
+        ((p[0] - q[0]).powi(2) + (p[1] - q[1]).powi(2)).sqrt()
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -31,8 +31,11 @@ pub fn run() {
             commands::load_export,
             commands::set_active_export,
             commands::load_image,
+            commands::load_undistorted_image,
             commands::load_text_file,
             commands::compute_epipolar_overlay,
+            commands::compute_epipolar_overlay_undistorted,
+            commands::undistort_points,
             run::run_calibration_cmd,
         ])
         .run(tauri::generate_context!())

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
+use vision_calibration_core::{FrameRef, ImageManifest};
 use vision_calibration_dataset::{DatasetSpec, Topology};
 use vision_calibration_detect::FsDetectionCache;
 use vision_calibration_pipeline::dataset_runner::{RunError, build_planar_input};
@@ -169,12 +170,21 @@ fn run_blocking(
             message: format!("calibration failed: {e}"),
         };
     }
-    let export = match session.export() {
+    let mut export = match session.export() {
         Ok(e) => e,
         Err(e) => {
             return RunResponse::Failed {
                 category: "session_export".into(),
                 message: format!("export failed: {e}"),
+            };
+        }
+    };
+    export.image_manifest = match planar_image_manifest(&planar_run.view_paths, base_dir) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            return RunResponse::Failed {
+                category: "image_manifest".into(),
+                message: e,
             };
         }
     };
@@ -192,14 +202,41 @@ fn run_blocking(
     // worker returns, so the diagnose / 3D / epipolar workspaces can
     // pick it up via the existing `compute_*` commands without a disk
     // round-trip.
-    let _ = planar_run.view_paths; // PR 1 doesn't yet thread image_manifest back
-
     RunResponse::Ok(RunSuccess {
         export: export_value,
         duration_ms: started.elapsed().as_millis() as u64,
         usable_views: planar_run.usable_views,
         total_views: planar_run.total_views,
         cache_used,
+    })
+}
+
+fn planar_image_manifest(view_paths: &[PathBuf], base_dir: &Path) -> Result<ImageManifest, String> {
+    let base_abs = base_dir
+        .canonicalize()
+        .map_err(|e| format!("canonicalize manifest dir {}: {e}", base_dir.display()))?;
+    let mut frames = Vec::with_capacity(view_paths.len());
+    for (pose, path) in view_paths.iter().enumerate() {
+        let abs = path
+            .canonicalize()
+            .map_err(|e| format!("canonicalize image path {}: {e}", path.display()))?;
+        let rel = abs.strip_prefix(&base_abs).map_err(|_| {
+            format!(
+                "accepted image {} is not under manifest dir {}",
+                abs.display(),
+                base_abs.display()
+            )
+        })?;
+        frames.push(FrameRef {
+            pose,
+            camera: 0,
+            path: rel.to_path_buf(),
+            roi: None,
+        });
+    }
+    Ok(ImageManifest {
+        root: PathBuf::from("."),
+        frames,
     })
 }
 

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -6,8 +6,14 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "bun run dev",
-    "beforeBuildCommand": "bun run build"
+    "beforeDevCommand": {
+      "script": "bun run dev",
+      "cwd": ".."
+    },
+    "beforeBuildCommand": {
+      "script": "bun run build",
+      "cwd": ".."
+    }
   },
   "app": {
     "windows": [

--- a/app/src/hooks/useImageData.ts
+++ b/app/src/hooks/useImageData.ts
@@ -66,6 +66,77 @@ export function useImageData(
   return data;
 }
 
+/** Loads a frame through the backend's canonical camera model into the
+ * undistorted pixel frame. The returned image is already ROI-local when
+ * `frame.roi` is set, so callers should render it without applying the
+ * ROI crop a second time. */
+export function useUndistortedImageData(
+  frame: FrameKey | null,
+  camera: number,
+  onError?: (msg: string) => void,
+): ImageData | null {
+  const [data, setData] = useState<ImageData | null>(null);
+
+  useEffect(() => {
+    if (!frame) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+    setData(null);
+    invoke<string>("load_undistorted_image", {
+      path: frame.abs_path,
+      camera,
+      roi: frame.roi ?? null,
+    })
+      .then((dataUrl) => decodeImageDataUrl(dataUrl, () => cancelled, setData, onError))
+      .catch((e) => {
+        if (!cancelled) onError?.(`Could not load undistorted image: ${e}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    frame?.abs_path,
+    frame?.roi?.x,
+    frame?.roi?.y,
+    frame?.roi?.w,
+    frame?.roi?.h,
+    camera,
+    onError,
+  ]);
+
+  return data;
+}
+
+function decodeImageDataUrl(
+  dataUrl: string,
+  isCancelled: () => boolean,
+  setData: (data: ImageData) => void,
+  onError?: (msg: string) => void,
+) {
+  if (isCancelled()) return;
+  const img = new Image();
+  img.onload = () => {
+    if (isCancelled()) return;
+    try {
+      const luminance = decodeLuminance(img);
+      setData({
+        image: img,
+        naturalWidth: img.naturalWidth,
+        naturalHeight: img.naturalHeight,
+        luminance,
+      });
+    } catch (e) {
+      onError?.(`Pixel decode failed: ${e}`);
+    }
+  };
+  img.onerror = () => {
+    if (!isCancelled()) onError?.("Image failed to decode.");
+  };
+  img.src = dataUrl;
+}
+
 /** Pull luminance out of an HTMLImageElement by drawing it into an
  * OffscreenCanvas (or a hidden 2D canvas for older runtimes) and
  * extracting RGBA. We compute Rec. 601 luma and discard the rest. */

--- a/app/src/lib/configForm.tsx
+++ b/app/src/lib/configForm.tsx
@@ -88,6 +88,9 @@ function SchemaField(props: FieldProps) {
   const schema = resolve(props.schema, props.ctx);
 
   if (schema.oneOf && schema.oneOf.length > 0) {
+    if (isExternalTaggedOneOf(schema, props.ctx)) {
+      return <ExternalTaggedOneOfField {...props} schema={schema} />;
+    }
     return <OneOfField {...props} schema={schema} />;
   }
   if (schema.enum && hasType(schema, "string")) {
@@ -148,6 +151,126 @@ function ObjectField({ schema, value, onChange, ctx, label }: FieldProps) {
       ))}
     </fieldset>
   );
+}
+
+// ─── oneOf with serde externally tagged enum shape ─────────────────────────
+interface ExternalVariant {
+  tag: string;
+  schema: JsonSchema | null;
+}
+
+function externalVariant(variant: JsonSchema, ctx: FormCtx): ExternalVariant | null {
+  const v = resolve(variant, ctx);
+  if (typeof v.const === "string" && hasType(v, "string")) {
+    return { tag: v.const, schema: null };
+  }
+  const required = v.required ?? [];
+  const props = v.properties ?? {};
+  if (required.length === 1 && props[required[0]]) {
+    return { tag: required[0], schema: props[required[0]] };
+  }
+  const keys = Object.keys(props);
+  if (keys.length === 1) {
+    return { tag: keys[0], schema: props[keys[0]] };
+  }
+  return null;
+}
+
+function isExternalTaggedOneOf(schema: JsonSchema, ctx: FormCtx): boolean {
+  const variants = schema.oneOf ?? [];
+  return variants.length > 0 && variants.every((v) => externalVariant(v, ctx) != null);
+}
+
+function ExternalTaggedOneOfField({ schema, value, onChange, ctx, label }: FieldProps) {
+  const variants = (schema.oneOf ?? [])
+    .map((v) => externalVariant(v, ctx))
+    .filter((v): v is ExternalVariant => v != null);
+  const currentTag = externalCurrentTag(value, variants);
+  const active = variants.find((v) => v.tag === currentTag) ?? variants[0];
+  const payload =
+    active?.schema &&
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    active.tag in value
+      ? (value as Record<string, unknown>)[active.tag]
+      : active?.schema
+        ? defaultValueForSchema(resolve(active.schema, ctx))
+        : undefined;
+
+  return (
+    <fieldset className="flex flex-col gap-2 rounded-md border border-border bg-bg-soft p-3">
+      {label && (
+        <legend className="px-1 text-[12px] font-semibold tracking-tight">{label}</legend>
+      )}
+      {schema.description && (
+        <p className="text-[11px] text-muted-foreground">{schema.description}</p>
+      )}
+      <select
+        className="rounded border border-border bg-bg px-2 py-1 text-[12px]"
+        value={active?.tag ?? ""}
+        onChange={(e) => {
+          const next = variants.find((v) => v.tag === e.target.value);
+          if (!next) return;
+          if (!next.schema) {
+            onChange(next.tag);
+          } else {
+            onChange({ [next.tag]: defaultValueForSchema(resolve(next.schema, ctx)) });
+          }
+        }}
+      >
+        {variants.map((v) => (
+          <option key={v.tag} value={v.tag}>
+            {v.tag}
+          </option>
+        ))}
+      </select>
+      {active?.schema && (
+        <SchemaField
+          schema={active.schema}
+          value={payload}
+          onChange={(next) => onChange({ [active.tag]: next })}
+          ctx={{ ...ctx, path: `${ctx.path}.${active.tag}` }}
+          label={active.tag}
+        />
+      )}
+    </fieldset>
+  );
+}
+
+function externalCurrentTag(value: unknown, variants: ExternalVariant[]): string {
+  if (typeof value === "string" && variants.some((v) => v.tag === value)) {
+    return value;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    const key = Object.keys(obj).find((k) => variants.some((v) => v.tag === k));
+    if (key) return key;
+  }
+  return variants[0]?.tag ?? "";
+}
+
+function defaultValueForSchema(schema: JsonSchema): unknown {
+  const resolved = schema;
+  if (resolved.default !== undefined) return resolved.default;
+  if (typeof resolved.const === "string") return resolved.const;
+  if (resolved.enum && resolved.enum.length > 0) return resolved.enum[0];
+  if (hasType(resolved, "object") && resolved.properties) {
+    const out: Record<string, unknown> = {};
+    const required = resolved.required ?? Object.keys(resolved.properties);
+    for (const key of required) {
+      const sub = resolved.properties[key];
+      if (sub) out[key] = defaultValueForSchema(sub);
+    }
+    return out;
+  }
+  if (hasType(resolved, "array")) return [];
+  if (hasType(resolved, "boolean")) return false;
+  if (hasType(resolved, "integer") || hasType(resolved, "number")) {
+    return resolved.minimum ?? 1;
+  }
+  if (hasType(resolved, "string")) return "";
+  return {};
 }
 
 // ─── oneOf with `kind` discriminator ────────────────────────────────────────

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -19,6 +19,88 @@ function nextInWrap(arr: number[], current: number, delta: number): number {
   return arr[(((idx + delta) % n) + n) % n];
 }
 
+interface MaterializedExport {
+  frames: FrameKey[];
+  poseValues: number[];
+  cameraValues: number[];
+  posesByCamera: Map<number, number[]>;
+  camerasByPose: Map<number, number[]>;
+  first: FrameKey;
+  second: FrameKey;
+}
+
+function materializeExport(data: AnyExport, exportDir: string):
+  | { ok: true; value: MaterializedExport }
+  | { ok: false; error: string } {
+  const manifest = data.image_manifest;
+  if (!manifest) {
+    return {
+      ok: false,
+      error:
+        "This export has no image_manifest field. v0 requires the manifest to render the source images alongside the residuals.",
+    };
+  }
+  const root = joinPath(exportDir, manifest.root);
+  const frames: FrameKey[] = manifest.frames.map((f) => ({
+    pose: f.pose,
+    camera: f.camera,
+    label: `pose ${f.pose} · cam ${f.camera}`,
+    abs_path: joinPath(root, f.path),
+    roi: f.roi,
+  }));
+  if (frames.length === 0) {
+    return {
+      ok: false,
+      error:
+        "This export's image_manifest is empty. v0 needs at least one (pose, camera) frame to render.",
+    };
+  }
+
+  const poseSet = new Set<number>();
+  const cameraSet = new Set<number>();
+  const posesByCameraSet = new Map<number, Set<number>>();
+  const camerasByPoseSet = new Map<number, Set<number>>();
+  for (const f of frames) {
+    poseSet.add(f.pose);
+    cameraSet.add(f.camera);
+    if (!posesByCameraSet.has(f.camera)) {
+      posesByCameraSet.set(f.camera, new Set());
+    }
+    posesByCameraSet.get(f.camera)!.add(f.pose);
+    if (!camerasByPoseSet.has(f.pose)) {
+      camerasByPoseSet.set(f.pose, new Set());
+    }
+    camerasByPoseSet.get(f.pose)!.add(f.camera);
+  }
+  const sortNum = (s: Set<number>) => [...s].sort((a, b) => a - b);
+  const poseValues = sortNum(poseSet);
+  const cameraValues = sortNum(cameraSet);
+  const posesByCamera = new Map(
+    [...posesByCameraSet].map(([k, v]) => [k, sortNum(v)]),
+  );
+  const camerasByPose = new Map(
+    [...camerasByPoseSet].map(([k, v]) => [k, sortNum(v)]),
+  );
+
+  const first = frames[0];
+  const second =
+    frames.find((f) => f.pose !== first.pose || f.camera !== first.camera) ??
+    first;
+
+  return {
+    ok: true,
+    value: {
+      frames,
+      poseValues,
+      cameraValues,
+      posesByCamera,
+      camerasByPose,
+      first,
+      second,
+    },
+  };
+}
+
 export interface ExportSlice {
   exportPath: string | null;
   exportDir: string | null;
@@ -31,6 +113,7 @@ export interface ExportSlice {
   camerasByPose: Map<number, number[]>;
   loadError: string | null;
   loadExport: (path: string) => Promise<void>;
+  acceptLiveRunExport: (exportValue: unknown, exportDir: string) => void;
   resetExport: () => void;
   setLoadError: (msg: string | null) => void;
 }
@@ -91,68 +174,11 @@ export const useStore = create<AppState>()(
         return;
       }
       const data = result.export;
-      const manifest = data.image_manifest;
-      if (!manifest) {
-        // Reject the file. We deliberately do NOT promote it to the
-        // backend export cache — `compute_epipolar_overlay` (and any
-        // future math command) must keep operating against the
-        // previous accepted export until the user picks a valid one.
-        set({
-          loadError:
-            "This export has no image_manifest field. v0 requires the manifest to render the source images alongside the residuals.",
-        });
+      const materialized = materializeExport(data, result.export_dir);
+      if (!materialized.ok) {
+        set({ loadError: materialized.error });
         return;
       }
-      const root = joinPath(result.export_dir, manifest.root);
-      const frames: FrameKey[] = manifest.frames.map((f) => ({
-        pose: f.pose,
-        camera: f.camera,
-        label: `pose ${f.pose} · cam ${f.camera}`,
-        abs_path: joinPath(root, f.path),
-        roi: f.roi,
-      }));
-      if (frames.length === 0) {
-        set({
-          loadError:
-            "This export's image_manifest is empty. v0 needs at least one (pose, camera) frame to render.",
-        });
-        return;
-      }
-
-      // Build sparse availability indices off the actual manifest entries.
-      // A manifest may be sparse (detector failures, partial captures), so
-      // navigation must NOT walk a dense [0..max] Cartesian grid.
-      const poseSet = new Set<number>();
-      const cameraSet = new Set<number>();
-      const posesByCameraSet = new Map<number, Set<number>>();
-      const camerasByPoseSet = new Map<number, Set<number>>();
-      for (const f of frames) {
-        poseSet.add(f.pose);
-        cameraSet.add(f.camera);
-        if (!posesByCameraSet.has(f.camera)) {
-          posesByCameraSet.set(f.camera, new Set());
-        }
-        posesByCameraSet.get(f.camera)!.add(f.pose);
-        if (!camerasByPoseSet.has(f.pose)) {
-          camerasByPoseSet.set(f.pose, new Set());
-        }
-        camerasByPoseSet.get(f.pose)!.add(f.camera);
-      }
-      const sortNum = (s: Set<number>) => [...s].sort((a, b) => a - b);
-      const poseValues = sortNum(poseSet);
-      const cameraValues = sortNum(cameraSet);
-      const posesByCamera = new Map(
-        [...posesByCameraSet].map(([k, v]) => [k, sortNum(v)]),
-      );
-      const camerasByPose = new Map(
-        [...camerasByPoseSet].map(([k, v]) => [k, sortNum(v)]),
-      );
-
-      const first = frames[0];
-      const second =
-        frames.find(
-          (f) => f.pose !== first.pose || f.camera !== first.camera,
-        ) ?? first;
 
       // Promote the validated export into the backend cache *before*
       // updating the frontend state, so `compute_epipolar_overlay` and
@@ -171,16 +197,43 @@ export const useStore = create<AppState>()(
         exportDir: result.export_dir,
         data,
         kind: inferExportKind(data),
-        frames,
-        poseValues,
-        cameraValues,
-        posesByCamera,
-        camerasByPose,
+        frames: materialized.value.frames,
+        poseValues: materialized.value.poseValues,
+        cameraValues: materialized.value.cameraValues,
+        posesByCamera: materialized.value.posesByCamera,
+        camerasByPose: materialized.value.camerasByPose,
         loadError: null,
-        selectedPose: first.pose,
-        selectedPoseB: second.pose,
-        cameraA: first.camera,
-        cameraB: second.camera,
+        selectedPose: materialized.value.first.pose,
+        selectedPoseB: materialized.value.second.pose,
+        cameraA: materialized.value.first.camera,
+        cameraB: materialized.value.second.camera,
+        selectedFeature: null,
+        hoverFeature: null,
+      });
+    },
+
+    acceptLiveRunExport: (exportValue, exportDir) => {
+      const data = exportValue as AnyExport;
+      const materialized = materializeExport(data, exportDir);
+      if (!materialized.ok) {
+        set({ loadError: materialized.error });
+        return;
+      }
+      set({
+        exportPath: "<live-run>",
+        exportDir,
+        data,
+        kind: inferExportKind(data),
+        frames: materialized.value.frames,
+        poseValues: materialized.value.poseValues,
+        cameraValues: materialized.value.cameraValues,
+        posesByCamera: materialized.value.posesByCamera,
+        camerasByPose: materialized.value.camerasByPose,
+        loadError: null,
+        selectedPose: materialized.value.first.pose,
+        selectedPoseB: materialized.value.second.pose,
+        cameraA: materialized.value.first.camera,
+        cameraB: materialized.value.second.camera,
         selectedFeature: null,
         hoverFeature: null,
       });

--- a/app/src/workspaces/EpipolarWorkspace/index.tsx
+++ b/app/src/workspaces/EpipolarWorkspace/index.tsx
@@ -11,7 +11,7 @@ import {
   type FrameCanvasHandle,
 } from "../../components/FrameCanvas";
 import { PoseStepper } from "../../components/PoseStepper";
-import { useImageData } from "../../hooks/useImageData";
+import { useUndistortedImageData } from "../../hooks/useImageData";
 import {
   iso3DistanceM,
   iso3EulerXYZDeg,
@@ -231,8 +231,61 @@ function EpipolarBody(props: BodyProps) {
     () => residualsForPose.filter((r) => r.camera === cameraB),
     [residualsForPose, cameraB],
   );
+  const [undistortedResidualsA, setUndistortedResidualsA] = useState<
+    TargetFeatureResidual[]
+  >([]);
+  const [undistortedResidualsB, setUndistortedResidualsB] = useState<
+    TargetFeatureResidual[]
+  >([]);
+
+  const imageA = useUndistortedImageData(frameA, cameraA, setOverlayError);
+  const imageB = useUndistortedImageData(frameB, cameraB, setOverlayError);
 
   const latestRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      try {
+        const [pointsA, pointsB] = await Promise.all([
+          residualsA.length > 0
+            ? invoke<[number, number][]>("undistort_points", {
+                camera: cameraA,
+                pointsPx: residualsA.map((r) => r.observed_px),
+              })
+            : Promise.resolve<[number, number][]>([]),
+          residualsB.length > 0
+            ? invoke<[number, number][]>("undistort_points", {
+                camera: cameraB,
+                pointsPx: residualsB.map((r) => r.observed_px),
+              })
+            : Promise.resolve<[number, number][]>([]),
+        ]);
+        if (cancelled) return;
+        setUndistortedResidualsA(
+          residualsA.map((r, i) => ({
+            ...r,
+            observed_px: pointsA[i] ?? r.observed_px,
+          })),
+        );
+        setUndistortedResidualsB(
+          residualsB.map((r, i) => ({
+            ...r,
+            observed_px: pointsB[i] ?? r.observed_px,
+          })),
+        );
+      } catch (e) {
+        if (cancelled) return;
+        setUndistortedResidualsA([]);
+        setUndistortedResidualsB([]);
+        setOverlayError(`undistort points failed: ${e}`);
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [cameraA, cameraB, residualsA, residualsB, setOverlayError]);
 
   // Reset the overlay whenever the working tuple changes; bump the
   // request id so any in-flight response from the previous tuple is
@@ -252,7 +305,7 @@ function EpipolarBody(props: BodyProps) {
       let feature: number | null = null;
       let bestDist = FEATURE_SNAP_PX;
       let snappedPx: [number, number] = px;
-      for (const r of residualsA) {
+      for (const r of undistortedResidualsA) {
         const dx = r.observed_px[0] - px[0];
         const dy = r.observed_px[1] - px[1];
         const d = Math.hypot(dx, dy);
@@ -266,10 +319,21 @@ function EpipolarBody(props: BodyProps) {
       setOverlayError(null);
       latestRequestIdRef.current += 1;
       const myRequestId = latestRequestIdRef.current;
+      if (!imageB) {
+        setOverlay(null);
+        setOverlayError("epipolar overlay failed: pane-B undistorted image is not ready yet");
+        return;
+      }
       try {
         const result = await invoke<EpipolarOverlayResult>(
-          "compute_epipolar_overlay",
-          { camA: cameraA, camB: cameraB, pointPx: snappedPx },
+          "compute_epipolar_overlay_undistorted",
+          {
+            camA: cameraA,
+            camB: cameraB,
+            pointPx: snappedPx,
+            imageWidthB: imageB.naturalWidth,
+            imageHeightB: imageB.naturalHeight,
+          },
         );
         if (myRequestId !== latestRequestIdRef.current) return;
         setOverlay(result);
@@ -279,38 +343,23 @@ function EpipolarBody(props: BodyProps) {
         setOverlayError(`epipolar overlay failed: ${e}`);
       }
     },
-    [cameraA, cameraB, residualsA, setOverlay, setOverlayError, setPicked],
+    [
+      cameraA,
+      cameraB,
+      imageB,
+      setOverlay,
+      setOverlayError,
+      setPicked,
+      undistortedResidualsA,
+    ],
   );
 
   const ghostInB = useMemo<TargetFeatureResidual | null>(() => {
     if (!picked || picked.feature == null) return null;
-    return residualsB.find((r) => r.feature === picked.feature) ?? null;
-  }, [picked, residualsB]);
+    return undistortedResidualsB.find((r) => r.feature === picked.feature) ?? null;
+  }, [picked, undistortedResidualsB]);
 
-  // Polyline clipped strictly to pane-B's image bounds + split on
-  // unphysically large jumps. The Rust side sweeps depths from 0.05 m
-  // to 5 m, which is wider than any real dataset's working volume —
-  // most samples land outside the image and pull the polyline into a
-  // long curve (distortion gets visually amplified far from the
-  // principal point). On top of that, when cam A's ray approaches
-  // cam B's optical axis the projection passes through a near-
-  // singular fold zone and consecutive samples can land hundreds of
-  // pixels apart on opposite sides of the epipolar line — visually a
-  // "parabola" / fork. We keep only the longest contiguous in-image
-  // run AND require that consecutive surviving samples are close
-  // enough that the line is physically plausible.
-  const clippedPolyline = useMemo<[number, number][] | undefined>(() => {
-    if (!overlay || overlay.line_b.length < 2) return undefined;
-    if (!frameB) return overlay.line_b;
-    const w = frameB.roi?.w ?? 0;
-    const h = frameB.roi?.h ?? 0;
-    if (w === 0 || h === 0) return overlay.line_b;
-    // Quarter-frame jumps between consecutive depth samples are
-    // physically impossible for a smooth epipolar line and reliably
-    // indicate a fold-through-singularity in the projection.
-    const jumpPx = Math.min(w, h) * 0.25;
-    return longestContinuousRun(overlay.line_b, w, h, jumpPx);
-  }, [overlay, frameB]);
+  const clippedPolyline = overlay && overlay.line_b.length >= 2 ? overlay.line_b : undefined;
 
   // Distance from the corresponding pane-B feature to the polyline in
   // pixels — the calibration's epipolar residual for the picked
@@ -332,42 +381,42 @@ function EpipolarBody(props: BodyProps) {
 
   const tieMarkersA = useMemo<OverlayPoint[]>(() => {
     if (!showTieLines) return [];
-    return residualsA.map((r) => ({
+    return undistortedResidualsA.map((r) => ({
       px: r.observed_px,
       color: "var(--color-muted-foreground, #888)",
       dot: true,
       size: 4,
     }));
-  }, [showTieLines, residualsA]);
+  }, [showTieLines, undistortedResidualsA]);
 
   const tieMarkersB = useMemo<OverlayPoint[]>(() => {
     if (!showTieLines) return [];
-    return residualsB.map((r) => ({
+    return undistortedResidualsB.map((r) => ({
       px: r.observed_px,
       color: "var(--color-muted-foreground, #888)",
       dot: true,
       size: 4,
     }));
-  }, [showTieLines, residualsB]);
+  }, [showTieLines, undistortedResidualsB]);
 
   const featureMarkersA = useMemo<OverlayPoint[]>(() => {
     if (!showFeatures) return [];
-    return residualsA.map((r) => ({
+    return undistortedResidualsA.map((r) => ({
       px: r.observed_px,
       color: "var(--color-accent, #888)",
       dot: true,
       size: 6,
     }));
-  }, [showFeatures, residualsA]);
+  }, [showFeatures, undistortedResidualsA]);
   const featureMarkersB = useMemo<OverlayPoint[]>(() => {
     if (!showFeatures) return [];
-    return residualsB.map((r) => ({
+    return undistortedResidualsB.map((r) => ({
       px: r.observed_px,
       color: "var(--color-accent, #888)",
       dot: true,
       size: 6,
     }));
-  }, [showFeatures, residualsB]);
+  }, [showFeatures, undistortedResidualsB]);
 
   const markersA: OverlayPoint[] = [
     ...featureMarkersA,
@@ -502,23 +551,23 @@ function EpipolarBody(props: BodyProps) {
       <div className="grid min-h-0 flex-1 grid-cols-2 gap-2 overflow-hidden rounded-md bg-bg-soft p-2">
         <Pane
           frame={frameA}
-          residuals={residualsForPose}
           transform={linked ? linkedTransform : transformA}
           onTransformChange={linked ? setLinkedTransform : setTransformA}
           onPick={handlePickA}
           markers={markersA}
-          caption={frameA ? `pane A · cam ${cameraA}${showFeatures ? " · click feature or anywhere" : " · click to pick"}` : undefined}
+          image={imageA?.image ?? null}
+          caption={frameA ? `pane A · cam ${cameraA} · undistorted${showFeatures ? " · click feature or anywhere" : " · click to pick"}` : undefined}
           handleRef={handleARef}
         />
         <Pane
           frame={frameB}
-          residuals={residualsForPose}
           transform={linked ? linkedTransform : transformB}
           onTransformChange={linked ? setLinkedTransform : setTransformB}
           polyline={clippedPolyline}
           polylineColor="var(--color-brand, #1abc9c)"
           markers={markersB}
-          caption={frameB ? `pane B · cam ${cameraB}` : undefined}
+          image={imageB?.image ?? null}
+          caption={frameB ? `pane B · cam ${cameraB} · undistorted` : undefined}
           handleRef={handleBRef}
           annotation={
             ghostInB && ghostDistancePx != null
@@ -538,69 +587,6 @@ function EpipolarBody(props: BodyProps) {
       </div>
     </section>
   );
-}
-
-/** Return the longest contiguous run of polyline points that
- * (a) fall inside `[0, w] × [0, h]` AND
- * (b) sit within `jumpPx` of the previous in-run point.
- *
- * The Rust side densely samples depths along the back-projected ray;
- * only some samples project inside pane B's image. Filtering
- * in-bounds points and re-stitching them into one polyline draws a
- * "straight bridge" across out-of-image gaps, which looks like a
- * curve. Worse, when the ray passes near cam B's principal axis the
- * projection wraps around a near-singularity and consecutive in-image
- * samples can land hundreds of pixels apart on opposite sides of the
- * actual epipolar line — visually a fork / "parabola". Picking the
- * single longest run that survives both filters sidesteps both
- * artefacts. */
-function longestContinuousRun(
-  pts: [number, number][],
-  w: number,
-  h: number,
-  jumpPx: number,
-): [number, number][] {
-  let bestStart = 0;
-  let bestLen = 0;
-  let curStart = -1;
-  let curLen = 0;
-  const flushIfBetter = () => {
-    if (curLen > bestLen) {
-      bestLen = curLen;
-      bestStart = curStart;
-    }
-  };
-  const reset = (i: number) => {
-    flushIfBetter();
-    curStart = i;
-    curLen = 0;
-  };
-  const inBounds = (x: number, y: number) => x >= 0 && x <= w && y >= 0 && y <= h;
-  for (let i = 0; i < pts.length; i++) {
-    const [x, y] = pts[i];
-    if (!inBounds(x, y)) {
-      if (curLen > 0) reset(-1);
-      continue;
-    }
-    if (curStart < 0) {
-      curStart = i;
-      curLen = 1;
-      continue;
-    }
-    const [px, py] = pts[curStart + curLen - 1];
-    const dx = x - px;
-    const dy = y - py;
-    if (dx * dx + dy * dy > jumpPx * jumpPx) {
-      // Singularity-induced fold: end the current run at `i-1` and
-      // start a new one at `i`.
-      reset(i);
-      curLen = 1;
-      continue;
-    }
-    curLen += 1;
-  }
-  flushIfBetter();
-  return bestLen > 0 ? pts.slice(bestStart, bestStart + bestLen) : [];
 }
 
 function distanceToPolyline(
@@ -635,7 +621,6 @@ function distanceToSegment(
 
 interface PaneProps {
   frame: FrameKey | null;
-  residuals: TargetFeatureResidual[];
   transform: ViewportTransform;
   onTransformChange: (t: ViewportTransform) => void;
   onPick?: (pixel: { x: number; y: number }) => void;
@@ -643,13 +628,13 @@ interface PaneProps {
   polylineColor?: string;
   markers?: OverlayPoint[];
   caption?: string;
+  image: HTMLImageElement | null;
   handleRef: React.MutableRefObject<FrameCanvasHandle | null>;
   annotation?: { px: [number, number]; text: string; color: string };
 }
 
 function Pane({
   frame,
-  residuals,
   transform,
   onTransformChange,
   onPick,
@@ -657,6 +642,7 @@ function Pane({
   polylineColor,
   markers,
   caption,
+  image,
   handleRef,
   annotation,
 }: PaneProps) {
@@ -671,7 +657,6 @@ function Pane({
     <PaneInner
       key={frame.abs_path}
       frame={frame}
-      residuals={residuals}
       transform={transform}
       onTransformChange={onTransformChange}
       onPick={onPick}
@@ -679,6 +664,7 @@ function Pane({
       polylineColor={polylineColor}
       markers={markers}
       caption={caption}
+      image={image}
       handleRef={handleRef}
       annotation={annotation}
     />
@@ -687,7 +673,6 @@ function Pane({
 
 function PaneInner({
   frame,
-  residuals,
   transform,
   onTransformChange,
   onPick,
@@ -695,18 +680,22 @@ function PaneInner({
   polylineColor,
   markers,
   caption,
+  image,
   handleRef,
   annotation,
 }: PaneProps & { frame: FrameKey }) {
-  const image = useImageData(frame);
+  const displayFrame = useMemo<FrameKey>(
+    () => ({ ...frame, roi: undefined }),
+    [frame],
+  );
   return (
     <div className="relative flex h-full flex-col">
       <div className="relative flex-1 overflow-hidden">
         <FrameCanvas
           ref={handleRef}
-          frame={frame}
-          residuals={residuals}
-          image={image?.image ?? null}
+          frame={displayFrame}
+          residuals={[]}
+          image={image}
           transform={transform}
           onTransformChange={onTransformChange}
           onPick={onPick}

--- a/app/src/workspaces/RunWorkspace/index.tsx
+++ b/app/src/workspaces/RunWorkspace/index.tsx
@@ -22,9 +22,10 @@ import * as TOML from "toml";
 
 import { ConfigForm, type JsonSchema } from "../../lib/configForm";
 import { runCalibration, type RunResponse } from "../../lib/runCalibration";
-import { isTauriContext, joinPath } from "../../lib/tauri";
+import { isTauriContext } from "../../lib/tauri";
 import datasetSchemaJson from "../../schemas/dataset_spec.json";
 import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
+import { useStore } from "../../store";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { PresetCard } from "./PresetCard";
 import { BUILTIN_PRESETS, type EnabledPreset } from "./presets";
@@ -60,7 +61,7 @@ const DEFAULT_PLANAR_CONFIG: unknown = {
   zero_skew: true,
   max_iters: 50,
   verbosity: 0,
-  robust_loss: { type: "None" },
+  robust_loss: "None",
   fix_intrinsics: { fx: false, fy: false, cx: false, cy: false },
   fix_distortion: { k1: false, k2: false, k3: true, p1: false, p2: false },
   fix_poses: [],
@@ -81,6 +82,7 @@ type RunStatus =
 export function RunWorkspace() {
   const navigate = useNavigate();
   const inTauri = isTauriContext();
+  const acceptLiveRunExport = useStore((s) => s.acceptLiveRunExport);
 
   // Preset state — null means "no preset selected / custom".
   const [activePresetId, setActivePresetId] = useState<string | null>(null);
@@ -118,7 +120,7 @@ export function RunWorkspace() {
   const configSummary = useMemo<string>(() => {
     const c = config as Record<string, unknown>;
     const iters = typeof c?.max_iters === "number" ? c.max_iters : "?";
-    const loss = (c?.robust_loss as Record<string, unknown> | undefined)?.type ?? "None";
+    const loss = robustLossLabel(c?.robust_loss);
     return `max_iters=${iters} · loss=${loss}`;
   }, [config]);
 
@@ -246,6 +248,9 @@ export function RunWorkspace() {
 
   const handleResponse = (response: RunResponse) => {
     if (response.kind === "ok") {
+      if (manifestDir) {
+        acceptLiveRunExport(response.export, manifestDir);
+      }
       setStatus({
         kind: "ok",
         durationMs: response.duration_ms,
@@ -379,6 +384,17 @@ export function RunWorkspace() {
       </CollapsibleSection>
     </div>
   );
+}
+
+function robustLossLabel(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.type === "string") return obj.type;
+    const key = Object.keys(obj)[0];
+    if (key) return key;
+  }
+  return "None";
 }
 
 // ── Quick-start grid ─────────────────────────────────────────────────────────
@@ -597,8 +613,3 @@ function SpinnerIcon() {
     </svg>
   );
 }
-
-// Keep joinPath in scope (it's imported at the top and referenced in
-// path-derivation logic; TypeScript would otherwise flag it unused).
-// The actual invocations are inside the handlers above.
-void joinPath; // used: imported from lib/tauri for path building in handlePickManifest

--- a/app/src/workspaces/Viewer3DWorkspace/CameraFrustum.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/CameraFrustum.tsx
@@ -1,5 +1,6 @@
+import { Html } from "@react-three/drei";
 import { useMemo } from "react";
-import { BufferGeometry, Float32BufferAttribute, type Object3D } from "three";
+import { BufferGeometry, DoubleSide, Float32BufferAttribute, type Object3D } from "three";
 import { iso3InverseFromWire } from "../../lib/se3";
 import type { Iso3Wire, PinholeCameraWire } from "../../store/types";
 
@@ -29,6 +30,8 @@ interface CameraFrustumProps {
   active: boolean;
   /** Click handler — clicking the frustum sets cameraA in the store. */
   onSelect?: () => void;
+  /** Compact label shown for the active camera. */
+  label?: string;
 }
 
 /** Wireframe pyramid representing a calibrated pinhole camera. The
@@ -43,6 +46,7 @@ export function CameraFrustum({
   color,
   active,
   onSelect,
+  label,
 }: CameraFrustumProps) {
   const matrix = useMemo(() => iso3InverseFromWire(camSe3Rig), [camSe3Rig]);
 
@@ -54,14 +58,12 @@ export function CameraFrustum({
   ]);
 
   const geom = useMemo(() => buildEdgeGeometry(corners), [corners]);
+  const farPlaneGeom = useMemo(() => buildFarPlaneHitbox(corners), [corners]);
 
-  // Far-plane hitbox: a transparent quad covering the full far plane
-  // of the frustum. Three.js's raycaster doesn't intersect line
-  // geometry by default, so without this hitbox the only clickable
-  // surface is the small apex sphere — and most users naturally try
-  // to click on the visible far quad. The mesh has `visible={false}`
-  // so it draws nothing but still participates in raycasting.
-  const hitboxGeom = useMemo(() => buildFarPlaneHitbox(corners), [corners]);
+  // Whole-frustum hitbox: transparent side faces + far plane. Three.js's
+  // raycaster doesn't intersect line geometry, and a single front-sided
+  // far plane made selection feel arbitrary from most orbit angles.
+  const hitboxGeom = useMemo(() => buildFrustumHitbox(corners), [corners]);
 
   return (
     <group
@@ -86,18 +88,53 @@ export function CameraFrustum({
       {/* Wireframe edges — visual only. Opt out of raycast so clicks
         pass through to the hitbox below. */}
       <lineSegments geometry={geom} raycast={NO_RAYCAST}>
-        <lineBasicMaterial color={color} linewidth={active ? 2 : 1} />
+        <lineBasicMaterial
+          color={color}
+          linewidth={active ? 3 : 1}
+          transparent
+          opacity={active ? 1 : 0.55}
+        />
       </lineSegments>
+      {active && (
+        <lineSegments geometry={geom} raycast={NO_RAYCAST}>
+          <lineBasicMaterial color="#ffffff" linewidth={1} transparent opacity={0.55} />
+        </lineSegments>
+      )}
+      <mesh geometry={farPlaneGeom} raycast={NO_RAYCAST}>
+        <meshBasicMaterial
+          color={color}
+          transparent
+          opacity={active ? 0.16 : 0.035}
+          side={DoubleSide}
+          depthWrite={false}
+        />
+      </mesh>
       {/* Apex marker — visual only. */}
       <mesh raycast={NO_RAYCAST}>
-        <sphereGeometry args={[farDepth * 0.06, 12, 8]} />
-        <meshBasicMaterial color={color} transparent opacity={active ? 0.9 : 0.45} />
+        <sphereGeometry args={[farDepth * (active ? 0.095 : 0.06), 16, 10]} />
+        <meshBasicMaterial color={color} transparent opacity={active ? 1 : 0.45} />
       </mesh>
-      {/* Invisible far-plane hitbox. The `visible={false}` flag stops
-        Three from rasterising this mesh, but the raycaster still
-        considers it. */}
-      <mesh geometry={hitboxGeom} visible={false}>
-        <meshBasicMaterial transparent opacity={0} />
+      {active &&
+        corners.map((corner, i) => (
+          <mesh key={`corner-${i}`} position={corner} raycast={NO_RAYCAST}>
+            <sphereGeometry args={[farDepth * 0.05, 12, 8]} />
+            <meshBasicMaterial color={color} transparent opacity={0.95} />
+          </mesh>
+        ))}
+      {active && label && (
+        <Html position={[0, -farDepth * 0.18, 0]} center style={{ pointerEvents: "none" }}>
+          <span className="rounded border border-brand/70 bg-bg-soft/90 px-1.5 py-0.5 font-mono text-[10px] text-brand shadow-sm">
+            {label}
+          </span>
+        </Html>
+      )}
+      {/* Invisible but raycastable camera body. */}
+      <mesh geometry={hitboxGeom}>
+        <meshBasicMaterial transparent opacity={0} side={DoubleSide} depthWrite={false} />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[farDepth * 0.14, 12, 8]} />
+        <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
     </group>
   );
@@ -158,4 +195,41 @@ function buildFarPlaneHitbox(
   const g = new BufferGeometry();
   g.setAttribute("position", new Float32BufferAttribute(verts, 3));
   return g;
+}
+
+/** Build a two-sided transparent frustum hull for picking: four side
+ * triangles plus the far-plane quad. Corners are padded around the
+ * far-plane center so near-edge clicks still feel intentional. */
+function buildFrustumHitbox(
+  corners: [number, number, number][],
+): BufferGeometry {
+  const padded = padCorners(corners, 1.18);
+  const apex: [number, number, number] = [0, 0, 0];
+  const [a, b, c, d] = padded;
+  const verts: number[] = [
+    ...apex, ...a, ...b,
+    ...apex, ...b, ...c,
+    ...apex, ...c, ...d,
+    ...apex, ...d, ...a,
+    ...a, ...b, ...c,
+    ...a, ...c, ...d,
+  ];
+  const g = new BufferGeometry();
+  g.setAttribute("position", new Float32BufferAttribute(verts, 3));
+  return g;
+}
+
+function padCorners(
+  corners: [number, number, number][],
+  scale: number,
+): [number, number, number][] {
+  const center = corners.reduce<[number, number, number]>(
+    (acc, c) => [acc[0] + c[0] / 4, acc[1] + c[1] / 4, acc[2] + c[2] / 4],
+    [0, 0, 0],
+  );
+  return corners.map((c) => [
+    center[0] + (c[0] - center[0]) * scale,
+    center[1] + (c[1] - center[1]) * scale,
+    center[2] + (c[2] - center[2]) * scale,
+  ]);
 }

--- a/app/src/workspaces/Viewer3DWorkspace/Scene.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/Scene.tsx
@@ -104,6 +104,7 @@ export function Scene({
             color={i === cameraA ? colors.active : colors.inactive}
             active={i === cameraA}
             onSelect={() => setCamera(i, "A")}
+            label={`cam ${i}`}
           />
         );
       })}

--- a/crates/vision-calibration-detect/Cargo.toml
+++ b/crates/vision-calibration-detect/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 [features]
 default = ["chessboard"]
-chessboard = ["dep:chess-corners", "dep:calib-targets"]
+chessboard = ["dep:calib-targets"]
 schemars = ["dep:schemars"]
 
 [dependencies]
@@ -23,7 +23,6 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 image = { workspace = true }
 schemars = { workspace = true, optional = true }
-chess-corners = { workspace = true, optional = true }
 calib-targets = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/vision-calibration-detect/src/chessboard.rs
+++ b/crates/vision-calibration-detect/src/chessboard.rs
@@ -8,7 +8,6 @@
 use anyhow::{Result, anyhow};
 use calib_targets::chessboard::DetectorParams as ChessboardDetectorParams;
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -52,9 +51,9 @@ impl Detector for ChessboardDetector {
         // The underlying detector auto-labels corners from
         // intersection clustering — `rows`/`cols` from our config are
         // used only for output validation, not as input parameters.
-        // `chess-corners` provides defaults tuned for typical
-        // 5–13 mm calibration boards.
-        let _chess_config = ChessConfig::default();
+        // ChESS corner config is fixed inside `detect::detect_chessboard`
+        // (uses `default_chess_config()`); callers needing custom ChESS
+        // parameters must drop down to `chessboard::Detector::detect`.
         let board_params = ChessboardDetectorParams::default();
 
         let detection = detect::detect_chessboard(&luma, &board_params);

--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 image = { version = "0.25" }
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
-calib-targets = "0.7"
+calib-targets = "0.8"
 vision-metrology = { path = "../../../vision-metrology/crates/vision-metrology" }
 vm-primitives = { path = "../../../vision-metrology/crates/vm-primitives" }
 

--- a/crates/vision-calibration/Cargo.toml
+++ b/crates/vision-calibration/Cargo.toml
@@ -20,7 +20,6 @@ anyhow.workspace = true
 
 [dev-dependencies]
 serde_json = { workspace = true }
-chess-corners = { workspace = true }
 calib-targets = { workspace = true }
 image = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/vision-calibration/examples/handeye_session.rs
+++ b/crates/vision-calibration/examples/handeye_session.rs
@@ -19,7 +19,6 @@
 mod handeye_io;
 
 use anyhow::Result;
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use vision_calibration::optim::HandEyeMode;
@@ -50,12 +49,10 @@ fn main() -> Result<()> {
 
     // Load dataset with corner detection
     println!("\nLoading images and detecting corners...");
-    let chess_config = ChessConfig::default();
     let board_params = handeye_io::kuka_chessboard_params();
 
     let (samples, summary) = handeye_io::load_kuka_dataset_with_progress(
         &data_path,
-        &chess_config,
         &board_params,
         |current, total| {
             print!("\r  Processing image {current}/{total}...");

--- a/crates/vision-calibration/examples/manual_init_proof.rs
+++ b/crates/vision-calibration/examples/manual_init_proof.rs
@@ -24,7 +24,6 @@
 mod stereo_charuco_io;
 
 use anyhow::{Result, ensure};
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use stereo_charuco_io::{
@@ -58,13 +57,11 @@ fn main() -> Result<()> {
     );
     println!("Max views: {max_views}\n");
 
-    let chess_config = ChessConfig::default();
     let charuco_params = make_charuco_detector_params();
 
     let load = || -> Result<RigExtrinsicsInput> {
         let (input, summary) = load_stereo_charuco_input_with_progress(
             &data_dir,
-            &chess_config,
             &charuco_params,
             Some(max_views),
             |idx, total, suffix| {

--- a/crates/vision-calibration/examples/planar_real.rs
+++ b/crates/vision-calibration/examples/planar_real.rs
@@ -14,7 +14,6 @@
 use anyhow::{Context, Result};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use vision_calibration::planar_intrinsics::{
@@ -139,7 +138,6 @@ fn main() -> Result<()> {
 }
 
 fn load_views_with_progress(imgs_dir: &Path) -> Result<Vec<CorrespondenceView>> {
-    let chess_config = ChessConfig::default();
     let board_params = DetectorParams::default();
 
     // Find all left camera images
@@ -168,7 +166,7 @@ fn load_views_with_progress(imgs_dir: &Path) -> Result<Vec<CorrespondenceView>> 
         io::stdout().flush()?;
 
         let path = imgs_dir.join(format!("Im_L_{}.png", idx));
-        match detect_chessboard(&path, &chess_config, &board_params) {
+        match detect_chessboard(&path, &board_params) {
             Ok(Some(view)) => views.push(view),
             Ok(None) => skipped += 1,
             Err(e) => {
@@ -188,7 +186,6 @@ fn load_views_with_progress(imgs_dir: &Path) -> Result<Vec<CorrespondenceView>> 
 
 fn detect_chessboard(
     path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
 ) -> Result<Option<CorrespondenceView>> {
     let img = image::ImageReader::open(path)

--- a/crates/vision-calibration/examples/stereo_charuco_session.rs
+++ b/crates/vision-calibration/examples/stereo_charuco_session.rs
@@ -17,7 +17,6 @@
 mod stereo_charuco_io;
 
 use anyhow::{Result, ensure};
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use stereo_charuco_io::{
@@ -54,13 +53,11 @@ fn main() -> Result<()> {
     }
     println!();
 
-    let chess_config = ChessConfig::default();
     let charuco_params = make_charuco_detector_params();
 
     println!("Detecting ChArUco corners...");
     let (input, summary) = load_stereo_charuco_input_with_progress(
         &data_dir,
-        &chess_config,
         &charuco_params,
         max_views,
         |idx, total, suffix| {
@@ -167,7 +164,6 @@ fn main() -> Result<()> {
     println!("--- Alternative: single facade function ---");
     let (input2, _summary2) = load_stereo_charuco_input_with_progress(
         &data_dir,
-        &chess_config,
         &charuco_params,
         max_views,
         |idx, total, suffix| {

--- a/crates/vision-calibration/examples/stereo_session.rs
+++ b/crates/vision-calibration/examples/stereo_session.rs
@@ -18,7 +18,6 @@ mod stereo_io;
 
 use anyhow::{Result, ensure};
 use calib_targets::chessboard::DetectorParams;
-use chess_corners::ChessConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use stereo_io::load_stereo_input_with_progress;
@@ -59,13 +58,11 @@ fn main() -> Result<()> {
     }
     println!();
 
-    let chess_config = ChessConfig::default();
     let board_params = DetectorParams::default();
 
     println!("Detecting chessboard corners...");
     let (input, summary) = load_stereo_input_with_progress(
         &imgs_dir,
-        &chess_config,
         &board_params,
         SQUARE_SIZE_M,
         max_views,
@@ -184,7 +181,6 @@ fn main() -> Result<()> {
     println!("--- Alternative: single facade function ---");
     let (input2, _summary2) = load_stereo_input_with_progress(
         &imgs_dir,
-        &chess_config,
         &board_params,
         SQUARE_SIZE_M,
         max_views,

--- a/crates/vision-calibration/examples/support/handeye_io.rs
+++ b/crates/vision-calibration/examples/support/handeye_io.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use image::ImageReader;
 use nalgebra::{Matrix3, Rotation3, Translation3, UnitQuaternion, Vector3};
 use std::path::Path;
@@ -34,7 +33,6 @@ pub fn kuka_chessboard_params() -> DetectorParams {
 
 pub fn load_kuka_dataset_with_progress<F>(
     base_path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
     mut progress: F,
 ) -> Result<(Vec<ViewSample>, DatasetSummary)>

--- a/crates/vision-calibration/examples/support/rig_handeye_io.rs
+++ b/crates/vision-calibration/examples/support/rig_handeye_io.rs
@@ -6,7 +6,6 @@
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use image::ImageReader;
 use std::path::Path;
 use vision_calibration::core::{CorrespondenceView, Iso3, Pt3, Real, Vec2};
@@ -32,7 +31,6 @@ fn image2_filename(index: usize) -> String {
 
 pub fn load_rig_handeye_input_with_progress<F>(
     imgs_dir: &Path,
-    chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: Real,
     max_views: Option<usize>,
@@ -93,11 +91,11 @@ where
             img2_path.display()
         );
 
-        let view0 = detect_view(&img0_path, chess_config, board_params, square_size_m)
+        let view0 = detect_view(&img0_path, board_params, square_size_m)
             .with_context(|| format!("failed to detect view for {}", img0_path.display()))?;
-        let view1 = detect_view(&img1_path, chess_config, board_params, square_size_m)
+        let view1 = detect_view(&img1_path, board_params, square_size_m)
             .with_context(|| format!("failed to detect view for {}", img1_path.display()))?;
-        let view2 = detect_view(&img2_path, chess_config, board_params, square_size_m)
+        let view2 = detect_view(&img2_path, board_params, square_size_m)
             .with_context(|| format!("failed to detect view for {}", img2_path.display()))?;
 
         // Skip if all cameras failed to detect
@@ -151,7 +149,6 @@ where
 
 fn detect_view(
     path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: Real,
 ) -> Result<Option<CorrespondenceView>> {

--- a/crates/vision-calibration/examples/support/stereo_charuco_io.rs
+++ b/crates/vision-calibration/examples/support/stereo_charuco_io.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result, ensure};
 use calib_targets::aruco::builtins;
 use calib_targets::charuco::{CharucoBoardSpec, CharucoParams, MarkerLayout};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use vision_calibration::prelude::*;
@@ -58,7 +57,6 @@ pub fn make_charuco_detector_params() -> CharucoParams {
 /// - right: `Cam2_<suffix>.png`
 pub fn load_stereo_charuco_input_with_progress<F>(
     base_dir: &Path,
-    chess_config: &ChessConfig,
     charuco_params: &CharucoParams,
     max_views: Option<usize>,
     mut progress: F,
@@ -109,9 +107,9 @@ where
             right_path.display()
         );
 
-        let left = detect_view(&left_path, chess_config, charuco_params)
+        let left = detect_view(&left_path, charuco_params)
             .with_context(|| format!("left detection failed for {}", left_path.display()))?;
-        let right = detect_view(&right_path, chess_config, charuco_params)
+        let right = detect_view(&right_path, charuco_params)
             .with_context(|| format!("right detection failed for {}", right_path.display()))?;
 
         if left.is_none() && right.is_none() {
@@ -188,11 +186,7 @@ fn list_stereo_pair_suffixes(left_dir: &Path, right_dir: &Path) -> Result<Vec<St
     Ok(left.intersection(&right).cloned().collect())
 }
 
-fn detect_view(
-    path: &Path,
-    _chess_config: &ChessConfig,
-    charuco_params: &CharucoParams,
-) -> Result<Option<CorrespondenceView>> {
+fn detect_view(path: &Path, charuco_params: &CharucoParams) -> Result<Option<CorrespondenceView>> {
     let img = image::ImageReader::open(path)
         .with_context(|| format!("failed to read image {}", path.display()))?
         .decode()

--- a/crates/vision-calibration/examples/support/stereo_io.rs
+++ b/crates/vision-calibration/examples/support/stereo_io.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::{Detection as ChessboardDetection, DetectorParams};
 use calib_targets::detect;
-use chess_corners::ChessConfig;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use vision_calibration::prelude::*;
@@ -34,7 +33,6 @@ pub struct StereoDatasetSummary {
 /// pairs.
 pub fn load_stereo_input_with_progress<F>(
     imgs_dir: &Path,
-    chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: f64,
     max_views: Option<usize>,
@@ -86,9 +84,9 @@ where
             right_path.display()
         );
 
-        let left = detect_view(&left_path, chess_config, board_params, square_size_m)
+        let left = detect_view(&left_path, board_params, square_size_m)
             .with_context(|| format!("left detection failed for {}", left_path.display()))?;
-        let right = detect_view(&right_path, chess_config, board_params, square_size_m)
+        let right = detect_view(&right_path, board_params, square_size_m)
             .with_context(|| format!("right detection failed for {}", right_path.display()))?;
 
         if left.is_none() && right.is_none() {
@@ -182,7 +180,6 @@ fn list_stereo_pair_indices(left_dir: &Path, right_dir: &Path) -> Result<Vec<usi
 
 fn detect_view(
     path: &Path,
-    _chess_config: &ChessConfig,
     board_params: &DetectorParams,
     square_size_m: f64,
 ) -> Result<Option<CorrespondenceView>> {

--- a/crates/vision-calibration/examples/viewer_fixtures.rs
+++ b/crates/vision-calibration/examples/viewer_fixtures.rs
@@ -23,7 +23,6 @@ mod stereo_io;
 
 use anyhow::{Context, Result, ensure};
 use calib_targets::chessboard::DetectorParams;
-use chess_corners::ChessConfig;
 use std::path::{Path, PathBuf};
 use stereo_charuco_io::{
     BOARD_CELL_SIZE_MM, BOARD_COLS, BOARD_DICTIONARY_NAME, BOARD_ROWS,
@@ -63,11 +62,9 @@ fn write_stereo_fixture(repo_root: &Path) -> Result<()> {
     );
 
     println!("[stereo] detecting chessboard corners (7×11, 30 mm)…");
-    let chess_config = ChessConfig::default();
     let board_params = DetectorParams::default();
     let (input, summary) = load_stereo_input_with_progress(
         &imgs_dir,
-        &chess_config,
         &board_params,
         STEREO_SQUARE_SIZE_M,
         None,
@@ -116,15 +113,9 @@ fn write_stereo_charuco_fixture(repo_root: &Path) -> Result<()> {
         "[stereo_charuco] detecting ChArUco corners ({BOARD_ROWS}×{BOARD_COLS} board, \
          cell {BOARD_CELL_SIZE_MM:.4} mm, dict {BOARD_DICTIONARY_NAME})…"
     );
-    let chess_config = ChessConfig::default();
     let charuco_params = make_charuco_detector_params();
-    let (input, summary) = load_stereo_charuco_input_with_progress(
-        &dataset_dir,
-        &chess_config,
-        &charuco_params,
-        None,
-        |_, _, _| {},
-    )?;
+    let (input, summary) =
+        load_stereo_charuco_input_with_progress(&dataset_dir, &charuco_params, None, |_, _, _| {})?;
     println!(
         "[stereo_charuco] {} pairs total, {} accepted ({} skipped); usable left={} right={}",
         summary.total_pairs,


### PR DESCRIPTION
## Summary

Fixes the three Tauri app issues reported on top of `b3-foundation-schema-driven`:

- Epipolar inspection now renders in an undistorted image/point frame and draws a clipped straight epipolar line from backend geometry.
- 3D camera picking now targets the full frustum hull, with clearer selected-camera visuals.
- Run calibration now accepts the generated serde robust-loss schema and sends successful live exports into Diagnose with an image manifest.

## Root Cause

- Epipolar overlays were being sampled/projected through distorted image geometry in the frontend, so a physically straight epipolar line could appear as a curve in raw distorted pixels.
- 3D camera raycasting only targeted the far projection plane, so many intuitive clicks on the frustum did not select the camera.
- The generated config used serde externally tagged enum shapes for robust loss, while the default app config used an internally tagged `{ type: ... }` object.

## Validation

- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path app/src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path app/src-tauri/Cargo.toml epipolar`
- `cargo test --manifest-path app/src-tauri/Cargo.toml`
- `cd app && bun run build`
- `git diff --check`

Manual Tauri visual checks were not launched in this session.