### PR TITLE
feat(app): Tauri topology dispatch + default_config_cmd (B3c-1, PR 3/4)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tempfile",
  "vision-calibration",
  "vision-calibration-core",
  "vision-calibration-dataset",
@@ -5620,6 +5621,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6445,6 +6459,7 @@ dependencies = [
  "glob",
  "image",
  "nalgebra",
+ "regex",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -38,6 +38,9 @@ vision-calibration-dataset = { path = "../../crates/vision-calibration-dataset" 
 vision-calibration-detect = { path = "../../crates/vision-calibration-detect" }
 dirs = "5"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 # Avoid touching the embed_plist build hooks unless explicitly running
 # `cargo tauri build`. `tauri dev` enables what it needs from the CLI.

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub fn run() {
             commands::compute_epipolar_overlay_undistorted,
             commands::undistort_points,
             run::run_calibration_cmd,
+            run::default_config_cmd,
         ])
         .run(tauri::generate_context!())
         .expect("failed to launch calibration-diagnose");

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -1,11 +1,13 @@
-//! In-process calibration runner for the Run workspace (B3b).
+//! In-process calibration runner for the Run workspace (B3b/B3c).
 //!
 //! Takes a JSON-encoded [`DatasetSpec`] manifest plus a JSON-encoded
-//! per-problem `*Config`, dispatches to the right `CalibrationSession`,
-//! runs detection (cached) + calibration on a `tauri::async_runtime::spawn_blocking`
-//! task, and returns the export plus a structured log. PR 1 wires up
-//! `PlanarIntrinsics` only; PR 2 (B3c) extends to the other 7 topologies
-//! via the same shape.
+//! per-problem `*Config`, dispatches on the manifest's topology to the
+//! right `CalibrationSession`, runs detection (cached) + calibration on
+//! a `tauri::async_runtime::spawn_blocking` task, and returns the
+//! export plus run metrics. Supported topologies: `PlanarIntrinsics`,
+//! `ScheimpflugIntrinsics`, `RigExtrinsics`, `RigHandeye`. The laser
+//! topologies await the laser-frame manifest design; `SingleCamHandeye`
+//! follows in B3c-2.
 //!
 //! Per ADR 0019, ambiguity that the runtime cannot auto-resolve is
 //! surfaced as a structured `RunResponse::AskUser` so the Run workspace
@@ -17,37 +19,55 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
-use vision_calibration_core::{FrameRef, ImageManifest};
+use vision_calibration_core::{FrameRef, ImageManifest, PlanarDataset, RigDataset};
 use vision_calibration_dataset::{DatasetSpec, Topology};
 use vision_calibration_detect::FsDetectionCache;
-use vision_calibration_pipeline::dataset_runner::{RunError, build_planar_input};
-use vision_calibration_pipeline::planar_intrinsics::{
-    PlanarIntrinsicsConfig, PlanarIntrinsicsProblem, run_calibration,
+use vision_calibration_pipeline::dataset_runner::{
+    RunError, build_planar_input, build_rig_extrinsics_input, build_rig_handeye_input,
 };
-use vision_calibration_pipeline::session::CalibrationSession;
+use vision_calibration_pipeline::laserline_device::LaserlineDeviceConfig;
+use vision_calibration_pipeline::planar_intrinsics::{
+    PlanarIntrinsicsConfig, PlanarIntrinsicsProblem, run_calibration as run_planar_calibration,
+};
+use vision_calibration_pipeline::rig_extrinsics::{
+    RigExtrinsicsConfig, RigExtrinsicsProblem, run_calibration as run_rig_extrinsics_calibration,
+};
+use vision_calibration_pipeline::rig_handeye::{
+    RigHandeyeConfig, RigHandeyeProblem, run_calibration as run_rig_handeye_calibration,
+};
+use vision_calibration_pipeline::rig_laserline_device::RigLaserlineDeviceConfig;
+use vision_calibration_pipeline::scheimpflug_intrinsics::{
+    ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsProblem,
+    run_calibration as run_scheimpflug_calibration,
+};
+use vision_calibration_pipeline::session::{CalibrationSession, ProblemType};
+use vision_calibration_pipeline::single_cam_handeye::SingleCamHandeyeConfig;
 
 use crate::export_cache::ExportCache;
 
 /// Successful calibration run.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RunSuccess {
     /// Final export JSON, ready to drop into the diagnose viewer.
     pub export: serde_json::Value,
     /// Total wall-clock time for detection + calibration.
     pub duration_ms: u64,
-    /// Number of views with >= 4 features after detection.
+    /// Number of usable views after detection. For single-camera
+    /// topologies: views with >= 4 features. For rig topologies: views
+    /// where at least one camera reached >= 4 features.
     pub usable_views: usize,
-    /// Total number of images attempted.
+    /// Total number of views attempted (images for single-camera
+    /// topologies, paired rig views for rig topologies).
     pub total_views: usize,
     /// Whether at least one detection was served from the cache.
-    /// (Useful as a sanity check for "second run is faster"
-    /// in PR 1; precise per-image hit/miss counts come in PR 4.)
+    /// (Sanity check for "second run is faster"; precise per-image
+    /// hit/miss counts come in B3e.)
     pub cache_used: bool,
 }
 
 /// Tagged response shape so the React layer can match on `kind` rather
 /// than parsing free-form error strings.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RunResponse {
     /// Calibration completed and an export was produced.
@@ -104,6 +124,25 @@ pub async fn run_calibration_cmd(
     Ok(response)
 }
 
+/// Tauri command: default `*Config` JSON for a topology.
+///
+/// Single source of truth for the Run workspace's config defaults —
+/// the TS side never hand-copies Rust default values.
+#[tauri::command]
+pub fn default_config_cmd(topology: String) -> Result<serde_json::Value, String> {
+    let value = match topology.as_str() {
+        "planar_intrinsics" => serde_json::to_value(PlanarIntrinsicsConfig::default()),
+        "scheimpflug_intrinsics" => serde_json::to_value(ScheimpflugIntrinsicsConfig::default()),
+        "single_cam_handeye" => serde_json::to_value(SingleCamHandeyeConfig::default()),
+        "laserline_device" => serde_json::to_value(LaserlineDeviceConfig::default()),
+        "rig_extrinsics" => serde_json::to_value(RigExtrinsicsConfig::default()),
+        "rig_handeye" => serde_json::to_value(RigHandeyeConfig::default()),
+        "rig_laserline_device" => serde_json::to_value(RigLaserlineDeviceConfig::default()),
+        other => return Err(format!("unknown topology {other:?}")),
+    };
+    value.map_err(|e| format!("default config serialization failed: {e}"))
+}
+
 fn run_blocking(
     manifest_json: serde_json::Value,
     config_json: serde_json::Value,
@@ -119,91 +158,162 @@ fn run_blocking(
             };
         }
     };
