### PR TITLE
feat(detect): ChArUco detector + runner dispatch (B3c-1, PR 1/4)

### DIFF
--- a/app/src/schemas/dataset_spec.json
+++ b/app/src/schemas/dataset_spec.json
@@ -144,7 +144,7 @@
       "description": "How per-camera image lists align across views and (optionally)\nalign with robot poses.",
       "oneOf": [
         {
-          "description": "All cameras have the same number of images, paired by index\n(image[i] from cam0 ↔ image[i] from cam1 ↔ pose[i]).",
+          "description": "All cameras have the same number of images, paired by index\n(`image[i]` from cam0 ↔ `image[i]` from cam1 ↔ `pose[i]`).",
           "properties": {
             "kind": {
               "const": "by_index",

--- a/crates/vision-calibration-detect/Cargo.toml
+++ b/crates/vision-calibration-detect/Cargo.toml
@@ -12,8 +12,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["chessboard"]
+default = ["chessboard", "charuco"]
 chessboard = ["dep:calib-targets"]
+charuco = ["dep:calib-targets"]
 schemars = ["dep:schemars"]
 
 [dependencies]

--- a/crates/vision-calibration-detect/src/charuco.rs
+++ b/crates/vision-calibration-detect/src/charuco.rs
@@ -13,7 +13,8 @@
 use anyhow::{Result, anyhow};
 use calib_targets::aruco::builtins;
 use calib_targets::charuco::{
-    CharucoBoardSpec, CharucoDetector as CtCharucoDetector, CharucoParams, MarkerLayout,
+    CharucoBoard, CharucoBoardSpec, CharucoDetector as CtCharucoDetector, CharucoParams,
+    MarkerLayout,
 };
 use calib_targets::detect::{self, default_chess_config};
 use serde::{Deserialize, Serialize};
@@ -62,8 +63,38 @@ pub fn validate_dictionary(name: &str) -> Result<()> {
     }
 }
 
+/// Validate a full ChArUco board layout before any image I/O: the
+/// dictionary name must be known *and* hold enough marker codes for the
+/// requested `rows × cols` OpenCV layout. A larger board needs more
+/// markers (e.g. a 12×12 board needs 72, which `DICT_4X4_50` cannot
+/// supply), so validating the name alone is not enough — that lets an
+/// impossible board reach detection with a guaranteed-empty result. This
+/// subsumes [`validate_dictionary`]: an unknown name fails here too.
+/// Geometry (square/marker size) is checked separately by the detector.
+pub fn validate_charuco_layout(rows: u32, cols: u32, dictionary: &str) -> Result<()> {
+    let dictionary = builtins::builtin_dictionary(dictionary).ok_or_else(|| {
+        anyhow!(
+            "unknown ArUco dictionary {dictionary:?}; supported: {}",
+            builtins::BUILTIN_DICTIONARY_NAMES.join(", ")
+        )
+    })?;
+    // Unit geometry: `CharucoBoard::new` only inspects rows/cols and the
+    // dictionary capacity here; cell/marker size are placeholders.
+    let spec = CharucoBoardSpec {
+        rows,
+        cols,
+        cell_size: 1.0,
+        marker_size_rel: 0.5,
+        dictionary,
+        marker_layout: MarkerLayout::OpenCvCharuco,
+    };
+    CharucoBoard::new(spec)
+        .map(|_| ())
+        .map_err(|e| anyhow!("invalid charuco board: {e}"))
+}
+
 fn params_for(cfg: &CharucoConfig) -> Result<CharucoParams> {
-    validate_dictionary(&cfg.dictionary)?;
+    validate_charuco_layout(cfg.rows, cfg.cols, &cfg.dictionary)?;
     let dictionary = builtins::builtin_dictionary(&cfg.dictionary)
         .expect("validated above; builtin lookup is deterministic");
     if !(cfg.marker_size_m > 0.0 && cfg.marker_size_m <= cfg.square_size_m) {
@@ -202,6 +233,27 @@ mod tests {
             msg.contains("unknown ArUco dictionary") && msg.contains("DICT_4X4_50"),
             "error should name the bad dictionary and list supported ones, got: {msg}"
         );
+    }
+
+    #[test]
+    fn dictionary_too_small_for_board_rejected() {
+        // 12×12 needs 72 markers; DICT_4X4_50 only has 50.
+        assert!(validate_charuco_layout(8, 8, "DICT_4X4_50").is_ok());
+        let err = validate_charuco_layout(12, 12, "DICT_4X4_50").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("72") && msg.contains("50"),
+            "expected a needs-72/has-50 capacity error, got: {msg}"
+        );
+
+        // The detector itself must also reject the impossible board
+        // rather than silently returning no features.
+        let img = image::DynamicImage::new_luma8(64, 64);
+        let mut cfg = board_config();
+        cfg["rows"] = json!(12);
+        cfg["cols"] = json!(12);
+        let err = CharucoDetector.detect_json(&img, &cfg).unwrap_err();
+        assert!(format!("{err}").contains("charuco board"));
     }
 
     #[test]

--- a/crates/vision-calibration-detect/src/charuco.rs
+++ b/crates/vision-calibration-detect/src/charuco.rs
@@ -1,0 +1,222 @@
+//! ChArUco detector wrapping `chess-corners` + `calib-targets`.
+//!
+//! The detector returns one [`Feature`] per ChArUco corner whose marker-based
+//! identification succeeded. ChArUco correspondences are *sparse* — occluded
+//! or unidentified cells simply produce no feature — so the per-view feature
+//! count varies; the runner decides whether a view is usable.
+//!
+//! Canonical impl note: `vision-calibration-bench/src/detect.rs::detect_charuco_view`
+//! and the `examples-private` helper carry near-identical calib-targets glue
+//! with different output shapes. This is the canonical app-facing version;
+//! dedup of the other two is tracked as B3c follow-up.
+
+use anyhow::{Result, anyhow};
+use calib_targets::aruco::builtins;
+use calib_targets::charuco::{
+    CharucoBoardSpec, CharucoDetector as CtCharucoDetector, CharucoParams, MarkerLayout,
+};
+use calib_targets::detect::{self, default_chess_config};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
+use crate::{Detector, Feature};
+
+/// ChArUco detector configuration. Mirrors the shape of the charuco
+/// variant in `vision_calibration_dataset::TargetSpec` so the
+/// dispatcher can translate one to the other directly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CharucoConfig {
+    /// Number of squares along the rows axis (full grid, not interior
+    /// corners — ChArUco boards are described by their square counts).
+    pub rows: u32,
+    /// Number of squares along the cols axis.
+    pub cols: u32,
+    /// Edge length of one square in metres. The detector's board spec
+    /// is built in metres, so detected corners carry metric target
+    /// coordinates directly.
+    pub square_size_m: f64,
+    /// Edge length of an embedded ArUco marker in metres. Must be
+    /// smaller than `square_size_m`.
+    pub marker_size_m: f64,
+    /// ArUco dictionary identifier (e.g. `"DICT_4X4_50"`). Validated
+    /// against the embedded builtin set; see [`validate_dictionary`].
+    pub dictionary: String,
+}
+
+/// Check `name` against the ArUco dictionaries embedded in
+/// `calib-targets`. Lets the dispatcher fail fast on a manifest typo
+/// before touching any image files. The error lists the supported names.
+pub fn validate_dictionary(name: &str) -> Result<()> {
+    if builtins::builtin_dictionary(name).is_some() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "unknown ArUco dictionary {name:?}; supported: {}",
+            builtins::BUILTIN_DICTIONARY_NAMES.join(", ")
+        ))
+    }
+}
+
+fn params_for(cfg: &CharucoConfig) -> Result<CharucoParams> {
+    validate_dictionary(&cfg.dictionary)?;
+    let dictionary = builtins::builtin_dictionary(&cfg.dictionary)
+        .expect("validated above; builtin lookup is deterministic");
+    if !(cfg.marker_size_m > 0.0 && cfg.marker_size_m <= cfg.square_size_m) {
+        return Err(anyhow!(
+            "marker_size_m ({}) must be in (0, square_size_m = {}]",
+            cfg.marker_size_m,
+            cfg.square_size_m
+        ));
+    }
+    let board = CharucoBoardSpec {
+        rows: cfg.rows,
+        cols: cfg.cols,
+        cell_size: cfg.square_size_m as f32,
+        marker_size_rel: (cfg.marker_size_m / cfg.square_size_m) as f32,
+        dictionary,
+        marker_layout: MarkerLayout::OpenCvCharuco,
+    };
+    Ok(CharucoParams::for_board(&board))
+}
+
+/// Stateless ChArUco detector instance.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CharucoDetector;
+
+impl crate::sealed::Sealed for CharucoDetector {}
+
+impl Detector for CharucoDetector {
+    fn name(&self) -> &'static str {
+        "charuco"
+    }
+
+    fn detect_json(&self, image: &image::DynamicImage, config: &Value) -> Result<Vec<Feature>> {
+        let cfg: CharucoConfig = serde_json::from_value(config.clone())
+            .map_err(|e| anyhow!("invalid charuco config: {e}"))?;
+        let params = params_for(&cfg)?;
+        let luma = image.to_luma8();
+
+        // ChESS corner pre-detection feeds the ChArUco identifier; we
+        // use the default corner-stage config, matching the chessboard
+        // detector's choice.
+        let corners = detect::detect_corners(&luma, &default_chess_config());
+        let detector = CtCharucoDetector::new(params)?;
+        // A failed board identification (too few markers, no board in
+        // frame) is "no features", not an error — same semantics as
+        // the chessboard detector on a blank image.
+        let detection = match detector.detect(&detect::gray_view(&luma), &corners) {
+            Ok(detection) => detection,
+            Err(_) => return Ok(Vec::new()),
+        };
+
+        // `target_position` is metric because the board spec's
+        // `cell_size` was given in metres.
+        Ok(detection
+            .corners
+            .into_iter()
+            .map(|corner| Feature {
+                image_xy: [corner.position.x as f64, corner.position.y as f64],
+                world_xyz: [
+                    corner.target_position.x as f64,
+                    corner.target_position.y as f64,
+                    0.0,
+                ],
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // 8x8 squares => 32 markers in the OpenCV layout, which fits the
+    // 50-code DICT_4X4_50 dictionary.
+    fn board_config() -> Value {
+        json!({
+            "rows": 8,
+            "cols": 8,
+            "square_size_m": 0.020,
+            "marker_size_m": 0.015,
+            "dictionary": "DICT_4X4_50",
+        })
+    }
+
+    /// Render a synthetic frontal board via calib-targets' printable
+    /// pipeline and decode it back into a `DynamicImage`.
+    fn synthetic_board_image() -> image::DynamicImage {
+        let dictionary = builtins::builtin_dictionary("DICT_4X4_50").expect("builtin dict");
+        let document = calib_targets::generate::charuco_document(8, 8, 20.0, 0.75, dictionary);
+        let bundle =
+            calib_targets::printable::render_target_bundle(&document).expect("render bundle");
+        image::load_from_memory(&bundle.png_bytes).expect("decode rendered PNG")
+    }
+
+    #[test]
+    fn detects_synthetic_board() {
+        let img = synthetic_board_image();
+        let features = CharucoDetector.detect_json(&img, &board_config()).unwrap();
+        assert!(
+            features.len() >= 4,
+            "expected >= 4 corners on a clean frontal board, got {}",
+            features.len()
+        );
+        for f in &features {
+            assert_eq!(f.world_xyz[2], 0.0, "target is planar");
+            // Corners sit on the square lattice; allow float slack from
+            // the f32 target coordinates.
+            for &coord in &f.world_xyz[..2] {
+                let cells = coord / 0.020;
+                assert!(
+                    (cells - cells.round()).abs() < 1e-4,
+                    "world coord {coord} not on the 20 mm lattice"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_config_rejected() {
+        let img = image::DynamicImage::new_luma8(8, 8);
+        let err = CharucoDetector
+            .detect_json(&img, &json!({"rows": 12})) // missing the rest
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid charuco config"), "got: {msg}");
+    }
+
+    #[test]
+    fn unknown_dictionary_rejected() {
+        let img = image::DynamicImage::new_luma8(8, 8);
+        let mut cfg = board_config();
+        cfg["dictionary"] = json!("DICT_9X9_1");
+        let err = CharucoDetector.detect_json(&img, &cfg).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("unknown ArUco dictionary") && msg.contains("DICT_4X4_50"),
+            "error should name the bad dictionary and list supported ones, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn oversized_marker_rejected() {
+        let img = image::DynamicImage::new_luma8(8, 8);
+        let mut cfg = board_config();
+        cfg["marker_size_m"] = json!(0.021);
+        let err = CharucoDetector.detect_json(&img, &cfg).unwrap_err();
+        assert!(format!("{err}").contains("marker_size_m"));
+    }
+
+    #[test]
+    fn blank_image_returns_no_features() {
+        let img = image::DynamicImage::new_luma8(64, 64);
+        let features = CharucoDetector.detect_json(&img, &board_config()).unwrap();
+        assert!(features.is_empty(), "blank image should yield no features");
+    }
+}

--- a/crates/vision-calibration-detect/src/lib.rs
+++ b/crates/vision-calibration-detect/src/lib.rs
@@ -38,7 +38,7 @@ pub use cache::{
 pub use feature::Feature;
 
 #[cfg(feature = "charuco")]
-pub use charuco::{CharucoConfig, CharucoDetector, validate_dictionary};
+pub use charuco::{CharucoConfig, CharucoDetector, validate_charuco_layout, validate_dictionary};
 #[cfg(feature = "chessboard")]
 pub use chessboard::{ChessboardConfig, ChessboardDetector};
 

--- a/crates/vision-calibration-detect/src/lib.rs
+++ b/crates/vision-calibration-detect/src/lib.rs
@@ -27,6 +27,8 @@
 pub mod cache;
 mod feature;
 
+#[cfg(feature = "charuco")]
+mod charuco;
 #[cfg(feature = "chessboard")]
 mod chessboard;
 
@@ -35,6 +37,8 @@ pub use cache::{
 };
 pub use feature::Feature;
 
+#[cfg(feature = "charuco")]
+pub use charuco::{CharucoConfig, CharucoDetector, validate_dictionary};
 #[cfg(feature = "chessboard")]
 pub use chessboard::{ChessboardConfig, ChessboardDetector};
 

--- a/crates/vision-calibration-pipeline/src/dataset_runner.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner.rs
@@ -20,7 +20,8 @@ use vision_calibration_dataset::{
     DatasetSpec, ImagePattern, TargetSpec, Topology, ValidationError, validate,
 };
 use vision_calibration_detect::{
-    CacheKey, CachedFeatures, ChessboardDetector, DetectionCache, Detector, Feature,
+    CacheKey, CachedFeatures, CharucoDetector, ChessboardDetector, DetectionCache, Detector,
+    Feature, validate_dictionary,
 };
 
 /// Errors produced by the dataset-driven runner.
@@ -44,6 +45,15 @@ pub enum RunError {
     UnsupportedTarget {
         /// Discriminator from the manifest (e.g. `"ringgrid"`).
         kind: String,
+    },
+
+    /// Target config carries an invalid value (e.g. an unknown ArUco
+    /// dictionary name). Caught before any image I/O so manifest typos
+    /// fail fast.
+    #[error("invalid target config: {message}")]
+    InvalidTargetConfig {
+        /// Human-readable description of the bad field/value.
+        message: String,
     },
 
     /// Glob pattern produced no matches. The user almost certainly
@@ -297,9 +307,28 @@ fn target_to_detector_config(target: &TargetSpec) -> Result<(&'static str, Value
                 "square_size_m": *square_size_m,
             }),
         )),
-        TargetSpec::Charuco { .. } => Err(RunError::UnsupportedTarget {
-            kind: "charuco".to_string(),
-        }),
+        TargetSpec::Charuco {
+            rows,
+            cols,
+            square_size_m,
+            marker_size_m,
+            dictionary,
+        } => {
+            // Fail fast on a manifest typo before touching the filesystem.
+            validate_dictionary(dictionary).map_err(|e| RunError::InvalidTargetConfig {
+                message: e.to_string(),
+            })?;
+            Ok((
+                "charuco",
+                json!({
+                    "rows": *rows,
+                    "cols": *cols,
+                    "square_size_m": *square_size_m,
+                    "marker_size_m": *marker_size_m,
+                    "dictionary": dictionary,
+                }),
+            ))
+        }
         TargetSpec::Puzzleboard { .. } => Err(RunError::UnsupportedTarget {
             kind: "puzzleboard".to_string(),
         }),
@@ -312,6 +341,7 @@ fn target_to_detector_config(target: &TargetSpec) -> Result<(&'static str, Value
 fn pick_detector(name: &str) -> Result<Box<dyn Detector>, RunError> {
     match name {
         "chessboard" => Ok(Box::new(ChessboardDetector)),
+        "charuco" => Ok(Box::new(CharucoDetector)),
         other => Err(RunError::UnsupportedTarget {
             kind: other.to_string(),
         }),
@@ -436,12 +466,12 @@ mod tests {
     #[test]
     fn rejects_unsupported_target() {
         let mut spec = planar_spec_for_globless_test();
-        spec.target = TargetSpec::Charuco {
-            rows: 9,
-            cols: 6,
-            square_size_m: 0.025,
-            marker_size_m: 0.018,
-            dictionary: "DICT_4X4_50".into(),
+        spec.target = TargetSpec::Ringgrid {
+            rows: 5,
+            cols: 5,
+            spacing_m: 0.02,
+            inner_radius_m: 0.004,
+            outer_radius_m: 0.008,
         };
         spec.cameras[0].images = ImagePattern::Glob {
             pattern: "*.png".into(),
@@ -449,6 +479,43 @@ mod tests {
         let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
         let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
         assert!(matches!(err, RunError::UnsupportedTarget { .. }));
+    }
+
+    #[test]
+    fn charuco_target_maps_to_detector_config() {
+        let target = TargetSpec::Charuco {
+            rows: 12,
+            cols: 12,
+            square_size_m: 0.020,
+            marker_size_m: 0.015,
+            dictionary: "DICT_4X4_50".into(),
+        };
+        let (name, config) = target_to_detector_config(&target).unwrap();
+        assert_eq!(name, "charuco");
+        assert_eq!(config["dictionary"], "DICT_4X4_50");
+        assert_eq!(config["marker_size_m"], 0.015);
+        // The mapped config must deserialize into the detector's own
+        // config struct — guards the field-name contract between the
+        // manifest and the detect crate.
+        pick_detector(name).unwrap();
+    }
+
+    #[test]
+    fn charuco_bad_dictionary_fails_before_io() {
+        let target = TargetSpec::Charuco {
+            rows: 12,
+            cols: 12,
+            square_size_m: 0.020,
+            marker_size_m: 0.015,
+            dictionary: "DICT_TYPO_99".into(),
+        };
+        let err = target_to_detector_config(&target).unwrap_err();
+        match err {
+            RunError::InvalidTargetConfig { message } => {
+                assert!(message.contains("DICT_TYPO_99"), "got: {message}");
+            }
+            other => panic!("expected InvalidTargetConfig, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/dataset_runner.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner.rs
@@ -21,7 +21,7 @@ use vision_calibration_dataset::{
 };
 use vision_calibration_detect::{
     CacheKey, CachedFeatures, CharucoDetector, ChessboardDetector, DetectionCache, Detector,
-    Feature, validate_dictionary,
+    Feature, validate_charuco_layout,
 };
 
 /// Errors produced by the dataset-driven runner.
@@ -314,9 +314,13 @@ fn target_to_detector_config(target: &TargetSpec) -> Result<(&'static str, Value
             marker_size_m,
             dictionary,
         } => {
-            // Fail fast on a manifest typo before touching the filesystem.
-            validate_dictionary(dictionary).map_err(|e| RunError::InvalidTargetConfig {
-                message: e.to_string(),
+            // Fail fast before touching the filesystem on a manifest typo
+            // (unknown dictionary) or an impossible board whose layout
+            // needs more markers than the dictionary holds.
+            validate_charuco_layout(*rows, *cols, dictionary).map_err(|e| {
+                RunError::InvalidTargetConfig {
+                    message: e.to_string(),
+                }
             })?;
             Ok((
                 "charuco",
@@ -483,16 +487,18 @@ mod tests {
 
     #[test]
     fn charuco_target_maps_to_detector_config() {
+        // 12×12 needs 72 markers, so the dictionary must hold at least
+        // that many (DICT_4X4_50 would be rejected — see the capacity test).
         let target = TargetSpec::Charuco {
             rows: 12,
             cols: 12,
             square_size_m: 0.020,
             marker_size_m: 0.015,
-            dictionary: "DICT_4X4_50".into(),
+            dictionary: "DICT_4X4_100".into(),
         };
         let (name, config) = target_to_detector_config(&target).unwrap();
         assert_eq!(name, "charuco");
-        assert_eq!(config["dictionary"], "DICT_4X4_50");
+        assert_eq!(config["dictionary"], "DICT_4X4_100");
         assert_eq!(config["marker_size_m"], 0.015);
         // The mapped config must deserialize into the detector's own
         // config struct — guards the field-name contract between the
@@ -513,6 +519,30 @@ mod tests {
         match err {
             RunError::InvalidTargetConfig { message } => {
                 assert!(message.contains("DICT_TYPO_99"), "got: {message}");
+            }
+            other => panic!("expected InvalidTargetConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn charuco_dictionary_too_small_for_board_fails_before_io() {
+        // A 12×12 board needs 72 markers in the OpenCV layout; DICT_4X4_50
+        // only holds 50, so the manifest is impossible and must be
+        // rejected up front rather than reaching a guaranteed-empty detect.
+        let target = TargetSpec::Charuco {
+            rows: 12,
+            cols: 12,
+            square_size_m: 0.020,
+            marker_size_m: 0.015,
+            dictionary: "DICT_4X4_50".into(),
+        };
+        let err = target_to_detector_config(&target).unwrap_err();
+        match err {
+            RunError::InvalidTargetConfig { message } => {
+                assert!(
+                    message.contains("72") && message.contains("50"),
+                    "expected a needs-72/has-50 capacity error, got: {message}"
+                );
             }
             other => panic!("expected InvalidTargetConfig, got {other:?}"),
         }


### PR DESCRIPTION
First of four PRs for the **B3c-1** iteration (Run-workspace coverage: charuco + RigHandeye + cheap-win topologies; see docs/ROADMAP.md, B3c sequencing for the V-track).

## What
- New `CharucoDetector` in `vision-calibration-detect` behind a default-on `charuco` feature, ported from the canonical bench `detect_charuco_view` logic (ChESS corners → calib-targets ChArUco identification). Sparse metric features; a failed board identification yields zero features, matching chessboard semantics.
- `CharucoConfig` mirrors `TargetSpec::Charuco` 1:1. Dictionary names are validated against the embedded builtin set (`validate_dictionary`) — covering **all** calib-targets builtin dictionaries, not just DICT_4X4_*.
- `dataset_runner`: charuco arms in `target_to_detector_config` (dictionary pre-validated before any image I/O, per the fail-fast ordering) and `pick_detector`; new `RunError::InvalidTargetConfig`.
- Regenerated `app/src/schemas/dataset_spec.json` (pre-existing doc-comment drift from main).

## Why
After this PR, **PlanarIntrinsics + charuco runs end-to-end in the app** with zero further changes. PR 2 adds the rig/handeye dataset converters, PR 3 the Tauri topology dispatch, PR 4 the TS topology selector.

## Tests
- Synthetic rendered-board roundtrip (8×8, DICT_4X4_50 — 32 markers fit the 50-code dict) via calib-targets' printable pipeline; lattice + planarity assertions.
- Config rejection, unknown-dictionary (lists supported names), oversized marker, blank image.
- Runner-level: charuco→detector config mapping contract, fail-fast bad dictionary.

Gates: fmt, clippy -D warnings, test --workspace --all-features, doc, emit-schemas all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)