### PR TITLE
feat(pipeline): dataset_runner converters for rig + scheimpflug (B3c-1, PR 2/4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,6 +3530,7 @@ dependencies = [
  "glob",
  "image",
  "nalgebra",
+ "regex",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ image = { version = "0.25" }
 calib-targets = "0.9"
 chess-corners = "0.11"
 glob = "0.3"
+regex = "1"
 rand = { version = "0.10" }
 tracing = { version = "0.1" }
 tiny-solver = "0.18"

--- a/crates/vision-calibration-pipeline/Cargo.toml
+++ b/crates/vision-calibration-pipeline/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { workspace = true }
 nalgebra = { workspace = true }
 image = { workspace = true }
 glob = { workspace = true }
+regex = { workspace = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/vision-calibration-pipeline/src/dataset_runner/mod.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/mod.rs
@@ -1,10 +1,18 @@
-//! Dataset-driven runner: takes a [`DatasetSpec`] manifest plus a
+//! Dataset-driven runner: takes a
+//! [`DatasetSpec`](vision_calibration_dataset::DatasetSpec) manifest plus a
 //! per-problem `*Config` and produces the existing `*Input` IR by
 //! running detection (cached) on the per-camera images.
 //!
-//! PR 1 wires up `PlanarIntrinsics` only. PR 2 extends to the other
-//! seven problem types via the same `(spec, config, &cache) → *Input`
-//! shape.
+//! Converters:
+//! - [`build_planar_input`] — `PlanarIntrinsics` / `ScheimpflugIntrinsics`
+//!   (both consume a `PlanarDataset`).
+//! - [`build_rig_extrinsics_input`] — `RigExtrinsics` (`RigDataset<NoMeta>`).
+//! - [`build_rig_handeye_input`] — `RigHandeye`
+//!   (`RigDataset<RobotPoseMeta>`, robot poses loaded from the manifest's
+//!   [`RobotPoseSource`](vision_calibration_dataset::RobotPoseSource)).
+//!
+//! The laser topologies (`LaserlineDevice`, `RigLaserlineDevice`) await
+//! the laser-frame manifest design; `SingleCamHandeye` follows in B3c-2.
 //!
 //! Per ADR 0019, any ambiguity that cannot be auto-resolved at
 //! conversion time is surfaced as a [`RunError::AskUser`] event so
@@ -15,14 +23,21 @@ use std::path::{Path, PathBuf};
 use serde_json::{Value, json};
 use thiserror::Error;
 
-use vision_calibration_core::{CorrespondenceView, NoMeta, PlanarDataset, Pt2, Pt3, View};
-use vision_calibration_dataset::{
-    DatasetSpec, ImagePattern, TargetSpec, Topology, ValidationError, validate,
-};
+use vision_calibration_core::{CorrespondenceView, NoMeta, Pt2, Pt3, View};
+use vision_calibration_dataset::{ImagePattern, TargetSpec, Topology, ValidationError};
 use vision_calibration_detect::{
     CacheKey, CachedFeatures, CharucoDetector, ChessboardDetector, DetectionCache, Detector,
     Feature, validate_charuco_layout,
 };
+
+mod pairing;
+mod planar;
+mod poses;
+mod rig;
+
+pub use pairing::PairedViews;
+pub use planar::{PlanarRunResult, build_planar_input};
+pub use rig::{RigRunResult, build_rig_extrinsics_input, build_rig_handeye_input};
 
 /// Errors produced by the dataset-driven runner.
 #[derive(Debug, Error)]
@@ -32,9 +47,10 @@ pub enum RunError {
     #[error("manifest validation failed: {0}")]
     Validation(#[from] ValidationError),
 
-    /// Topology is not yet supported by the runner. PR 1 ships with
-    /// `PlanarIntrinsics` only; PR 2 lifts this restriction.
-    #[error("topology {topology:?} is not yet supported by the dataset runner")]
+    /// Topology is not supported by this converter (e.g. a rig manifest
+    /// handed to the planar converter, or a topology whose converter
+    /// has not shipped yet).
+    #[error("topology {topology:?} is not supported by this converter")]
     UnsupportedTopology {
         /// The offending topology.
         topology: Topology,
@@ -78,6 +94,51 @@ pub enum RunError {
         /// Underlying glob compile error.
         #[source]
         source: glob::PatternError,
+    },
+
+    /// Cameras expanded to different image counts under `by_index`
+    /// pairing, where every camera must contribute one image per view.
+    #[error("by_index pairing requires equal image counts per camera, got {counts:?}")]
+    ViewCountMismatch {
+        /// `(camera_id, image_count)` per camera, in manifest order.
+        counts: Vec<(String, usize)>,
+    },
+
+    /// Robot pose count does not match the paired view count.
+    #[error("pose file has {poses} poses but the cameras paired into {views} views")]
+    PoseCountMismatch {
+        /// Number of poses parsed from the pose file.
+        poses: usize,
+        /// Number of paired views.
+        views: usize,
+    },
+
+    /// A row of the robot pose file failed to parse.
+    #[error("pose file {path}, row {row}: {message}")]
+    PoseParse {
+        /// The pose file.
+        path: PathBuf,
+        /// Zero-based data-row index (header excluded for CSV).
+        row: usize,
+        /// What went wrong.
+        message: String,
+    },
+
+    /// The `shared_filename_token` regex failed to compile.
+    #[error("pose pairing regex {regex:?} failed to compile: {message}")]
+    BadPairingRegex {
+        /// The offending regex source.
+        regex: String,
+        /// Compile error text.
+        message: String,
+    },
+
+    /// Filename-token pairing failed: a filename did not match the
+    /// regex, the named group was missing, or token sets are unusable.
+    #[error("filename-token pairing failed: {message}")]
+    PairingTokenMismatch {
+        /// Human-readable description (names the offending file/token).
+        message: String,
     },
 
     /// I/O failure while reading/writing the cache or images.
@@ -127,7 +188,7 @@ pub enum RunError {
     /// actionable error rather than a deep optim panic.
     #[error("camera {camera_id:?}: only {usable}/{total} views had >= 4 features")]
     InsufficientUsableViews {
-        /// Camera id (single camera for `PlanarIntrinsics`).
+        /// Camera id.
         camera_id: String,
         /// Number of views with at least 4 detected features.
         usable: usize,
@@ -137,160 +198,7 @@ pub enum RunError {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Public API
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Convert a Planar manifest + config + cache into the existing
-/// [`PlanarDataset`] IR. Returns the dataset plus a per-view list of
-/// the source image paths (for downstream `image_manifest`
-/// population).
-pub fn build_planar_input(
-    spec: &DatasetSpec,
-    base_dir: &Path,
-    cache: &dyn DetectionCache,
-    force_redetect: bool,
-) -> Result<PlanarRunResult, RunError> {
-    // Order matters: gate on topology + target before touching the
-    // filesystem so users with broken globs still see helpful
-    // "wrong topology" or "wrong target" errors first.
-    if spec.topology != Topology::PlanarIntrinsics {
-        return Err(RunError::UnsupportedTopology {
-            topology: spec.topology,
-        });
-    }
-    let (detector_name, detector_config) = target_to_detector_config(&spec.target)?;
-    let detector = pick_detector(detector_name)?;
-    validate(spec)?;
-
-    // PlanarIntrinsics has the validator-enforced invariant of exactly
-    // one camera, so `cameras[0]` is the only camera — no silent
-    // truncation.
-    let camera = spec
-        .cameras
-        .first()
-        .expect("validate guarantees exactly one camera for PlanarIntrinsics");
-    let images = expand_camera_images(camera, base_dir)?;
-    if images.is_empty() {
-        return Err(RunError::EmptyImageMatch {
-            camera_id: camera.id.clone(),
-            pattern: pattern_repr(&camera.images),
-            base: base_dir.to_path_buf(),
-        });
-    }
-
-    let mut views: Vec<View<NoMeta>> = Vec::new();
-    let mut view_paths: Vec<PathBuf> = Vec::new();
-    let mut usable = 0usize;
-    let total = images.len();
-
-    // ROI is part of what determines detection output, so it has to be
-    // part of the cache key. We splice it into the key-side config and
-    // leave the actual `detector_config` untouched (the detector itself
-    // doesn't know about ROI — the runner crops the image first).
-    let roi = camera.roi_xywh;
-    let key_config = augment_config_with_roi(&detector_config, roi);
-
-    for image_path in &images {
-        let bytes = std::fs::read(image_path)?;
-        let key = CacheKey::from_inputs(&bytes, detector_name, &key_config);
-
-        let cached: Option<CachedFeatures> = if force_redetect {
-            None
-        } else {
-            cache.get(&key)?
-        };
-
-        let features = match cached {
-            Some(entry) => entry.features,
-            None => {
-                let img = image::load_from_memory(&bytes).map_err(|e| RunError::Decode {
-                    path: image_path.clone(),
-                    source: e,
-                })?;
-                let img_for_detect = if let Some([x, y, w, h]) = roi {
-                    img.crop_imm(x, y, w, h)
-                } else {
-                    img
-                };
-                let mut detected = detector
-                    .detect_json(&img_for_detect, &detector_config)
-                    .map_err(|e| RunError::Detection {
-                        detector: detector_name.to_string(),
-                        path: image_path.clone(),
-                        source: e,
-                    })?;
-                // Detected pixels are in the cropped frame; lift them
-                // back into source-image coordinates so the rest of
-                // the pipeline (and the export's `image_manifest`)
-                // stays in one consistent coordinate system.
-                if let Some([x, y, _w, _h]) = roi {
-                    let dx = x as f64;
-                    let dy = y as f64;
-                    for f in detected.iter_mut() {
-                        f.image_xy[0] += dx;
-                        f.image_xy[1] += dy;
-                    }
-                }
-                cache.put(
-                    &key,
-                    &CachedFeatures {
-                        features: detected.clone(),
-                    },
-                )?;
-                detected
-            }
-        };
-
-        if features.len() < 4 {
-            // Too few features for a homography — drop the view but
-            // keep walking so we can surface a meaningful error if
-            // _everything_ failed.
-            continue;
-        }
-        usable += 1;
-        views.push(features_to_view(&features)?);
-        view_paths.push(image_path.clone());
-    }
-
-    if views.is_empty() {
-        return Err(RunError::InsufficientUsableViews {
-            camera_id: camera.id.clone(),
-            usable,
-            total,
-        });
-    }
-
-    let dataset = PlanarDataset::new(views).expect(
-        "PlanarDataset::new failed after we already filtered to >=4 \
-         features per view; this indicates a regression in the core \
-         crate's invariants",
-    );
-
-    Ok(PlanarRunResult {
-        dataset,
-        view_paths,
-        usable_views: usable,
-        total_views: total,
-    })
-}
-
-/// Result of a Planar dataset conversion.
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct PlanarRunResult {
-    /// The IR ready to feed into `CalibrationSession::set_input`.
-    pub dataset: PlanarDataset,
-    /// One source image path per accepted view, in the same order.
-    /// Used to populate the export's `image_manifest` after the solve.
-    pub view_paths: Vec<PathBuf>,
-    /// Number of views where detection produced ≥4 features.
-    pub usable_views: usize,
-    /// Total number of images attempted.
-    pub total_views: usize,
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Helpers
+// Shared helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn target_to_detector_config(target: &TargetSpec) -> Result<(&'static str, Value), RunError> {
@@ -372,7 +280,10 @@ fn expand_camera_images(
                 .filter_map(|r| r.ok())
                 .filter(|p| p.is_file())
                 .collect();
-            paths.sort();
+            // Natural sort keeps `Im_2` before `Im_10` so `by_index`
+            // pairing matches the acquisition order of non-zero-padded
+            // filename schemes.
+            paths.sort_by(|a, b| natural_cmp(&a.to_string_lossy(), &b.to_string_lossy()));
             Ok(paths)
         }
         ImagePattern::List { paths } => {
@@ -388,6 +299,58 @@ fn expand_camera_images(
             Ok(resolved)
         }
     }
+}
+
+/// Natural (numeric-aware) string comparison: splits each string into
+/// runs of digits and non-digits, comparing digit runs by numeric
+/// value. Keeps `Im_2` < `Im_10`, matching the bench harness's
+/// ordering (`vision-calibration-bench/src/detect.rs`).
+fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let mut ai = a.chars().peekable();
+    let mut bi = b.chars().peekable();
+    loop {
+        match (ai.peek().copied(), bi.peek().copied()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(ca), Some(cb)) => {
+                if ca.is_ascii_digit() && cb.is_ascii_digit() {
+                    let na: String = take_digits(&mut ai);
+                    let nb: String = take_digits(&mut bi);
+                    // Compare by numeric value; fall back to string
+                    // length then lexically for runs too long for u128.
+                    let cmp = match (na.parse::<u128>(), nb.parse::<u128>()) {
+                        (Ok(x), Ok(y)) => x.cmp(&y),
+                        _ => na.len().cmp(&nb.len()).then_with(|| na.cmp(&nb)),
+                    };
+                    if cmp != Ordering::Equal {
+                        return cmp;
+                    }
+                } else {
+                    let cmp = ca.cmp(&cb);
+                    if cmp != Ordering::Equal {
+                        return cmp;
+                    }
+                    ai.next();
+                    bi.next();
+                }
+            }
+        }
+    }
+}
+
+fn take_digits(it: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+    let mut s = String::new();
+    while let Some(&c) = it.peek() {
+        if c.is_ascii_digit() {
+            s.push(c);
+            it.next();
+        } else {
+            break;
+        }
+    }
+    s
 }
 
 /// Splice a `_roi` field into the detector's canonical config JSON so
@@ -411,79 +374,91 @@ fn pattern_repr(p: &ImagePattern) -> String {
     }
 }
 
+/// Run one image through the cache-or-detect path shared by every
+/// converter: read bytes → cache lookup → on miss, decode, crop to
+/// ROI, detect, lift pixels back to source coordinates, store.
+///
+/// Returns the features plus whether they came from the cache.
+#[allow(clippy::too_many_arguments)]
+fn detect_features(
+    detector: &dyn Detector,
+    detector_name: &str,
+    detector_config: &Value,
+    key_config: &Value,
+    roi: Option<[u32; 4]>,
+    image_path: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<(Vec<Feature>, bool), RunError> {
+    let bytes = std::fs::read(image_path)?;
+    let key = CacheKey::from_inputs(&bytes, detector_name, key_config);
+
+    let cached: Option<CachedFeatures> = if force_redetect {
+        None
+    } else {
+        cache.get(&key)?
+    };
+    if let Some(entry) = cached {
+        return Ok((entry.features, true));
+    }
+
+    let img = image::load_from_memory(&bytes).map_err(|e| RunError::Decode {
+        path: image_path.to_path_buf(),
+        source: e,
+    })?;
+    let img_for_detect = if let Some([x, y, w, h]) = roi {
+        img.crop_imm(x, y, w, h)
+    } else {
+        img
+    };
+    let mut detected = detector
+        .detect_json(&img_for_detect, detector_config)
+        .map_err(|e| RunError::Detection {
+            detector: detector_name.to_string(),
+            path: image_path.to_path_buf(),
+            source: e,
+        })?;
+    // Detected pixels are in the cropped frame; lift them back into
+    // source-image coordinates so the rest of the pipeline (and the
+    // export's `image_manifest`) stays in one consistent coordinate
+    // system.
+    if let Some([x, y, _w, _h]) = roi {
+        let dx = x as f64;
+        let dy = y as f64;
+        for f in detected.iter_mut() {
+            f.image_xy[0] += dx;
+            f.image_xy[1] += dy;
+        }
+    }
+    cache.put(
+        &key,
+        &CachedFeatures {
+            features: detected.clone(),
+        },
+    )?;
+    Ok((detected, false))
+}
+
 fn features_to_view(features: &[Feature]) -> Result<View<NoMeta>, RunError> {
+    Ok(View::without_meta(features_to_obs(features)))
+}
+
+fn features_to_obs(features: &[Feature]) -> CorrespondenceView {
     let mut points_3d = Vec::with_capacity(features.len());
     let mut points_2d = Vec::with_capacity(features.len());
     for f in features {
         points_3d.push(Pt3::new(f.world_xyz[0], f.world_xyz[1], f.world_xyz[2]));
         points_2d.push(Pt2::new(f.image_xy[0], f.image_xy[1]));
     }
-    let cv = CorrespondenceView::new(points_3d, points_2d).expect(
+    CorrespondenceView::new(points_3d, points_2d).expect(
         "Feature vectors are non-empty and equal-length by construction; \
          CorrespondenceView::new only fails on mismatched lengths.",
-    );
-    Ok(View::without_meta(cv))
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vision_calibration_dataset::{CameraSource, ImagePattern, TargetSpec, Topology};
-    use vision_calibration_detect::FsDetectionCache;
-
-    fn planar_spec_for_globless_test() -> DatasetSpec {
-        DatasetSpec {
-            version: 1,
-            cameras: vec![CameraSource {
-                id: "cam0".into(),
-                images: ImagePattern::List { paths: vec![] },
-                roi_xywh: None,
-            }],
-            target: TargetSpec::Chessboard {
-                rows: 9,
-                cols: 6,
-                square_size_m: 0.025,
-            },
-            robot_poses: None,
-            topology: Topology::PlanarIntrinsics,
-            pose_pairing: None,
-            pose_convention: None,
-            unresolved: vec![],
-            description: None,
-        }
-    }
-
-    #[test]
-    fn rejects_non_planar_topology() {
-        let mut spec = planar_spec_for_globless_test();
-        spec.topology = Topology::RigExtrinsics;
-        spec.cameras.push(CameraSource {
-            id: "cam1".into(),
-            images: ImagePattern::List { paths: vec![] },
-            roi_xywh: None,
-        });
-        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
-        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
-        assert!(matches!(err, RunError::UnsupportedTopology { .. }));
-    }
-
-    #[test]
-    fn rejects_unsupported_target() {
-        let mut spec = planar_spec_for_globless_test();
-        spec.target = TargetSpec::Ringgrid {
-            rows: 5,
-            cols: 5,
-            spacing_m: 0.02,
-            inner_radius_m: 0.004,
-            outer_radius_m: 0.008,
-        };
-        spec.cameras[0].images = ImagePattern::Glob {
-            pattern: "*.png".into(),
-        };
-        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
-        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
-        assert!(matches!(err, RunError::UnsupportedTarget { .. }));
-    }
 
     #[test]
     fn charuco_target_maps_to_detector_config() {
@@ -549,22 +524,13 @@ mod tests {
     }
 
     #[test]
-    fn empty_image_match_is_actionable() {
-        let mut spec = planar_spec_for_globless_test();
-        spec.cameras[0].images = ImagePattern::Glob {
-            pattern: "**/no_such_pattern_should_match_*.png".into(),
-        };
-        let tmp = tempdir_or_skip();
-        let cache = FsDetectionCache::new(tmp.path().join("cache"));
-        let err = build_planar_input(&spec, tmp.path(), &cache, false).unwrap_err();
-        match err {
-            RunError::EmptyImageMatch { camera_id, .. } => assert_eq!(camera_id, "cam0"),
-            other => panic!("expected EmptyImageMatch, got {other:?}"),
-        }
-    }
-
-    fn tempdir_or_skip() -> tempfile::TempDir {
-        tempfile::tempdir().expect("tempdir")
+    fn natural_sort_orders_numeric_runs() {
+        let mut names = vec!["Im_10.png", "Im_2.png", "Im_1.png", "Im_20.png"];
+        names.sort_by(|a, b| natural_cmp(a, b));
+        assert_eq!(
+            names,
+            vec!["Im_1.png", "Im_2.png", "Im_10.png", "Im_20.png"]
+        );
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/dataset_runner/pairing.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/pairing.rs
@@ -1,0 +1,223 @@
+//! View pairing: align per-camera image lists into rig views, and
+//! (for hand-eye) align those views with robot poses.
+//!
+//! Two strategies, per the manifest's `pose_pairing` field:
+//! - `by_index` — every camera contributes image `i` to view `i`;
+//!   poses pair by row index. Requires equal counts everywhere.
+//! - `shared_filename_token` — a regex with a named capture group
+//!   extracts a view token from each filename; views are the sorted
+//!   intersection of the per-camera token sets; poses pair by their
+//!   `pose_id` column equalling the token.
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::PathBuf;
+
+use vision_calibration_dataset::PosePairing;
+
+use super::RunError;
+
+/// Per-camera image lists aligned into rig views.
+#[derive(Debug)]
+pub struct PairedViews {
+    /// `paths[view][camera]` — `None` when a camera has no image for
+    /// this view (only possible under token pairing).
+    pub paths: Vec<Vec<Option<PathBuf>>>,
+    /// View token per view (token pairing) or stringified index
+    /// (`by_index`). Used to pair robot poses by `pose_id`.
+    pub tokens: Vec<String>,
+}
+
+/// Align per-camera image lists into views using `pairing`.
+///
+/// `images[c]` is camera `c`'s expanded, sorted image list and
+/// `camera_ids[c]` its manifest id (for error messages).
+pub(crate) fn pair_views(
+    images: &[Vec<PathBuf>],
+    camera_ids: &[String],
+    pairing: &PosePairing,
+) -> Result<PairedViews, RunError> {
+    match pairing {
+        PosePairing::ByIndex => {
+            let counts: Vec<(String, usize)> = camera_ids
+                .iter()
+                .cloned()
+                .zip(images.iter().map(Vec::len))
+                .collect();
+            let first = counts[0].1;
+            if counts.iter().any(|(_, n)| *n != first) {
+                return Err(RunError::ViewCountMismatch { counts });
+            }
+            let paths = (0..first)
+                .map(|view| images.iter().map(|cam| Some(cam[view].clone())).collect())
+                .collect();
+            let tokens = (0..first).map(|i| i.to_string()).collect();
+            Ok(PairedViews { paths, tokens })
+        }
+        PosePairing::SharedFilenameToken { regex, group } => {
+            let re = regex::Regex::new(regex).map_err(|e| RunError::BadPairingRegex {
+                regex: regex.clone(),
+                message: e.to_string(),
+            })?;
+            if !re.capture_names().flatten().any(|name| name == group) {
+                return Err(RunError::BadPairingRegex {
+                    regex: regex.clone(),
+                    message: format!("regex has no named capture group {group:?}"),
+                });
+            }
+
+            // token → path, per camera.
+            let mut per_camera: Vec<HashMap<String, PathBuf>> = Vec::with_capacity(images.len());
+            for (cam_images, cam_id) in images.iter().zip(camera_ids) {
+                let mut map = HashMap::new();
+                for path in cam_images {
+                    let name = path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    let token = re
+                        .captures(&name)
+                        .and_then(|c| c.name(group))
+                        .map(|m| m.as_str().to_string())
+                        .ok_or_else(|| RunError::PairingTokenMismatch {
+                            message: format!(
+                                "camera {cam_id:?}: filename {name:?} does not match the \
+                                 pairing regex (or group {group:?} did not participate)"
+                            ),
+                        })?;
+                    if let Some(previous) = map.insert(token.clone(), path.clone()) {
+                        return Err(RunError::PairingTokenMismatch {
+                            message: format!(
+                                "camera {cam_id:?}: token {token:?} extracted from two files \
+                                 ({} and {})",
+                                previous.display(),
+                                path.display()
+                            ),
+                        });
+                    }
+                }
+                per_camera.push(map);
+            }
+
+            // Views = sorted union of tokens; cameras missing a token
+            // contribute `None` for that view. (Intersection would
+            // silently drop views where one camera blinked — the rig
+            // IR supports per-camera gaps, so keep them.)
+            let mut all_tokens: BTreeSet<String> = BTreeSet::new();
+            for map in &per_camera {
+                all_tokens.extend(map.keys().cloned());
+            }
+            if all_tokens.is_empty() {
+                return Err(RunError::PairingTokenMismatch {
+                    message: "no view tokens extracted from any camera".into(),
+                });
+            }
+
+            let tokens: Vec<String> = all_tokens.into_iter().collect();
+            let paths = tokens
+                .iter()
+                .map(|t| per_camera.iter().map(|map| map.get(t).cloned()).collect())
+                .collect();
+            Ok(PairedViews { paths, tokens })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn paths(names: &[&str]) -> Vec<PathBuf> {
+        names.iter().map(PathBuf::from).collect()
+    }
+
+    fn ids(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("cam{i}")).collect()
+    }
+
+    #[test]
+    fn by_index_pairs_in_order() {
+        let images = vec![
+            paths(&["a/1.png", "a/2.png"]),
+            paths(&["b/1.png", "b/2.png"]),
+        ];
+        let paired = pair_views(&images, &ids(2), &PosePairing::ByIndex).unwrap();
+        assert_eq!(paired.paths.len(), 2);
+        assert_eq!(paired.paths[1][0].as_deref(), Some(Path::new("a/2.png")));
+        assert_eq!(paired.tokens, vec!["0", "1"]);
+    }
+
+    #[test]
+    fn by_index_rejects_unequal_counts() {
+        let images = vec![paths(&["a/1.png", "a/2.png"]), paths(&["b/1.png"])];
+        let err = pair_views(&images, &ids(2), &PosePairing::ByIndex).unwrap_err();
+        match err {
+            RunError::ViewCountMismatch { counts } => {
+                assert_eq!(counts, vec![("cam0".into(), 2), ("cam1".into(), 1)]);
+            }
+            other => panic!("expected ViewCountMismatch, got {other:?}"),
+        }
+    }
+
+    fn token_pairing() -> PosePairing {
+        PosePairing::SharedFilenameToken {
+            regex: r"^Cam\d+_(?<view>\d+)\.png$".into(),
+            group: "view".into(),
+        }
+    }
+
+    #[test]
+    fn token_pairing_aligns_and_fills_gaps() {
+        let images = vec![
+            paths(&["x/Cam0_001.png", "x/Cam0_002.png", "x/Cam0_003.png"]),
+            paths(&["y/Cam1_001.png", "y/Cam1_003.png"]), // 002 missing
+        ];
+        let paired = pair_views(&images, &ids(2), &token_pairing()).unwrap();
+        assert_eq!(paired.tokens, vec!["001", "002", "003"]);
+        assert!(paired.paths[1][1].is_none(), "cam1 has no 002 frame");
+        assert!(paired.paths[0][1].is_some());
+        assert_eq!(
+            paired.paths[2][1].as_deref().unwrap().to_str().unwrap(),
+            "y/Cam1_003.png"
+        );
+    }
+
+    #[test]
+    fn token_regex_compile_error_is_actionable() {
+        let pairing = PosePairing::SharedFilenameToken {
+            regex: "([unclosed".into(),
+            group: "view".into(),
+        };
+        let images = vec![paths(&["a/1.png"])];
+        let err = pair_views(&images, &ids(1), &pairing).unwrap_err();
+        assert!(matches!(err, RunError::BadPairingRegex { .. }));
+    }
+
+    #[test]
+    fn missing_group_is_actionable() {
+        let pairing = PosePairing::SharedFilenameToken {
+            regex: r"^Cam\d+_(\d+)\.png$".into(), // unnamed group
+            group: "view".into(),
+        };
+        let images = vec![paths(&["a/Cam0_001.png"])];
+        let err = pair_views(&images, &ids(1), &pairing).unwrap_err();
+        match err {
+            RunError::BadPairingRegex { message, .. } => {
+                assert!(message.contains("view"), "got: {message}")
+            }
+            other => panic!("expected BadPairingRegex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unmatched_filename_is_actionable() {
+        let images = vec![paths(&["a/notes.txt"])];
+        let err = pair_views(&images, &ids(1), &token_pairing()).unwrap_err();
+        match err {
+            RunError::PairingTokenMismatch { message } => {
+                assert!(message.contains("notes.txt"), "got: {message}")
+            }
+            other => panic!("expected PairingTokenMismatch, got {other:?}"),
+        }
+    }
+}

--- a/crates/vision-calibration-pipeline/src/dataset_runner/planar.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/planar.rs
@@ -1,0 +1,220 @@
+//! `DatasetSpec → PlanarDataset` converter, shared by the
+//! `PlanarIntrinsics` and `ScheimpflugIntrinsics` topologies (both
+//! problem types consume the same `PlanarDataset` IR).
+
+use std::path::{Path, PathBuf};
+
+use vision_calibration_core::{NoMeta, PlanarDataset, View};
+use vision_calibration_dataset::{DatasetSpec, Topology, validate};
+use vision_calibration_detect::DetectionCache;
+
+use super::{
+    RunError, augment_config_with_roi, detect_features, expand_camera_images, features_to_view,
+    pattern_repr, pick_detector, target_to_detector_config,
+};
+
+/// Convert a single-camera planar manifest + cache into the existing
+/// [`PlanarDataset`] IR. Accepts the `PlanarIntrinsics` and
+/// `ScheimpflugIntrinsics` topologies — the Scheimpflug problem type
+/// consumes the same input, only its config differs. Returns the
+/// dataset plus a per-view list of the source image paths (for
+/// downstream `image_manifest` population).
+pub fn build_planar_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<PlanarRunResult, RunError> {
+    // Order matters: gate on topology + target before touching the
+    // filesystem so users with broken globs still see helpful
+    // "wrong topology" or "wrong target" errors first.
+    if !matches!(
+        spec.topology,
+        Topology::PlanarIntrinsics | Topology::ScheimpflugIntrinsics
+    ) {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let (detector_name, detector_config) = target_to_detector_config(&spec.target)?;
+    let detector = pick_detector(detector_name)?;
+    validate(spec)?;
+
+    // Single-camera topologies have the validator-enforced invariant
+    // of exactly one camera, so `cameras[0]` is the only camera — no
+    // silent truncation.
+    let camera = spec
+        .cameras
+        .first()
+        .expect("validate guarantees exactly one camera for planar topologies");
+    let images = expand_camera_images(camera, base_dir)?;
+    if images.is_empty() {
+        return Err(RunError::EmptyImageMatch {
+            camera_id: camera.id.clone(),
+            pattern: pattern_repr(&camera.images),
+            base: base_dir.to_path_buf(),
+        });
+    }
+
+    let mut views: Vec<View<NoMeta>> = Vec::new();
+    let mut view_paths: Vec<PathBuf> = Vec::new();
+    let mut usable = 0usize;
+    let total = images.len();
+
+    // ROI is part of what determines detection output, so it has to be
+    // part of the cache key. We splice it into the key-side config and
+    // leave the actual `detector_config` untouched (the detector itself
+    // doesn't know about ROI — the runner crops the image first).
+    let roi = camera.roi_xywh;
+    let key_config = augment_config_with_roi(&detector_config, roi);
+
+    for image_path in &images {
+        let (features, _cache_hit) = detect_features(
+            detector.as_ref(),
+            detector_name,
+            &detector_config,
+            &key_config,
+            roi,
+            image_path,
+            cache,
+            force_redetect,
+        )?;
+
+        if features.len() < 4 {
+            // Too few features for a homography — drop the view but
+            // keep walking so we can surface a meaningful error if
+            // _everything_ failed.
+            continue;
+        }
+        usable += 1;
+        views.push(features_to_view(&features)?);
+        view_paths.push(image_path.clone());
+    }
+
+    if views.is_empty() {
+        return Err(RunError::InsufficientUsableViews {
+            camera_id: camera.id.clone(),
+            usable,
+            total,
+        });
+    }
+
+    let dataset = PlanarDataset::new(views).expect(
+        "PlanarDataset::new failed after we already filtered to >=4 \
+         features per view; this indicates a regression in the core \
+         crate's invariants",
+    );
+
+    Ok(PlanarRunResult {
+        dataset,
+        view_paths,
+        usable_views: usable,
+        total_views: total,
+    })
+}
+
+/// Result of a planar dataset conversion.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct PlanarRunResult {
+    /// The IR ready to feed into `CalibrationSession::set_input`.
+    pub dataset: PlanarDataset,
+    /// One source image path per accepted view, in the same order.
+    /// Used to populate the export's `image_manifest` after the solve.
+    pub view_paths: Vec<PathBuf>,
+    /// Number of views where detection produced ≥4 features.
+    pub usable_views: usize,
+    /// Total number of images attempted.
+    pub total_views: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vision_calibration_dataset::{CameraSource, ImagePattern, TargetSpec};
+    use vision_calibration_detect::FsDetectionCache;
+
+    pub(crate) fn planar_spec_for_globless_test() -> DatasetSpec {
+        DatasetSpec {
+            version: 1,
+            cameras: vec![CameraSource {
+                id: "cam0".into(),
+                images: ImagePattern::List { paths: vec![] },
+                roi_xywh: None,
+            }],
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: None,
+            topology: Topology::PlanarIntrinsics,
+            pose_pairing: None,
+            pose_convention: None,
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    #[test]
+    fn rejects_rig_topology() {
+        let mut spec = planar_spec_for_globless_test();
+        spec.topology = Topology::RigExtrinsics;
+        spec.cameras.push(CameraSource {
+            id: "cam1".into(),
+            images: ImagePattern::List { paths: vec![] },
+            roi_xywh: None,
+        });
+        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
+        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
+        assert!(matches!(err, RunError::UnsupportedTopology { .. }));
+    }
+
+    #[test]
+    fn accepts_scheimpflug_topology() {
+        // Scheimpflug shares the planar input path; the topology gate
+        // must not reject it. (The empty image list then fails
+        // validation, which proves we got past the gate.)
+        let mut spec = planar_spec_for_globless_test();
+        spec.topology = Topology::ScheimpflugIntrinsics;
+        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
+        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
+        assert!(
+            !matches!(err, RunError::UnsupportedTopology { .. }),
+            "scheimpflug must pass the topology gate, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_target() {
+        let mut spec = planar_spec_for_globless_test();
+        spec.target = TargetSpec::Ringgrid {
+            rows: 5,
+            cols: 5,
+            spacing_m: 0.02,
+            inner_radius_m: 0.004,
+            outer_radius_m: 0.008,
+        };
+        spec.cameras[0].images = ImagePattern::Glob {
+            pattern: "*.png".into(),
+        };
+        let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
+        let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();
+        assert!(matches!(err, RunError::UnsupportedTarget { .. }));
+    }
+
+    #[test]
+    fn empty_image_match_is_actionable() {
+        let mut spec = planar_spec_for_globless_test();
+        spec.cameras[0].images = ImagePattern::Glob {
+            pattern: "**/no_such_pattern_should_match_*.png".into(),
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let err = build_planar_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::EmptyImageMatch { camera_id, .. } => assert_eq!(camera_id, "cam0"),
+            other => panic!("expected EmptyImageMatch, got {other:?}"),
+        }
+    }
+}

--- a/crates/vision-calibration-pipeline/src/dataset_runner/poses.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/poses.rs
@@ -1,0 +1,557 @@
+//! Robot-pose file loading: CSV / JSON / JSONL → canonical
+//! `T_B_G` (gripper-in-base) isometries.
+//!
+//! The manifest's [`PoseConvention`] declares what each row encodes
+//! (transform direction, rotation parameterisation, translation
+//! units); this module normalizes everything to the pipeline's
+//! convention: `RobotPoseMeta.base_se3_gripper` = `T_B_G` in metres.
+//!
+//! For the world-fixed conventions (`TWorldTcp` / `TTcpWorld`) the
+//! world frame plays the role of the robot base — hand-eye math only
+//! needs a consistent parent frame across views, not the frame's name.
+
+use std::path::Path;
+
+use nalgebra::{Quaternion, Rotation3, UnitQuaternion, Vector3};
+use serde_json::Value;
+
+use vision_calibration_core::Iso3;
+use vision_calibration_dataset::{
+    PoseConvention, RobotPoseFormat, RobotPoseSource, RotationFormat, TransformConvention,
+    TranslationUnits,
+};
+
+use super::RunError;
+
+/// One pose parsed from the file, normalized to the pipeline
+/// convention (`T_B_G`, metres).
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedPose {
+    /// Value of the `pose_id` column, when mapped. Used by
+    /// `shared_filename_token` pairing; `by_index` ignores it.
+    pub id: Option<String>,
+    /// Gripper pose in the robot base frame.
+    pub base_se3_gripper: Iso3,
+}
+
+/// Load and normalize every pose row from `source`.
+pub(crate) fn load_robot_poses(
+    source: &RobotPoseSource,
+    convention: &PoseConvention,
+    base_dir: &Path,
+) -> Result<Vec<ParsedPose>, RunError> {
+    let path = if source.path.is_absolute() {
+        source.path.clone()
+    } else {
+        base_dir.join(&source.path)
+    };
+    let text = std::fs::read_to_string(&path)?;
+
+    let rows: Vec<RawRow> = match source.format {
+        RobotPoseFormat::Csv => parse_csv_rows(&text, &path)?,
+        RobotPoseFormat::Json => {
+            let values: Vec<Value> =
+                serde_json::from_str(&text).map_err(|e| RunError::PoseParse {
+                    path: path.clone(),
+                    row: 0,
+                    message: format!("not a JSON array of objects: {e}"),
+                })?;
+            values
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| object_to_row(v, i, &path))
+                .collect::<Result<_, _>>()?
+        }
+        RobotPoseFormat::Jsonl => text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .enumerate()
+            .map(|(i, line)| {
+                let v: Value = serde_json::from_str(line).map_err(|e| RunError::PoseParse {
+                    path: path.clone(),
+                    row: i,
+                    message: format!("invalid JSON object: {e}"),
+                })?;
+                object_to_row(v, i, &path)
+            })
+            .collect::<Result<_, _>>()?,
+    };
+
+    rows.iter()
+        .enumerate()
+        .map(|(i, row)| parse_pose_row(row, i, source, convention, &path))
+        .collect()
+}
+
+/// One raw row: column name → string value. CSV and JSON funnel into
+/// the same shape so the field extraction below is format-agnostic.
+struct RawRow {
+    fields: std::collections::HashMap<String, String>,
+}
+
+fn parse_csv_rows(text: &str, path: &Path) -> Result<Vec<RawRow>, RunError> {
+    let mut lines = text.lines().filter(|l| !l.trim().is_empty());
+    let header = lines.next().ok_or_else(|| RunError::PoseParse {
+        path: path.to_path_buf(),
+        row: 0,
+        message: "empty pose file".into(),
+    })?;
+    // Hand-rolled split: pose files are plain numeric tables. Quoted
+    // CSV would need a real parser dependency; reject it explicitly
+    // rather than mis-parse.
+    if header.contains('"') {
+        return Err(RunError::PoseParse {
+            path: path.to_path_buf(),
+            row: 0,
+            message: "quoted CSV is not supported; use plain comma-separated columns".into(),
+        });
+    }
+    let columns: Vec<String> = header.split(',').map(|c| c.trim().to_string()).collect();
+
+    let mut rows = Vec::new();
+    for (i, line) in lines.enumerate() {
+        if line.contains('"') {
+            return Err(RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: i,
+                message: "quoted CSV is not supported; use plain comma-separated columns".into(),
+            });
+        }
+        let cells: Vec<&str> = line.split(',').map(str::trim).collect();
+        if cells.len() != columns.len() {
+            return Err(RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: i,
+                message: format!(
+                    "row has {} cells but the header has {} columns",
+                    cells.len(),
+                    columns.len()
+                ),
+            });
+        }
+        let fields = columns
+            .iter()
+            .cloned()
+            .zip(cells.iter().map(|c| c.to_string()))
+            .collect();
+        rows.push(RawRow { fields });
+    }
+    Ok(rows)
+}
+
+fn object_to_row(value: Value, row: usize, path: &Path) -> Result<RawRow, RunError> {
+    let Value::Object(map) = value else {
+        return Err(RunError::PoseParse {
+            path: path.to_path_buf(),
+            row,
+            message: "expected a JSON object per pose".into(),
+        });
+    };
+    let mut fields = std::collections::HashMap::new();
+    for (k, v) in map {
+        let s = match v {
+            Value::String(s) => s,
+            Value::Number(n) => n.to_string(),
+            other => {
+                return Err(RunError::PoseParse {
+                    path: path.to_path_buf(),
+                    row,
+                    message: format!("field {k:?} must be a number or string, got {other}"),
+                });
+            }
+        };
+        fields.insert(k, s);
+    }
+    Ok(RawRow { fields })
+}
+
+fn parse_pose_row(
+    row: &RawRow,
+    index: usize,
+    source: &RobotPoseSource,
+    convention: &PoseConvention,
+    path: &Path,
+) -> Result<ParsedPose, RunError> {
+    let columns = &source.columns;
+    let get = |name: &str| -> Result<&str, RunError> {
+        row.fields
+            .get(name)
+            .map(String::as_str)
+            .ok_or_else(|| RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: index,
+                message: format!("mapped column {name:?} not found in this row"),
+            })
+    };
+    let get_f64 = |name: &str| -> Result<f64, RunError> {
+        let raw = get(name)?;
+        raw.parse::<f64>().map_err(|_| RunError::PoseParse {
+            path: path.to_path_buf(),
+            row: index,
+            message: format!("column {name:?}: {raw:?} is not a number"),
+        })
+    };
+
+    let id = match &columns.pose_id {
+        Some(col) => Some(get(col)?.to_string()),
+        None => None,
+    };
+
+    let rotation_values: Vec<f64> = columns
+        .rotation
+        .iter()
+        .map(|c| get_f64(c))
+        .collect::<Result<_, _>>()?;
+    let rotation =
+        rotation_from_values(convention.rotation_format, &rotation_values).map_err(|message| {
+            RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: index,
+                message,
+            }
+        })?;
+
+    // Translation always comes from the tx/ty/tz columns — even for
+    // `Matrix4x4RowMajor`, where the matrix's fourth column is
+    // redundant with them. One deterministic rule beats guessing
+    // which copy the user meant.
+    let scale = match convention.translation_units {
+        TranslationUnits::M => 1.0,
+        TranslationUnits::Mm => 1e-3,
+    };
+    let translation = Vector3::new(
+        get_f64(&columns.tx)? * scale,
+        get_f64(&columns.ty)? * scale,
+        get_f64(&columns.tz)? * scale,
+    );
+
+    let pose = Iso3::from_parts(translation.into(), rotation);
+    let base_se3_gripper = match convention.transform {
+        // World-fixed conventions: the world frame plays the role of
+        // the base (see module docs).
+        TransformConvention::TBaseTcp | TransformConvention::TWorldTcp => pose,
+        TransformConvention::TTcpBase | TransformConvention::TTcpWorld => pose.inverse(),
+    };
+
+    Ok(ParsedPose {
+        id,
+        base_se3_gripper,
+    })
+}
+
+/// Build a rotation from the file's parameterisation.
+///
+/// Euler conventions are *intrinsic*, composed left-to-right in the
+/// order the name states: `EulerXyz` = `Rx(a) · Ry(b) · Rz(c)`,
+/// `EulerZyx` = `Rz(a) · Ry(b) · Rx(c)`. Note nalgebra's
+/// `from_euler_angles(r, p, y)` builds `Rz(y) · Ry(p) · Rx(r)` —
+/// equivalent to our `EulerZyx` with reversed argument order — so we
+/// compose from axis-angles explicitly to keep both orders honest.
+fn rotation_from_values(
+    format: RotationFormat,
+    values: &[f64],
+) -> Result<UnitQuaternion<f64>, String> {
+    let expect_len = |n: usize| -> Result<(), String> {
+        if values.len() == n {
+            Ok(())
+        } else {
+            Err(format!(
+                "rotation format {format:?} needs {n} values, got {}",
+                values.len()
+            ))
+        }
+    };
+    let rx = |a: f64| UnitQuaternion::from_axis_angle(&Vector3::x_axis(), a);
+    let ry = |a: f64| UnitQuaternion::from_axis_angle(&Vector3::y_axis(), a);
+    let rz = |a: f64| UnitQuaternion::from_axis_angle(&Vector3::z_axis(), a);
+
+    match format {
+        RotationFormat::QuatXyzw => {
+            expect_len(4)?;
+            Ok(UnitQuaternion::from_quaternion(Quaternion::new(
+                values[3], values[0], values[1], values[2],
+            )))
+        }
+        RotationFormat::QuatWxyz => {
+            expect_len(4)?;
+            Ok(UnitQuaternion::from_quaternion(Quaternion::new(
+                values[0], values[1], values[2], values[3],
+            )))
+        }
+        RotationFormat::EulerXyzDeg | RotationFormat::EulerXyzRad => {
+            expect_len(3)?;
+            let k = if matches!(format, RotationFormat::EulerXyzDeg) {
+                std::f64::consts::PI / 180.0
+            } else {
+                1.0
+            };
+            Ok(rx(values[0] * k) * ry(values[1] * k) * rz(values[2] * k))
+        }
+        RotationFormat::EulerZyxDeg | RotationFormat::EulerZyxRad => {
+            expect_len(3)?;
+            let k = if matches!(format, RotationFormat::EulerZyxDeg) {
+                std::f64::consts::PI / 180.0
+            } else {
+                1.0
+            };
+            Ok(rz(values[0] * k) * ry(values[1] * k) * rx(values[2] * k))
+        }
+        RotationFormat::AxisAngleRad => {
+            expect_len(3)?;
+            Ok(UnitQuaternion::from_scaled_axis(Vector3::new(
+                values[0], values[1], values[2],
+            )))
+        }
+        RotationFormat::Matrix4x4RowMajor => {
+            expect_len(16)?;
+            // Row-major upper-left 3×3; `from_matrix` re-orthonormalizes,
+            // tolerating mildly noisy exports.
+            let m = nalgebra::Matrix3::new(
+                values[0], values[1], values[2], values[4], values[5], values[6], values[8],
+                values[9], values[10],
+            );
+            Ok(UnitQuaternion::from_rotation_matrix(
+                &Rotation3::from_matrix(&m),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use vision_calibration_dataset::PoseColumnMap;
+
+    fn convention(
+        transform: TransformConvention,
+        rotation_format: RotationFormat,
+        translation_units: TranslationUnits,
+    ) -> PoseConvention {
+        PoseConvention {
+            transform,
+            rotation_format,
+            translation_units,
+        }
+    }
+
+    fn quat_columns(pose_id: Option<&str>) -> PoseColumnMap {
+        PoseColumnMap {
+            pose_id: pose_id.map(str::to_string),
+            tx: "tx".into(),
+            ty: "ty".into(),
+            tz: "tz".into(),
+            rotation: vec!["qx".into(), "qy".into(), "qz".into(), "qw".into()],
+        }
+    }
+
+    fn write_temp(content: &str, ext: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(format!("poses.{ext}"));
+        let mut f = std::fs::File::create(&path).expect("create");
+        f.write_all(content.as_bytes()).expect("write");
+        (dir, path)
+    }
+
+    fn source(path: &Path, format: RobotPoseFormat, columns: PoseColumnMap) -> RobotPoseSource {
+        RobotPoseSource {
+            path: path.to_path_buf(),
+            format,
+            columns,
+        }
+    }
+
+    const FRAC_1_SQRT_2: f64 = std::f64::consts::FRAC_1_SQRT_2;
+
+    #[test]
+    fn csv_quat_xyzw_roundtrip() {
+        // 90° about Z: q = (0, 0, sin 45°, cos 45°) in xyzw order.
+        let csv = format!("tx,ty,tz,qx,qy,qz,qw\n0.1,0.2,0.3,0,0,{FRAC_1_SQRT_2},{FRAC_1_SQRT_2}");
+        let (_dir, path) = write_temp(&csv, "csv");
+        let src = source(&path, RobotPoseFormat::Csv, quat_columns(None));
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::M,
+        );
+        let poses = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap();
+        assert_eq!(poses.len(), 1);
+        let p = &poses[0].base_se3_gripper;
+        assert!((p.translation.vector - Vector3::new(0.1, 0.2, 0.3)).norm() < 1e-12);
+        let expected = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), 90f64.to_radians());
+        assert!(p.rotation.angle_to(&expected) < 1e-9);
+    }
+
+    #[test]
+    fn euler_orders_are_intrinsic_and_distinct() {
+        // For a pure 90° Z rotation both orders agree...
+        let z90_xyz = rotation_from_values(RotationFormat::EulerXyzDeg, &[0.0, 0.0, 90.0]).unwrap();
+        let z90_zyx = rotation_from_values(RotationFormat::EulerZyxDeg, &[90.0, 0.0, 0.0]).unwrap();
+        let expected = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), 90f64.to_radians());
+        assert!(z90_xyz.angle_to(&expected) < 1e-12);
+        assert!(z90_zyx.angle_to(&expected) < 1e-12);
+
+        // ...but a mixed rotation must depend on the order. ZYX takes
+        // its arguments as (z, y, x), so feed the same per-axis angles
+        // to both and require the results to differ.
+        let xyz = rotation_from_values(RotationFormat::EulerXyzDeg, &[90.0, 45.0, 10.0]).unwrap();
+        let zyx = rotation_from_values(RotationFormat::EulerZyxDeg, &[10.0, 45.0, 90.0]).unwrap();
+        let manual_xyz = UnitQuaternion::from_axis_angle(&Vector3::x_axis(), 90f64.to_radians())
+            * UnitQuaternion::from_axis_angle(&Vector3::y_axis(), 45f64.to_radians())
+            * UnitQuaternion::from_axis_angle(&Vector3::z_axis(), 10f64.to_radians());
+        assert!(xyz.angle_to(&manual_xyz) < 1e-12, "intrinsic XYZ order");
+        assert!(
+            xyz.angle_to(&zyx) > 1e-3,
+            "XYZ and ZYX must differ on a mixed rotation"
+        );
+
+        // ZYX matches nalgebra's roll-pitch-yaw with reversed args.
+        let nalg = UnitQuaternion::from_euler_angles(
+            90f64.to_radians(),
+            45f64.to_radians(),
+            10f64.to_radians(),
+        );
+        assert!(zyx.angle_to(&nalg) < 1e-12, "ZYX == nalgebra rpy");
+    }
+
+    #[test]
+    fn axis_angle_and_matrix_agree() {
+        let axis_angle = [0.3, -0.2, 0.5];
+        let q = UnitQuaternion::from_scaled_axis(Vector3::new(
+            axis_angle[0],
+            axis_angle[1],
+            axis_angle[2],
+        ));
+        let from_aa = rotation_from_values(RotationFormat::AxisAngleRad, &axis_angle).unwrap();
+        assert!(from_aa.angle_to(&q) < 1e-12);
+
+        let m = q.to_rotation_matrix();
+        #[rustfmt::skip]
+        let values = [
+            m[(0, 0)], m[(0, 1)], m[(0, 2)], 99.0, // 4th column ignored
+            m[(1, 0)], m[(1, 1)], m[(1, 2)], 99.0,
+            m[(2, 0)], m[(2, 1)], m[(2, 2)], 99.0,
+            0.0, 0.0, 0.0, 1.0,
+        ];
+        let from_m = rotation_from_values(RotationFormat::Matrix4x4RowMajor, &values).unwrap();
+        assert!(from_m.angle_to(&q) < 1e-9);
+    }
+
+    #[test]
+    fn tcp_base_is_inverted_and_mm_scaled() {
+        let q = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), 0.7);
+        let t_b_g = Iso3::from_parts(Vector3::new(0.4, -0.1, 1.2).into(), q);
+        let t_g_b = t_b_g.inverse();
+        // Encode T_tcp_base in millimetres; expect T_base_tcp in metres back.
+        let csv = format!(
+            "tx,ty,tz,qx,qy,qz,qw\n{},{},{},{},{},{},{}",
+            t_g_b.translation.x * 1000.0,
+            t_g_b.translation.y * 1000.0,
+            t_g_b.translation.z * 1000.0,
+            t_g_b.rotation.i,
+            t_g_b.rotation.j,
+            t_g_b.rotation.k,
+            t_g_b.rotation.w,
+        );
+        let (_dir, path) = write_temp(&csv, "csv");
+        let src = source(&path, RobotPoseFormat::Csv, quat_columns(None));
+        let conv = convention(
+            TransformConvention::TTcpBase,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::Mm,
+        );
+        let poses = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap();
+        let got = &poses[0].base_se3_gripper;
+        assert!((got.translation.vector - t_b_g.translation.vector).norm() < 1e-9);
+        assert!(got.rotation.angle_to(&t_b_g.rotation) < 1e-9);
+    }
+
+    #[test]
+    fn jsonl_with_pose_id() {
+        let jsonl = concat!(
+            r#"{"view": "0007", "tx": 1, "ty": 2, "tz": 3, "qx": 0, "qy": 0, "qz": 0, "qw": 1}"#,
+            "\n",
+            r#"{"view": "0010", "tx": 4, "ty": 5, "tz": 6, "qx": 0, "qy": 0, "qz": 0, "qw": 1}"#,
+        );
+        let (_dir, path) = write_temp(jsonl, "jsonl");
+        let src = source(&path, RobotPoseFormat::Jsonl, quat_columns(Some("view")));
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::M,
+        );
+        let poses = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap();
+        assert_eq!(poses.len(), 2);
+        assert_eq!(poses[0].id.as_deref(), Some("0007"));
+        assert_eq!(poses[1].id.as_deref(), Some("0010"));
+        assert!((poses[1].base_se3_gripper.translation.x - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn json_array_parses() {
+        let json = r#"[{"tx": 1, "ty": 0, "tz": 0, "qx": 0, "qy": 0, "qz": 0, "qw": 1}]"#;
+        let (_dir, path) = write_temp(json, "json");
+        let src = source(&path, RobotPoseFormat::Json, quat_columns(None));
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::M,
+        );
+        let poses = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap();
+        assert_eq!(poses.len(), 1);
+    }
+
+    #[test]
+    fn missing_column_is_actionable() {
+        let csv = "tx,ty,tz,qx,qy,qz\n1,2,3,0,0,0"; // qw missing
+        let (_dir, path) = write_temp(csv, "csv");
+        let src = source(&path, RobotPoseFormat::Csv, quat_columns(None));
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::M,
+        );
+        let err = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap_err();
+        match err {
+            RunError::PoseParse { message, .. } => {
+                assert!(message.contains("qw"), "got: {message}")
+            }
+            other => panic!("expected PoseParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_number_is_actionable() {
+        let csv = "tx,ty,tz,qx,qy,qz,qw\n1,2,three,0,0,0,1";
+        let (_dir, path) = write_temp(csv, "csv");
+        let src = source(&path, RobotPoseFormat::Csv, quat_columns(None));
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::M,
+        );
+        let err = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap_err();
+        match err {
+            RunError::PoseParse { row, message, .. } => {
+                assert_eq!(row, 0);
+                assert!(message.contains("three"), "got: {message}");
+            }
+            other => panic!("expected PoseParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quoted_csv_rejected() {
+        let csv = "tx,ty,tz,qx,qy,qz,qw\n\"1\",2,3,0,0,0,1";
+        let (_dir, path) = write_temp(csv, "csv");
+        let src = source(&path, RobotPoseFormat::Csv, quat_columns(None));
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::QuatXyzw,
+            TranslationUnits::M,
+        );
+        let err = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap_err();
+        assert!(format!("{err}").contains("quoted CSV"));
+    }
+}

--- a/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
@@ -1,0 +1,625 @@
+//! `DatasetSpec → RigDataset` converters for the `RigExtrinsics` and
+//! `RigHandeye` topologies.
+//!
+//! Both share the same per-view/per-camera detection loop; hand-eye
+//! additionally loads robot poses from the manifest's
+//! [`RobotPoseSource`](vision_calibration_dataset::RobotPoseSource)
+//! and attaches one `RobotPoseMeta` per kept view.
+//!
+//! A camera that sees fewer than 4 features in a view contributes a
+//! `None` slot (the rig IR supports per-camera gaps); a view where
+//! *no* camera reaches 4 features is dropped entirely.
+
+use std::path::{Path, PathBuf};
+
+use vision_calibration_core::{CorrespondenceView, NoMeta, RigDataset, RigView, RigViewObs};
+use vision_calibration_dataset::{DatasetSpec, PosePairing, Topology, validate};
+use vision_calibration_detect::DetectionCache;
+use vision_calibration_optim::RobotPoseMeta;
+
+use super::pairing::pair_views;
+use super::poses::{ParsedPose, load_robot_poses};
+use super::{
+    RunError, augment_config_with_roi, detect_features, expand_camera_images, features_to_obs,
+    pattern_repr, pick_detector, target_to_detector_config,
+};
+
+/// Result of a rig dataset conversion.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct RigRunResult<Meta> {
+    /// The IR ready to feed into `CalibrationSession::set_input`.
+    pub dataset: RigDataset<Meta>,
+    /// `view_paths[view][camera]` — source image path per kept view
+    /// and camera, aligned with `dataset.views`; `None` where the
+    /// camera contributed no usable observation.
+    pub view_paths: Vec<Vec<Option<PathBuf>>>,
+    /// Number of kept views (≥1 camera with ≥4 features).
+    pub usable_views: usize,
+    /// Total number of paired views attempted.
+    pub total_views: usize,
+}
+
+/// Convert a multi-camera manifest + cache into a
+/// [`RigDataset<NoMeta>`] for `RigExtrinsics`.
+pub fn build_rig_extrinsics_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<RigRunResult<NoMeta>, RunError> {
+    if spec.topology != Topology::RigExtrinsics {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let core = build_rig_core(spec, base_dir, cache, force_redetect)?;
+    let views = core
+        .views
+        .into_iter()
+        .map(|(obs, _token)| RigView { obs, meta: NoMeta })
+        .collect();
+    finish(views, spec.cameras.len(), core.view_paths, core.total_views)
+}
+
+/// Convert a multi-camera + robot-poses manifest + cache into a
+/// [`RigDataset<RobotPoseMeta>`] for `RigHandeye`.
+pub fn build_rig_handeye_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<RigRunResult<RobotPoseMeta>, RunError> {
+    if spec.topology != Topology::RigHandeye {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let core = build_rig_core(spec, base_dir, cache, force_redetect)?;
+
+    // `validate` (called inside build_rig_core) guarantees both fields
+    // are present for the RigHandeye topology.
+    let source = spec
+        .robot_poses
+        .as_ref()
+        .expect("validate guarantees robot_poses for RigHandeye");
+    let convention = spec
+        .pose_convention
+        .as_ref()
+        .expect("validate guarantees pose_convention for RigHandeye");
+    let poses = load_robot_poses(source, convention, base_dir)?;
+
+    let views = pair_poses_to_views(core.views, &poses, spec, core.total_views)?;
+    finish(views, spec.cameras.len(), core.view_paths, core.total_views)
+}
+
+/// Kept views (observations + pairing token), pre-meta.
+struct RigCore {
+    views: Vec<(RigViewObs, String)>,
+    view_paths: Vec<Vec<Option<PathBuf>>>,
+    total_views: usize,
+}
+
+fn build_rig_core(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<RigCore, RunError> {
+    // Same gate ordering as the planar converter: target + validation
+    // + pairing config before any filesystem access.
+    let (detector_name, detector_config) = target_to_detector_config(&spec.target)?;
+    let detector = pick_detector(detector_name)?;
+    validate(spec)?;
+
+    let Some(pairing) = &spec.pose_pairing else {
+        return Err(RunError::AskUser {
+            field: "pose_pairing".into(),
+            prompt: "Rig topologies need to know how per-camera images align into views. \
+                     Pick by_index (same count and order everywhere) or \
+                     shared_filename_token (a regex extracts a view token from filenames)."
+                .into(),
+            suggestions: vec!["by_index".into(), "shared_filename_token".into()],
+        });
+    };
+
+    let mut images: Vec<Vec<PathBuf>> = Vec::with_capacity(spec.cameras.len());
+    for camera in &spec.cameras {
+        let expanded = expand_camera_images(camera, base_dir)?;
+        if expanded.is_empty() {
+            return Err(RunError::EmptyImageMatch {
+                camera_id: camera.id.clone(),
+                pattern: pattern_repr(&camera.images),
+                base: base_dir.to_path_buf(),
+            });
+        }
+        images.push(expanded);
+    }
+    let camera_ids: Vec<String> = spec.cameras.iter().map(|c| c.id.clone()).collect();
+    let paired = pair_views(&images, &camera_ids, pairing)?;
+    let total_views = paired.paths.len();
+
+    // Per-camera key configs (ROI differs per camera).
+    let key_configs: Vec<_> = spec
+        .cameras
+        .iter()
+        .map(|c| augment_config_with_roi(&detector_config, c.roi_xywh))
+        .collect();
+
+    let mut views: Vec<(RigViewObs, String)> = Vec::new();
+    let mut view_paths: Vec<Vec<Option<PathBuf>>> = Vec::new();
+    let mut per_camera_usable = vec![0usize; spec.cameras.len()];
+
+    for (paths, token) in paired.paths.iter().zip(&paired.tokens) {
+        let mut cameras: Vec<Option<CorrespondenceView>> = Vec::with_capacity(paths.len());
+        let mut kept_paths: Vec<Option<PathBuf>> = Vec::with_capacity(paths.len());
+        for (cam_idx, maybe_path) in paths.iter().enumerate() {
+            let Some(path) = maybe_path else {
+                cameras.push(None);
+                kept_paths.push(None);
+                continue;
+            };
+            let (features, _cache_hit) = detect_features(
+                detector.as_ref(),
+                detector_name,
+                &detector_config,
+                &key_configs[cam_idx],
+                spec.cameras[cam_idx].roi_xywh,
+                path,
+                cache,
+                force_redetect,
+            )?;
+            if features.len() < 4 {
+                cameras.push(None);
+                kept_paths.push(None);
+                continue;
+            }
+            per_camera_usable[cam_idx] += 1;
+            cameras.push(Some(features_to_obs(&features)));
+            kept_paths.push(Some(path.clone()));
+        }
+        if cameras.iter().all(Option::is_none) {
+            // No camera saw the target in this view — drop it (still
+            // counted in total_views).
+            continue;
+        }
+        views.push((RigViewObs { cameras }, token.clone()));
+        view_paths.push(kept_paths);
+    }
+
+    // Every camera must contribute at least one usable observation —
+    // a camera with zero observations cannot be placed in the rig.
+    for (cam_idx, usable) in per_camera_usable.iter().enumerate() {
+        if *usable == 0 {
+            return Err(RunError::InsufficientUsableViews {
+                camera_id: spec.cameras[cam_idx].id.clone(),
+                usable: 0,
+                total: total_views,
+            });
+        }
+    }
+
+    Ok(RigCore {
+        views,
+        view_paths,
+        total_views,
+    })
+}
+
+/// Attach one robot pose to every kept view.
+fn pair_poses_to_views(
+    views: Vec<(RigViewObs, String)>,
+    poses: &[ParsedPose],
+    spec: &DatasetSpec,
+    total_views: usize,
+) -> Result<Vec<RigView<RobotPoseMeta>>, RunError> {
+    let pairing = spec
+        .pose_pairing
+        .as_ref()
+        .expect("build_rig_core already required pose_pairing");
+
+    match pairing {
+        PosePairing::ByIndex => {
+            // Poses pair with *paired* views (pre-drop): pose[i] belongs
+            // to view token i even when that view was later dropped.
+            if poses.len() != total_views {
+                return Err(RunError::PoseCountMismatch {
+                    poses: poses.len(),
+                    views: total_views,
+                });
+            }
+            views
+                .into_iter()
+                .map(|(obs, token)| {
+                    let index: usize = token
+                        .parse()
+                        .expect("by_index pairing tokens are stringified indices");
+                    Ok(RigView {
+                        obs,
+                        meta: RobotPoseMeta {
+                            base_se3_gripper: poses[index].base_se3_gripper,
+                        },
+                    })
+                })
+                .collect()
+        }
+        PosePairing::SharedFilenameToken { .. } => {
+            // Poses pair by their pose_id column equalling the view token.
+            if spec
+                .robot_poses
+                .as_ref()
+                .is_none_or(|s| s.columns.pose_id.is_none())
+            {
+                return Err(RunError::AskUser {
+                    field: "robot_poses.columns.pose_id".into(),
+                    prompt: "shared_filename_token pairing needs a pose_id column mapping \
+                             so each pose row can be matched to its view token."
+                        .into(),
+                    suggestions: vec![],
+                });
+            }
+            let by_id: std::collections::HashMap<&str, &ParsedPose> = poses
+                .iter()
+                .filter_map(|p| p.id.as_deref().map(|id| (id, p)))
+                .collect();
+            views
+                .into_iter()
+                .map(|(obs, token)| {
+                    let pose = by_id.get(token.as_str()).ok_or_else(|| {
+                        RunError::PairingTokenMismatch {
+                            message: format!(
+                                "no pose row with pose_id {token:?} (the cameras produced a \
+                                 view with this token)"
+                            ),
+                        }
+                    })?;
+                    Ok(RigView {
+                        obs,
+                        meta: RobotPoseMeta {
+                            base_se3_gripper: pose.base_se3_gripper,
+                        },
+                    })
+                })
+                .collect()
+        }
+    }
+}
+
+fn finish<Meta>(
+    views: Vec<RigView<Meta>>,
+    num_cameras: usize,
+    view_paths: Vec<Vec<Option<PathBuf>>>,
+    total_views: usize,
+) -> Result<RigRunResult<Meta>, RunError> {
+    let usable_views = views.len();
+    let dataset = RigDataset::new(views, num_cameras).expect(
+        "RigDataset::new failed after the runner enforced non-empty views \
+         and per-view camera counts; this indicates a core-crate regression",
+    );
+    Ok(RigRunResult {
+        dataset,
+        view_paths,
+        usable_views,
+        total_views,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use vision_calibration_dataset::{
+        CameraSource, ImagePattern, PoseColumnMap, PoseConvention, RobotPoseFormat,
+        RobotPoseSource, RotationFormat, TargetSpec, TransformConvention, TranslationUnits,
+    };
+    use vision_calibration_detect::{CacheKey, CachedFeatures, Feature, FsDetectionCache};
+
+    /// Synthetic features on the chessboard lattice — enough (≥4) for
+    /// the runner to accept the view.
+    fn grid_features(n: usize) -> Vec<Feature> {
+        (0..n)
+            .map(|i| Feature {
+                image_xy: [100.0 + 10.0 * i as f64, 200.0 + 5.0 * i as f64],
+                world_xyz: [0.025 * i as f64, 0.0, 0.0],
+            })
+            .collect()
+    }
+
+    fn detector_config() -> serde_json::Value {
+        json!({"rows": 9, "cols": 6, "square_size_m": 0.025})
+    }
+
+    /// Write a dummy "image" file and pre-seed the cache for it, so the
+    /// runner takes the cache-hit path and never decodes the bytes.
+    fn seed_image(
+        dir: &Path,
+        cache: &FsDetectionCache,
+        rel_path: &str,
+        features: Vec<Feature>,
+    ) -> PathBuf {
+        let path = dir.join(rel_path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = rel_path.as_bytes(); // content only needs to be unique
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(bytes).unwrap();
+        let key = CacheKey::from_inputs(bytes, "chessboard", &detector_config());
+        cache.put(&key, &CachedFeatures { features }).unwrap();
+        path
+    }
+
+    fn rig_spec(camera_lists: &[Vec<&str>]) -> DatasetSpec {
+        DatasetSpec {
+            version: 1,
+            cameras: camera_lists
+                .iter()
+                .enumerate()
+                .map(|(i, paths)| CameraSource {
+                    id: format!("cam{i}"),
+                    images: ImagePattern::List {
+                        paths: paths.iter().map(PathBuf::from).collect(),
+                    },
+                    roi_xywh: None,
+                })
+                .collect(),
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: None,
+            topology: Topology::RigExtrinsics,
+            pose_pairing: Some(PosePairing::ByIndex),
+            pose_convention: None,
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    #[test]
+    fn rig_extrinsics_by_index_builds_dataset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for cam in 0..2 {
+            for view in 0..3 {
+                seed_image(
+                    tmp.path(),
+                    &cache,
+                    &format!("cam{cam}/img_{view}.png"),
+                    grid_features(6),
+                );
+            }
+        }
+        let spec = rig_spec(&[
+            vec!["cam0/img_0.png", "cam0/img_1.png", "cam0/img_2.png"],
+            vec!["cam1/img_0.png", "cam1/img_1.png", "cam1/img_2.png"],
+        ]);
+        let result = build_rig_extrinsics_input(&spec, tmp.path(), &cache, false).unwrap();
+        assert_eq!(result.dataset.num_cameras, 2);
+        assert_eq!(result.dataset.num_views(), 3);
+        assert_eq!(result.usable_views, 3);
+        assert_eq!(result.total_views, 3);
+        assert!(
+            result.view_paths[0][0]
+                .as_ref()
+                .unwrap()
+                .ends_with("cam0/img_0.png")
+        );
+        assert!(result.dataset.views[2].obs.cameras[1].is_some());
+    }
+
+    #[test]
+    fn weak_view_becomes_none_slot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_image(tmp.path(), &cache, "cam0/a.png", grid_features(6));
+        seed_image(tmp.path(), &cache, "cam0/b.png", grid_features(6));
+        seed_image(tmp.path(), &cache, "cam1/a.png", grid_features(6));
+        // cam1's second view has too few features → None slot.
+        seed_image(tmp.path(), &cache, "cam1/b.png", grid_features(3));
+        let spec = rig_spec(&[
+            vec!["cam0/a.png", "cam0/b.png"],
+            vec!["cam1/a.png", "cam1/b.png"],
+        ]);
+        let result = build_rig_extrinsics_input(&spec, tmp.path(), &cache, false).unwrap();
+        assert_eq!(result.dataset.num_views(), 2);
+        assert!(result.dataset.views[1].obs.cameras[0].is_some());
+        assert!(result.dataset.views[1].obs.cameras[1].is_none());
+        assert!(result.view_paths[1][1].is_none());
+    }
+
+    #[test]
+    fn camera_with_zero_usable_views_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_image(tmp.path(), &cache, "cam0/a.png", grid_features(6));
+        seed_image(tmp.path(), &cache, "cam1/a.png", grid_features(2));
+        let spec = rig_spec(&[vec!["cam0/a.png"], vec!["cam1/a.png"]]);
+        let err = build_rig_extrinsics_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::InsufficientUsableViews { camera_id, .. } => assert_eq!(camera_id, "cam1"),
+            other => panic!("expected InsufficientUsableViews, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_pose_pairing_asks_user() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let mut spec = rig_spec(&[vec!["cam0/a.png"], vec!["cam1/a.png"]]);
+        spec.pose_pairing = None;
+        let err = build_rig_extrinsics_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::AskUser { field, .. } => assert_eq!(field, "pose_pairing"),
+            other => panic!("expected AskUser, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_topology_rejected_by_both_converters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let spec = rig_spec(&[vec!["a.png"], vec!["b.png"]]); // RigExtrinsics
+        let err = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        assert!(matches!(err, RunError::UnsupportedTopology { .. }));
+
+        let mut spec2 = rig_spec(&[vec!["a.png"], vec!["b.png"]]);
+        spec2.topology = Topology::RigHandeye;
+        let err2 = build_rig_extrinsics_input(&spec2, tmp.path(), &cache, false).unwrap_err();
+        assert!(matches!(err2, RunError::UnsupportedTopology { .. }));
+    }
+
+    fn handeye_spec_with_poses(dir: &Path, csv: &str) -> DatasetSpec {
+        let pose_path = dir.join("poses.csv");
+        std::fs::write(&pose_path, csv).unwrap();
+        let mut spec = rig_spec(&[
+            vec!["cam0/img_0.png", "cam0/img_1.png", "cam0/img_2.png"],
+            vec!["cam1/img_0.png", "cam1/img_1.png", "cam1/img_2.png"],
+        ]);
+        spec.topology = Topology::RigHandeye;
+        spec.robot_poses = Some(RobotPoseSource {
+            path: PathBuf::from("poses.csv"),
+            format: RobotPoseFormat::Csv,
+            columns: PoseColumnMap {
+                pose_id: None,
+                tx: "tx".into(),
+                ty: "ty".into(),
+                tz: "tz".into(),
+                rotation: vec!["qx".into(), "qy".into(), "qz".into(), "qw".into()],
+            },
+        });
+        spec.pose_convention = Some(PoseConvention {
+            transform: TransformConvention::TBaseTcp,
+            rotation_format: RotationFormat::QuatXyzw,
+            translation_units: TranslationUnits::M,
+        });
+        spec
+    }
+
+    #[test]
+    fn rig_handeye_by_index_attaches_poses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for cam in 0..2 {
+            for view in 0..3 {
+                seed_image(
+                    tmp.path(),
+                    &cache,
+                    &format!("cam{cam}/img_{view}.png"),
+                    grid_features(6),
+                );
+            }
+        }
+        let csv = "tx,ty,tz,qx,qy,qz,qw\n\
+                   0.1,0,0,0,0,0,1\n\
+                   0.2,0,0,0,0,0,1\n\
+                   0.3,0,0,0,0,0,1";
+        let spec = handeye_spec_with_poses(tmp.path(), csv);
+        let result = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap();
+        assert_eq!(result.dataset.num_views(), 3);
+        let xs: Vec<f64> = result
+            .dataset
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper.translation.x)
+            .collect();
+        assert_eq!(xs, vec![0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn rig_handeye_pose_count_mismatch_is_actionable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for cam in 0..2 {
+            for view in 0..3 {
+                seed_image(
+                    tmp.path(),
+                    &cache,
+                    &format!("cam{cam}/img_{view}.png"),
+                    grid_features(6),
+                );
+            }
+        }
+        let csv = "tx,ty,tz,qx,qy,qz,qw\n0.1,0,0,0,0,0,1"; // 1 pose, 3 views
+        let spec = handeye_spec_with_poses(tmp.path(), csv);
+        let err = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::PoseCountMismatch { poses, views } => {
+                assert_eq!((poses, views), (1, 3));
+            }
+            other => panic!("expected PoseCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_pairing_without_pose_id_asks_user() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for cam in 0..2 {
+            for view in 0..3 {
+                seed_image(
+                    tmp.path(),
+                    &cache,
+                    &format!("cam{cam}/img_{view}.png"),
+                    grid_features(6),
+                );
+            }
+        }
+        let csv = "tx,ty,tz,qx,qy,qz,qw\n0.1,0,0,0,0,0,1";
+        let mut spec = handeye_spec_with_poses(tmp.path(), csv);
+        spec.pose_pairing = Some(PosePairing::SharedFilenameToken {
+            regex: r"^img_(?<view>\d+)\.png$".into(),
+            group: "view".into(),
+        });
+        let err = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::AskUser { field, .. } => {
+                assert_eq!(field, "robot_poses.columns.pose_id")
+            }
+            other => panic!("expected AskUser, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_pairing_matches_poses_by_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for cam in 0..2 {
+            for view in 0..2 {
+                seed_image(
+                    tmp.path(),
+                    &cache,
+                    &format!("cam{cam}/img_{view}.png"),
+                    grid_features(6),
+                );
+            }
+        }
+        let csv = "view,tx,ty,tz,qx,qy,qz,qw\n\
+                   1,0.2,0,0,0,0,0,1\n\
+                   0,0.1,0,0,0,0,0,1"; // deliberately out of order
+        let mut spec = handeye_spec_with_poses(tmp.path(), csv);
+        spec.cameras[0].images = ImagePattern::List {
+            paths: vec!["cam0/img_0.png".into(), "cam0/img_1.png".into()],
+        };
+        spec.cameras[1].images = ImagePattern::List {
+            paths: vec!["cam1/img_0.png".into(), "cam1/img_1.png".into()],
+        };
+        spec.pose_pairing = Some(PosePairing::SharedFilenameToken {
+            regex: r"^img_(?<view>\d+)\.png$".into(),
+            group: "view".into(),
+        });
+        if let Some(rp) = &mut spec.robot_poses {
+            rp.columns.pose_id = Some("view".into());
+        }
+        let result = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap();
+        assert_eq!(result.dataset.num_views(), 2);
+        // Views are sorted by token; pose rows were reversed in the file.
+        let xs: Vec<f64> = result
+            .dataset
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper.translation.x)
+            .collect();
+        assert_eq!(xs, vec![0.1, 0.2]);
+    }
+}

--- a/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
@@ -258,10 +258,24 @@ fn pair_poses_to_views(
                     suggestions: vec![],
                 });
             }
-            let by_id: std::collections::HashMap<&str, &ParsedPose> = poses
-                .iter()
-                .filter_map(|p| p.id.as_deref().map(|id| (id, p)))
-                .collect();
+            // Collecting straight into a HashMap would silently keep only
+            // the last row for a repeated pose_id, attaching an arbitrary
+            // pose to the matching view. A duplicate id is an ambiguous
+            // manifest, so reject it up front like a missing token.
+            let mut by_id: std::collections::HashMap<&str, &ParsedPose> =
+                std::collections::HashMap::with_capacity(poses.len());
+            for pose in poses {
+                if let Some(id) = pose.id.as_deref()
+                    && by_id.insert(id, pose).is_some()
+                {
+                    return Err(RunError::PairingTokenMismatch {
+                        message: format!(
+                            "duplicate pose_id {id:?} in the robot-pose table; each \
+                             pose_id must be unique so views pair unambiguously"
+                        ),
+                    });
+                }
+            }
             views
                 .into_iter()
                 .map(|(obs, token)| {
@@ -621,5 +635,50 @@ mod tests {
             .map(|v| v.meta.base_se3_gripper.translation.x)
             .collect();
         assert_eq!(xs, vec![0.1, 0.2]);
+    }
+
+    #[test]
+    fn token_pairing_rejects_duplicate_pose_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for cam in 0..2 {
+            for view in 0..2 {
+                seed_image(
+                    tmp.path(),
+                    &cache,
+                    &format!("cam{cam}/img_{view}.png"),
+                    grid_features(6),
+                );
+            }
+        }
+        // Two rows share pose_id "0" — an ambiguous table that must be
+        // rejected rather than silently keeping the last row.
+        let csv = "view,tx,ty,tz,qx,qy,qz,qw\n\
+                   0,0.1,0,0,0,0,0,1\n\
+                   0,0.9,0,0,0,0,0,1";
+        let mut spec = handeye_spec_with_poses(tmp.path(), csv);
+        spec.cameras[0].images = ImagePattern::List {
+            paths: vec!["cam0/img_0.png".into(), "cam0/img_1.png".into()],
+        };
+        spec.cameras[1].images = ImagePattern::List {
+            paths: vec!["cam1/img_0.png".into(), "cam1/img_1.png".into()],
+        };
+        spec.pose_pairing = Some(PosePairing::SharedFilenameToken {
+            regex: r"^img_(?<view>\d+)\.png$".into(),
+            group: "view".into(),
+        });
+        if let Some(rp) = &mut spec.robot_poses {
+            rp.columns.pose_id = Some("view".into());
+        }
+        let err = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::PairingTokenMismatch { message } => {
+                assert!(
+                    message.contains("duplicate pose_id") && message.contains('0'),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected PairingTokenMismatch, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Second PR of the **B3c-1** iteration (stacked on #51).

## What
- `dataset_runner.rs` → `dataset_runner/{mod,planar,poses,pairing,rig}.rs` (public paths stable via re-exports); shared `detect_features()` cache-or-detect path.
- **Scheimpflug**: `build_planar_input` now accepts the `ScheimpflugIntrinsics` topology (same `PlanarDataset` input as planar).
- **poses.rs**: `RobotPoseSource` loading (CSV/JSON/JSONL) normalized to `T_B_G` in metres. All 8 `RotationFormat`s with explicitly-composed intrinsic Euler orders (nalgebra's `from_euler_angles` is ZYX-only); `Matrix4x4RowMajor` contributes rotation only — translation always from `tx/ty/tz` (documented rule); mm→m scaling; `TTcpBase`/`TTcpWorld` inverted; world-fixed frames treated as the base frame.
- **pairing.rs**: `by_index` (equal counts enforced) and `shared_filename_token` (named capture group, sorted token **union** with `None` gaps — the rig IR supports per-camera holes, so a camera that blinked doesn't kill the view). New `regex` workspace dep (part of the shipped manifest contract).
- **rig.rs**: `build_rig_extrinsics_input` → `RigDataset<NoMeta>`, `build_rig_handeye_input` → `RigDataset<RobotPoseMeta>`. <4-feature observations become `None` slots; all-`None` views dropped; a camera with zero usable observations is a hard error. Hand-eye poses pair by index (count-checked against *paired* views) or by `pose_id == token`.
- Glob expansion now **natural-sorts** (`Im_2` < `Im_10`), ported from the bench harness.
- New `RunError` variants + ADR-0019 `AskUser` events: missing `pose_pairing` on rig topologies, missing `pose_id` column under token pairing.

## Tests (26 new)
- Pose formats vs hand-computed quaternions (90° Z for both Euler orders; ZYX ≡ nalgebra rpy with reversed args), axis-angle/matrix agreement, mm + inversion roundtrip, CSV/JSON/JSONL parse errors (missing column, bad number, quoted CSV rejected).
- Pairing: index mismatch, token extraction/gaps/duplicates, regex compile + missing group.
- Rig converters run against a **pre-seeded detection cache** (no real detection): dataset shape, None slots, zero-usable camera, pose attachment in token order, AskUser events.

Gates: fmt, clippy -D warnings, test --workspace --all-features (203 pipeline tests), doc (0 warnings), emit-schemas clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)