-    let config: PlanarIntrinsicsConfig = match serde_json::from_value(config_json) {
-        Ok(c) => c,
-        Err(e) => {
-            return RunResponse::Failed {
-                category: "config_parse".into(),
-                message: format!("config parse failed: {e}"),
-            };
-        }
-    };
-    if !matches!(spec.topology, Topology::PlanarIntrinsics) {
-        return RunResponse::Failed {
-            category: "unsupported_topology".into(),
-            message: format!(
-                "PR 1 of the runner only supports PlanarIntrinsics; \
-                 manifest declares {:?}. Coverage for the other seven \
-                 topologies ships in B3c.",
-                spec.topology
-            ),
-        };
-    }
-
     let base_dir = Path::new(manifest_dir);
     let detection_cache = FsDetectionCache::new(detection_cache_root(&spec, base_dir));
 
-    // Dataset → IR conversion (validation + detection-with-cache).
-    let planar_run = match build_planar_input(&spec, base_dir, &detection_cache, false) {
+    match spec.topology {
+        Topology::PlanarIntrinsics => run_planar_topology::<PlanarIntrinsicsProblem>(
+            &spec,
+            config_json,
+            base_dir,
+            &detection_cache,
+            started,
+            run_planar_calibration,
+        ),
+        Topology::ScheimpflugIntrinsics => run_planar_topology::<ScheimpflugIntrinsicsProblem>(
+            &spec,
+            config_json,
+            base_dir,
+            &detection_cache,
+            started,
+            |session| run_scheimpflug_calibration(session, None),
+        ),
+        Topology::RigExtrinsics => run_rig_topology::<RigExtrinsicsProblem, _>(
+            &spec,
+            config_json,
+            base_dir,
+            &detection_cache,
+            started,
+            build_rig_extrinsics_input,
+            run_rig_extrinsics_calibration,
+        ),
+        Topology::RigHandeye => run_rig_topology::<RigHandeyeProblem, _>(
+            &spec,
+            config_json,
+            base_dir,
+            &detection_cache,
+            started,
+            build_rig_handeye_input,
+            run_rig_handeye_calibration,
+        ),
+        other @ (Topology::SingleCamHandeye
+        | Topology::LaserlineDevice
+        | Topology::RigLaserlineDevice) => RunResponse::Failed {
+            category: "unsupported_topology".into(),
+            message: format!(
+                "topology {other:?} is not wired into the Run workspace yet \
+                 (the laser topologies land with the laser-frame manifest \
+                 design; single_cam_handeye follows in B3c-2)"
+            ),
+        },
+    }
+}
+
+/// Drive one `CalibrationSession` from parsed input to serialized
+/// export. Generic plumbing shared by every topology arm; the
+/// per-problem differences (input building, `run_calibration` wrapper,
+/// image-manifest shape) stay in the callers.
+fn run_session<P>(
+    input: P::Input,
+    config_json: serde_json::Value,
+    run: impl FnOnce(&mut CalibrationSession<P>) -> Result<(), vision_calibration_pipeline::Error>,
+) -> Result<serde_json::Value, Box<RunResponse>>
+where
+    P: ProblemType,
+{
+    let config: P::Config = serde_json::from_value(config_json).map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "config_parse".into(),
+            message: format!("config parse failed: {e}"),
+        })
+    })?;
+    let mut session = CalibrationSession::<P>::new();
+    session.set_input(input).map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "session_set_input".into(),
+            message: format!("set_input failed: {e}"),
+        })
+    })?;
+    session.set_config(config).map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "session_set_config".into(),
+            message: format!("set_config failed: {e}"),
+        })
+    })?;
+    run(&mut session).map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "calibration_failed".into(),
+            message: format!("calibration failed: {e}"),
+        })
+    })?;
+    let export = session.export().map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "session_export".into(),
+            message: format!("export failed: {e}"),
+        })
+    })?;
+    serde_json::to_value(&export).map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "export_serialize".into(),
+            message: format!("export serialization failed: {e}"),
+        })
+    })
+}
+
+/// Splice an image manifest into a serialized export. Every supported
+/// `*Export` carries an `image_manifest: Option<ImageManifest>` field
+/// with `#[serde(default)]`, so setting it on the JSON value is
+/// round-trip-safe and avoids a cross-export trait.
+fn splice_image_manifest(
+    export: &mut serde_json::Value,
+    manifest: Result<ImageManifest, String>,
+) -> Result<(), Box<RunResponse>> {
+    let manifest = manifest.map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "image_manifest".into(),
+            message: e,
+        })
+    })?;
+    let value = serde_json::to_value(&manifest).map_err(|e| {
+        Box::new(RunResponse::Failed {
+            category: "image_manifest".into(),
+            message: format!("image manifest serialization failed: {e}"),
+        })
+    })?;
+    export["image_manifest"] = value;
+    Ok(())
+}
+
+fn run_planar_topology<P>(
+    spec: &DatasetSpec,
+    config_json: serde_json::Value,
+    base_dir: &Path,
+    detection_cache: &FsDetectionCache,
+    started: Instant,
+    run: impl FnOnce(&mut CalibrationSession<P>) -> Result<(), vision_calibration_pipeline::Error>,
+) -> RunResponse
+where
+    P: ProblemType<Input = PlanarDataset>,
+{
+    let planar_run = match build_planar_input(spec, base_dir, detection_cache, false) {
         Ok(r) => r,
         Err(e) => return run_error_to_response(e),
     };
     let cache_used = planar_run.usable_views > 0; // refined in B3e with hit/miss counts
 
-    // Calibration: drive a session.
-    let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
-    if let Err(e) = session.set_input(planar_run.dataset.clone()) {
-        return RunResponse::Failed {
-            category: "session_set_input".into(),
-            message: format!("set_input failed: {e}"),
-        };
-    }
-    if let Err(e) = session.set_config(config) {
-        return RunResponse::Failed {
-            category: "session_set_config".into(),
-            message: format!("set_config failed: {e}"),
-        };
-    }
-    if let Err(e) = run_calibration(&mut session) {
-        return RunResponse::Failed {
-            category: "calibration_failed".into(),
-            message: format!("calibration failed: {e}"),
-        };
-    }
-    let mut export = match session.export() {
-        Ok(e) => e,
-        Err(e) => {
-            return RunResponse::Failed {
-                category: "session_export".into(),
-                message: format!("export failed: {e}"),
-            };
-        }
-    };
-    export.image_manifest = match planar_image_manifest(&planar_run.view_paths, base_dir) {
-        Ok(m) => Some(m),
-        Err(e) => {
-            return RunResponse::Failed {
-                category: "image_manifest".into(),
-                message: e,
-            };
-        }
-    };
-    let export_value = match serde_json::to_value(&export) {
+    let mut export = match run_session::<P>(planar_run.dataset.clone(), config_json, run) {
         Ok(v) => v,
-        Err(e) => {
-            return RunResponse::Failed {
-                category: "export_serialize".into(),
-                message: format!("export serialization failed: {e}"),
-            };
-        }
+        Err(boxed) => return *boxed,
     };
+    if let Err(boxed) = splice_image_manifest(
+        &mut export,
+        planar_image_manifest(&planar_run.view_paths, base_dir),
+    ) {
+        return *boxed;
+    }
 
-    // The async caller pushes `export_value` into ExportCache after the
-    // worker returns, so the diagnose / 3D / epipolar workspaces can
-    // pick it up via the existing `compute_*` commands without a disk
-    // round-trip.
     RunResponse::Ok(RunSuccess {
-        export: export_value,
+        export,
         duration_ms: started.elapsed().as_millis() as u64,
         usable_views: planar_run.usable_views,
         total_views: planar_run.total_views,
@@ -211,31 +321,110 @@ fn run_blocking(
     })
 }
 
+type RigBuilder<Meta> =
+    fn(
+        &DatasetSpec,
+        &Path,
+        &dyn vision_calibration_detect::DetectionCache,
+        bool,
+    ) -> Result<vision_calibration_pipeline::dataset_runner::RigRunResult<Meta>, RunError>;
+
+fn run_rig_topology<P, Meta>(
+    spec: &DatasetSpec,
+    config_json: serde_json::Value,
+    base_dir: &Path,
+    detection_cache: &FsDetectionCache,
+    started: Instant,
+    build: RigBuilder<Meta>,
+    run: impl FnOnce(&mut CalibrationSession<P>) -> Result<(), vision_calibration_pipeline::Error>,
+) -> RunResponse
+where
+    P: ProblemType<Input = RigDataset<Meta>>,
+{
+    let rig_run = match build(spec, base_dir, detection_cache, false) {
+        Ok(r) => r,
+        Err(e) => return run_error_to_response(e),
+    };
+    let cache_used = rig_run.usable_views > 0; // refined in B3e with hit/miss counts
+    let usable_views = rig_run.usable_views;
+    let total_views = rig_run.total_views;
+
+    let mut export = match run_session::<P>(rig_run.dataset, config_json, run) {
+        Ok(v) => v,
+        Err(boxed) => return *boxed,
+    };
+    if let Err(boxed) = splice_image_manifest(
+        &mut export,
+        rig_image_manifest(&rig_run.view_paths, base_dir),
+    ) {
+        return *boxed;
+    }
+
+    RunResponse::Ok(RunSuccess {
+        export,
+        duration_ms: started.elapsed().as_millis() as u64,
+        usable_views,
+        total_views,
+        cache_used,
+    })
+}
+
 fn planar_image_manifest(view_paths: &[PathBuf], base_dir: &Path) -> Result<ImageManifest, String> {
-    let base_abs = base_dir
-        .canonicalize()
-        .map_err(|e| format!("canonicalize manifest dir {}: {e}", base_dir.display()))?;
+    let base_abs = canonical_base(base_dir)?;
     let mut frames = Vec::with_capacity(view_paths.len());
     for (pose, path) in view_paths.iter().enumerate() {
-        let abs = path
-            .canonicalize()
-            .map_err(|e| format!("canonicalize image path {}: {e}", path.display()))?;
-        let rel = abs.strip_prefix(&base_abs).map_err(|_| {
-            format!(
-                "accepted image {} is not under manifest dir {}",
-                abs.display(),
-                base_abs.display()
-            )
-        })?;
-        let mut frame = FrameRef::default();
-        frame.pose = pose;
-        frame.path = rel.to_path_buf();
-        frames.push(frame);
+        frames.push(frame_ref(pose, 0, path, &base_abs)?);
     }
+    Ok(manifest_from_frames(frames))
+}
+
+/// Build a rig manifest from `view_paths[view][camera]` — one frame
+/// per `(view, camera)` slot that contributed a usable observation.
+fn rig_image_manifest(
+    view_paths: &[Vec<Option<PathBuf>>],
+    base_dir: &Path,
+) -> Result<ImageManifest, String> {
+    let base_abs = canonical_base(base_dir)?;
+    let mut frames = Vec::new();
+    for (pose, cameras) in view_paths.iter().enumerate() {
+        for (camera, maybe_path) in cameras.iter().enumerate() {
+            if let Some(path) = maybe_path {
+                frames.push(frame_ref(pose, camera, path, &base_abs)?);
+            }
+        }
+    }
+    Ok(manifest_from_frames(frames))
+}
+
+fn canonical_base(base_dir: &Path) -> Result<PathBuf, String> {
+    base_dir
+        .canonicalize()
+        .map_err(|e| format!("canonicalize manifest dir {}: {e}", base_dir.display()))
+}
+
+fn frame_ref(pose: usize, camera: usize, path: &Path, base_abs: &Path) -> Result<FrameRef, String> {
+    let abs = path
+        .canonicalize()
+        .map_err(|e| format!("canonicalize image path {}: {e}", path.display()))?;
+    let rel = abs.strip_prefix(base_abs).map_err(|_| {
+        format!(
+            "accepted image {} is not under manifest dir {}",
+            abs.display(),
+            base_abs.display()
+        )
+    })?;
+    let mut frame = FrameRef::default();
+    frame.pose = pose;
+    frame.camera = camera;
+    frame.path = rel.to_path_buf();
+    Ok(frame)
+}
+
+fn manifest_from_frames(frames: Vec<FrameRef>) -> ImageManifest {
     let mut manifest = ImageManifest::default();
     manifest.root = PathBuf::from(".");
     manifest.frames = frames;
-    Ok(manifest)
+    manifest
 }
 
 fn run_error_to_response(err: RunError) -> RunResponse {
@@ -264,8 +453,14 @@ fn error_category(err: &RunError) -> &'static str {
         RunError::Validation(_) => "validation",
         RunError::UnsupportedTopology { .. } => "unsupported_topology",
         RunError::UnsupportedTarget { .. } => "unsupported_target",
+        RunError::InvalidTargetConfig { .. } => "invalid_target_config",
         RunError::EmptyImageMatch { .. } => "empty_image_match",
         RunError::BadGlob { .. } => "bad_glob",
+        RunError::ViewCountMismatch { .. } => "view_pairing",
+        RunError::PoseCountMismatch { .. } => "view_pairing",
+        RunError::PoseParse { .. } => "pose_parse",
+        RunError::BadPairingRegex { .. } => "view_pairing",
+        RunError::PairingTokenMismatch { .. } => "view_pairing",
         RunError::Io(_) => "io",
         RunError::Decode { .. } => "decode",
         RunError::Detection { .. } => "detection",
@@ -301,4 +496,90 @@ fn slug(input: &str) -> String {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn unsupported_topologies_name_the_roadmap() {
+        for topology in [
+            "single_cam_handeye",
+            "laserline_device",
+            "rig_laserline_device",
+        ] {
+            let manifest = json!({
+                "version": 1,
+                "topology": topology,
+                "cameras": [
+                    {"id": "cam0", "images": {"kind": "glob", "pattern": "*.png"}},
+                ],
+                "target": {"kind": "chessboard", "rows": 9, "cols": 6, "square_size_m": 0.025},
+            });
+            let response = run_blocking(manifest, json!({}), "/tmp");
+            match response {
+                RunResponse::Failed { category, message } => {
+                    assert_eq!(category, "unsupported_topology");
+                    assert!(message.contains("not wired"), "got: {message}");
+                }
+                _ => panic!("expected Failed for {topology}"),
+            }
+        }
+    }
+
+    #[test]
+    fn default_config_round_trips_per_topology() {
+        for topology in [
+            "planar_intrinsics",
+            "scheimpflug_intrinsics",
+            "single_cam_handeye",
+            "laserline_device",
+            "rig_extrinsics",
+            "rig_handeye",
+            "rig_laserline_device",
+        ] {
+            let value = default_config_cmd(topology.to_string())
+                .unwrap_or_else(|e| panic!("default config for {topology}: {e}"));
+            assert!(value.is_object(), "{topology} default must be an object");
+        }
+        assert!(default_config_cmd("not_a_topology".into()).is_err());
+    }
+
+    #[test]
+    fn rig_manifest_skips_none_slots_and_indexes_cameras() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        std::fs::create_dir_all(base.join("cam0")).unwrap();
+        std::fs::create_dir_all(base.join("cam1")).unwrap();
+        std::fs::write(base.join("cam0/a.png"), b"x").unwrap();
+        std::fs::write(base.join("cam1/a.png"), b"x").unwrap();
+        std::fs::write(base.join("cam0/b.png"), b"x").unwrap();
+
+        let view_paths = vec![
+            vec![Some(base.join("cam0/a.png")), Some(base.join("cam1/a.png"))],
+            vec![Some(base.join("cam0/b.png")), None], // cam1 missed view 1
+        ];
+        let manifest = rig_image_manifest(&view_paths, base).unwrap();
+        assert_eq!(manifest.frames.len(), 3);
+        let f = &manifest.frames[2];
+        assert_eq!((f.pose, f.camera), (1, 0));
+        assert_eq!(f.path, PathBuf::from("cam0/b.png"));
+        // No frame for the None slot.
+        assert!(
+            !manifest.frames.iter().any(|f| f.pose == 1 && f.camera == 1),
+            "None slots must not produce frames"
+        );
+    }
+
+    #[test]
+    fn image_manifest_splice_lands_in_export_json() {
+        let mut export = json!({"params": {}, "report": {}});
+        let mut manifest = ImageManifest::default();
+        manifest.root = PathBuf::from(".");
+        splice_image_manifest(&mut export, Ok(manifest)).unwrap();
+        assert!(export["image_manifest"].is_object());
+        assert_eq!(export["image_manifest"]["root"], ".");
+    }
 }

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
@@ -3,8 +3,8 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    CameraParams, DistortionFixMask, IntrinsicsFixMask, Iso3, PerFeatureResiduals, PlanarDataset,
-    build_feature_histogram, compute_planar_target_residuals,
+    CameraParams, DistortionFixMask, ImageManifest, IntrinsicsFixMask, Iso3, PerFeatureResiduals,
+    PlanarDataset, build_feature_histogram, compute_planar_target_residuals,
 };
 use vision_calibration_optim::{RobustLoss, SolveReport};
 
@@ -125,6 +125,12 @@ pub struct ScheimpflugIntrinsicsExport {
     /// `Some(vec![one_entry])`.
     #[serde(default)]
     pub per_feature_residuals: PerFeatureResiduals,
+    /// Optional pointer to the source images behind this export. When
+    /// populated, downstream viewers (the diagnose UI) can locate the
+    /// source image for each view. `None` means "no images shipped";
+    /// the calibration pipeline never reads this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_manifest: Option<ImageManifest>,
 }
 
 impl ProblemState for ScheimpflugIntrinsicsProblem {
@@ -203,6 +209,9 @@ impl ProblemType for ScheimpflugIntrinsicsProblem {
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: vec![output.mean_reproj_error],
             per_feature_residuals,
+            // Populated by callers that know the source image paths
+            // (e.g. the Tauri runner); the pipeline itself never does.
+            image_manifest: None,
         })
     }
 }


### PR DESCRIPTION
Third PR of the **B3c-1** iteration (stacked on #52).

## What
- `run_blocking` dispatches on `DatasetSpec.topology`: **PlanarIntrinsics, ScheimpflugIntrinsics, RigExtrinsics, RigHandeye** run end-to-end in-process; laser topologies + SingleCamHandeye return an explicit not-yet message naming the roadmap step.
- Generic `run_session::<P: ProblemType>` plumbing (config parse → set_input → set_config → per-problem `run_calibration` wrapper → export → serialize). Per-topology arms keep only input building and manifest shape — adding SingleCamHandeye later is one arm + one converter.
- Image manifest is spliced into the **serialized** export `Value` (every supported `*Export` carries the `#[serde(default)]` field, so this is round-trip-safe without inventing a cross-export trait). New `rig_image_manifest` emits `FrameRef{pose, camera, path}` per usable (view, camera) slot, skipping `None` gaps.
- New `default_config_cmd` Tauri command: `Config::default()` JSON for all 7 topologies — kills the hand-copied-defaults drift class on the TS side (PR 4 consumes it).
- `ScheimpflugIntrinsicsExport` gains `image_manifest` (manifest sweep item from the roadmap).
- `error_category` covers the PR 2 `RunError` variants.

## Tests
App-side: unsupported-topology messages, per-topology default-config roundtrip (all 7 + unknown rejected), rig manifest camera indexing + None-slot skipping, manifest splice into export JSON.

Gates: workspace fmt/clippy/test/doc green; app crate `cargo test` (11 tests) + `cargo clippy -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)