### PR TITLE
feat(app): topology-aware Run workspace + rig/charuco presets (B3c-1, PR 4/4)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tempfile",
+ "toml 0.8.2",
  "vision-calibration",
  "vision-calibration-core",
  "vision-calibration-dataset",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ dirs = "5"
 
 [dev-dependencies]
 tempfile = "3"
+toml = "0.8"
 
 [features]
 # Avoid touching the embed_plist build hooks unless explicitly running

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -582,4 +582,63 @@ mod tests {
         assert!(export["image_manifest"].is_object());
         assert_eq!(export["image_manifest"]["root"], ".");
     }
+
+    /// Run one local-data preset end-to-end through `run_blocking` and
+    /// return the success payload. Skips (returns `None`) when the
+    /// dataset is absent — `data/stereo*` are gitignored, local-only.
+    fn run_local_preset(rel_manifest: &str) -> Option<RunSuccess> {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let manifest_path = repo_root.join(rel_manifest);
+        if !manifest_path.exists() {
+            eprintln!("skipping: {} not present", manifest_path.display());
+            return None;
+        }
+        let raw = std::fs::read_to_string(&manifest_path).unwrap();
+        let manifest: serde_json::Value =
+            serde_json::to_value(toml::from_str::<toml::Value>(&raw).unwrap()).unwrap();
+        let topology = manifest["topology"].as_str().unwrap().to_string();
+        let config = default_config_cmd(topology).unwrap();
+        let dir = manifest_path
+            .parent()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        match run_blocking(manifest, config, &dir) {
+            RunResponse::Ok(success) => Some(success),
+            other => panic!("{rel_manifest}: expected Ok, got {other:?}"),
+        }
+    }
+
+    /// Local-only end-to-end acceptance over the gitignored bundled
+    /// datasets. Run manually:
+    /// `cargo test -p calibration-diagnose -- --ignored --nocapture`
+    #[test]
+    #[ignore = "needs the local data/stereo + data/stereo_charuco datasets"]
+    fn local_presets_end_to_end() {
+        if let Some(s) = run_local_preset("data/stereo/dataset_rig.toml") {
+            assert!(
+                s.usable_views >= 10,
+                "stereo rig: {} usable",
+                s.usable_views
+            );
+            assert!(s.export["cameras"].is_array(), "rig export has cameras[]");
+            assert!(s.export["image_manifest"]["frames"].is_array());
+        }
+        if let Some(s) = run_local_preset("data/stereo_charuco/dataset_cam1.toml") {
+            assert!(
+                s.usable_views >= 10,
+                "charuco cam1: {} usable",
+                s.usable_views
+            );
+            assert!(s.export["image_manifest"]["frames"].is_array());
+        }
+        if let Some(s) = run_local_preset("data/stereo_charuco/dataset_rig.toml") {
+            assert!(
+                s.usable_views >= 10,
+                "charuco rig: {} usable",
+                s.usable_views
+            );
+            assert!(s.export["cameras"].is_array(), "rig export has cameras[]");
+        }
+    }
 }

--- a/app/src/workspaces/RunWorkspace/index.tsx
+++ b/app/src/workspaces/RunWorkspace/index.tsx
@@ -11,12 +11,14 @@
  *   6. Advanced JSON editor — third collapsible, lowest priority.
  *   7. Status banner — sticky top-of-workspace during / after a run.
  *
- * PR 1 wires up PlanarIntrinsics + chessboard only; the IA is designed
- * to accommodate all 8 topologies + 4 detectors without structural change.
+ * B3c wires PlanarIntrinsics, ScheimpflugIntrinsics, RigExtrinsics and
+ * RigHandeye end-to-end; the config schema follows the manifest's
+ * topology (see `topologies.ts`). Laser topologies + SingleCamHandeye
+ * render with a disabled Run button until their runners ship.
  */
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import * as TOML from "toml";
 
@@ -24,16 +26,15 @@ import { ConfigForm, type JsonSchema } from "../../lib/configForm";
 import { runCalibration, type RunResponse } from "../../lib/runCalibration";
 import { isTauriContext } from "../../lib/tauri";
 import datasetSchemaJson from "../../schemas/dataset_spec.json";
-import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
 import { useStore } from "../../store";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { PresetCard } from "./PresetCard";
 import { BUILTIN_PRESETS, type EnabledPreset } from "./presets";
+import { topologyInfo } from "./topologies";
 
-// schemars-emitted JSON Schemas; cast through unknown since both shapes
+// schemars-emitted JSON Schema; cast through unknown since both shapes
 // are JSON-compatible (our JsonSchema interface is intentionally loose).
 const datasetSchema = datasetSchemaJson as unknown as JsonSchema;
-const planarConfigSchema = planarConfigSchemaJson as unknown as JsonSchema;
 
 // ── Default form values ──────────────────────────────────────────────────────
 
@@ -54,6 +55,9 @@ const DEFAULT_DATASET: unknown = {
   topology: "planar_intrinsics",
 };
 
+// Browser-context fallback only — inside Tauri the defaults come from
+// `default_config_cmd` (Rust `Config::default()`), the single source
+// of truth.
 const DEFAULT_PLANAR_CONFIG: unknown = {
   init_iterations: 2,
   fix_k3_in_init: true,
@@ -66,6 +70,25 @@ const DEFAULT_PLANAR_CONFIG: unknown = {
   fix_distortion: { k1: false, k2: false, k3: true, p1: false, p2: false },
   fix_poses: [],
 };
+
+/** Topology of a manifest value, defaulting to planar. */
+function topologyOf(manifest: unknown): string {
+  const m = manifest as Record<string, unknown> | null;
+  return typeof m?.topology === "string" ? m.topology : "planar_intrinsics";
+}
+
+/** Default config for a topology: Rust-side defaults inside Tauri,
+ * a static fallback in plain-browser dev. */
+async function fetchDefaultConfig(topology: string, inTauri: boolean): Promise<unknown> {
+  if (inTauri) {
+    try {
+      return await invoke<unknown>("default_config_cmd", { topology });
+    } catch {
+      // Fall through to the static fallback (e.g. unknown topology).
+    }
+  }
+  return topology === "planar_intrinsics" ? DEFAULT_PLANAR_CONFIG : {};
+}
 
 // ── Run status ───────────────────────────────────────────────────────────────
 
@@ -105,6 +128,34 @@ export function RunWorkspace() {
   const jsonEditorRef = useRef<HTMLTextAreaElement>(null);
 
   const isRunning = status.kind === "running";
+
+  // ── Topology-driven config schema + defaults ─────────────────────────────
+
+  const topology = topologyOf(manifest);
+  const info = topologyInfo(topology);
+
+  // When the manifest's topology changes (form edit, JSON blur, preset
+  // load), swap the config schema and reset the config to that
+  // topology's defaults.
+  const prevTopologyRef = useRef(topology);
+  useEffect(() => {
+    if (prevTopologyRef.current === topology) return;
+    prevTopologyRef.current = topology;
+    let cancelled = false;
+    void fetchDefaultConfig(topology, inTauri).then((defaults) => {
+      if (cancelled) return;
+      setConfig(defaults);
+      if (jsonEditorRef.current) {
+        jsonEditorRef.current.value = JSON.stringify({ manifest, config: defaults }, null, 2);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // `manifest` is intentionally read, not depended on: this effect
+    // only fires on topology *changes*.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topology, inTauri]);
 
   // ── Derived summary strings for collapsible headers ──────────────────────
 
@@ -153,16 +204,19 @@ export function RunWorkspace() {
       setManifestDir(dir);
       setManifestPath(preset.manifestPath);
       setManifest(parsed);
-      // Reset config to defaults when switching presets (the config is
-      // topology-specific; PlanarIntrinsics is the only one wired up today).
-      setConfig(DEFAULT_PLANAR_CONFIG);
+      // Reset config to the preset topology's defaults (the topology
+      // effect above only fires on topology *changes*, and switching
+      // between same-topology presets must still reset).
+      const defaults = await fetchDefaultConfig(topologyOf(parsed), inTauri);
+      prevTopologyRef.current = topologyOf(parsed);
+      setConfig(defaults);
       setActivePresetId(preset.id);
       setGridExpanded(false);
       setStatus({ kind: "idle" });
 
       // Sync the JSON textarea if it happens to be mounted.
       if (jsonEditorRef.current) {
-        jsonEditorRef.current.value = JSON.stringify({ manifest: parsed, config: DEFAULT_PLANAR_CONFIG }, null, 2);
+        jsonEditorRef.current.value = JSON.stringify({ manifest: parsed, config: defaults }, null, 2);
       }
     } catch (e) {
       setStatus({
@@ -296,21 +350,27 @@ export function RunWorkspace() {
         <div className="flex flex-col gap-0.5">
           <h2 className="text-sm font-semibold tracking-tight">Run calibration</h2>
           <p className="font-mono text-[11px] text-muted-foreground">
-            PlanarIntrinsics + chessboard, end-to-end
+            {info.label} + {targetKindOf(manifest)}, end-to-end
+            {!info.supported && info.unsupportedReason ? ` — ${info.unsupportedReason}` : ""}
           </p>
         </div>
 
         <button
           type="button"
           onClick={handleRun}
-          disabled={isRunning || !manifestDir}
+          disabled={isRunning || !manifestDir || !info.supported}
+          title={!info.supported ? info.unsupportedReason : undefined}
           className={[
             "h-9 rounded-md px-5 text-[13px] font-semibold transition-colors",
-            isRunning || !manifestDir
+            isRunning || !manifestDir || !info.supported
               ? "cursor-not-allowed bg-bg-soft text-muted-foreground border border-border"
               : "bg-brand text-white hover:opacity-90",
           ].join(" ")}
-          style={isRunning || !manifestDir ? undefined : { backgroundColor: "var(--brand)" }}
+          style={
+            isRunning || !manifestDir || !info.supported
+              ? undefined
+              : { backgroundColor: "var(--brand)" }
+          }
         >
           {isRunning ? "Running…" : "Run"}
         </button>
@@ -359,12 +419,18 @@ export function RunWorkspace() {
 
       {/* 5. Calibration config section */}
       <CollapsibleSection title="Calibration config" summary={configSummary}>
-        <ConfigForm
-          schema={planarConfigSchema}
-          value={config}
-          onChange={setConfig}
-          rootLabel="config"
-        />
+        {info.schema ? (
+          <ConfigForm
+            schema={info.schema}
+            value={config}
+            onChange={setConfig}
+            rootLabel="config"
+          />
+        ) : (
+          <p className="text-[12px] text-muted-foreground">
+            {info.unsupportedReason ?? `No config form for topology "${topology}" yet.`}
+          </p>
+        )}
       </CollapsibleSection>
 
       {/* 6. Advanced JSON editor */}
@@ -384,6 +450,12 @@ export function RunWorkspace() {
       </CollapsibleSection>
     </div>
   );
+}
+
+function targetKindOf(manifest: unknown): string {
+  const m = manifest as Record<string, unknown> | null;
+  const target = m?.target as Record<string, unknown> | undefined;
+  return typeof target?.kind === "string" ? target.kind : "?";
 }
 
 function robustLossLabel(value: unknown): string {

--- a/app/src/workspaces/RunWorkspace/presets.ts
+++ b/app/src/workspaces/RunWorkspace/presets.ts
@@ -73,32 +73,40 @@ export const BUILTIN_PRESETS: Preset[] = [
     manifestPath: `${REPO_ROOT}/data/stereo/dataset_right.toml`,
   },
 
-  // ── Disabled: stereo rig ────────────────────────────────────────────────
+  // ── Enabled: stereo rig ─────────────────────────────────────────────────
   {
     id: "stereo-rig",
-    disabled: true,
     name: "Stereo rig",
     group: "Bundled stereo dataset",
     topology: "RigExtrinsics",
     targetKind: "chessboard",
-    targetSummary: "chessboard 7×11, 30 mm",
-    imageCount: null,
-    disabledReason: "Multi-camera rig topology is not wired into Run yet.",
-    milestone: "planned",
+    targetSummary: "chessboard 7×11, 30 mm · 2 cameras",
+    imageCount: 20,
+    manifestPath: `${REPO_ROOT}/data/stereo/dataset_rig.toml`,
   },
 
-  // ── Disabled: stereo-charuco ────────────────────────────────────────────
+  // ── Enabled: stereo-charuco (single camera) ─────────────────────────────
   {
     id: "stereo-charuco",
-    disabled: true,
-    name: "Stereo · ChArUco",
-    group: "Bundled stereo dataset",
+    name: "ChArUco · cam1",
+    group: "Stereo ChArUco dataset",
     topology: "PlanarIntrinsics",
     targetKind: "charuco",
-    targetSummary: "ChArUco DICT_4X4_50",
-    imageCount: null,
-    disabledReason: "ChArUco detector integration is not wired into Run yet.",
-    milestone: "planned",
+    targetSummary: "ChArUco 22×22, 1.35 mm, DICT_4X4_1000",
+    imageCount: 28,
+    manifestPath: `${REPO_ROOT}/data/stereo_charuco/dataset_cam1.toml`,
+  },
+
+  // ── Enabled: stereo-charuco rig (token pairing) ─────────────────────────
+  {
+    id: "stereo-charuco-rig",
+    name: "ChArUco rig",
+    group: "Stereo ChArUco dataset",
+    topology: "RigExtrinsics",
+    targetKind: "charuco",
+    targetSummary: "ChArUco 22×22 · 2 cameras · token pairing",
+    imageCount: 27,
+    manifestPath: `${REPO_ROOT}/data/stereo_charuco/dataset_rig.toml`,
   },
 
   // ── Disabled: KUKA handeye ───────────────────────────────────────────────
@@ -125,7 +133,7 @@ export const BUILTIN_PRESETS: Preset[] = [
     targetKind: "puzzleboard",
     targetSummary: "puzzleboard puzzle_130x130",
     imageCount: null,
-    disabledReason: "Scheimpflug topology + puzzleboard detector are not wired into Run yet.",
+    disabledReason: "The puzzleboard detector is not wired into Run yet (the Scheimpflug topology itself is).",
     milestone: "planned",
   },
 ];

--- a/app/src/workspaces/RunWorkspace/topologies.ts
+++ b/app/src/workspaces/RunWorkspace/topologies.ts
@@ -1,0 +1,86 @@
+/** Topology registry for the Run workspace.
+ *
+ * Maps every `DatasetSpec.topology` wire name to its display label,
+ * schemars-emitted config schema, and whether the in-process runner
+ * supports it today. The Run button is disabled (with a reason) for
+ * unsupported topologies, mirroring the dispatch in
+ * `app/src-tauri/src/run.rs`.
+ */
+import type { JsonSchema } from "../../lib/configForm";
+
+import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
+import rigExtrinsicsConfigSchemaJson from "../../schemas/rig_extrinsics_config.json";
+import rigHandeyeConfigSchemaJson from "../../schemas/rig_handeye_config.json";
+import scheimpflugConfigSchemaJson from "../../schemas/scheimpflug_intrinsics_config.json";
+
+// schemars-emitted JSON Schemas; cast through unknown since both shapes
+// are JSON-compatible (our JsonSchema interface is intentionally loose).
+const planarConfigSchema = planarConfigSchemaJson as unknown as JsonSchema;
+const scheimpflugConfigSchema = scheimpflugConfigSchemaJson as unknown as JsonSchema;
+const rigExtrinsicsConfigSchema = rigExtrinsicsConfigSchemaJson as unknown as JsonSchema;
+const rigHandeyeConfigSchema = rigHandeyeConfigSchemaJson as unknown as JsonSchema;
+
+export interface TopologyInfo {
+  /** Human-readable label for headers and summaries. */
+  label: string;
+  /** Config schema driving the ConfigForm; null when unsupported. */
+  schema: JsonSchema | null;
+  /** Whether the Tauri runner can execute this topology today. */
+  supported: boolean;
+  /** Shown as the Run-button tooltip when unsupported. */
+  unsupportedReason?: string;
+}
+
+/** All seven `Topology` wire names (serde snake_case). */
+export const TOPOLOGY_INFO: Record<string, TopologyInfo> = {
+  planar_intrinsics: {
+    label: "PlanarIntrinsics",
+    schema: planarConfigSchema,
+    supported: true,
+  },
+  scheimpflug_intrinsics: {
+    label: "ScheimpflugIntrinsics",
+    schema: scheimpflugConfigSchema,
+    supported: true,
+  },
+  single_cam_handeye: {
+    label: "SingleCamHandeye",
+    schema: null,
+    supported: false,
+    unsupportedReason: "SingleCamHandeye lands in B3c-2.",
+  },
+  laserline_device: {
+    label: "LaserlineDevice",
+    schema: null,
+    supported: false,
+    unsupportedReason: "Laser topologies await the laser-frame manifest design.",
+  },
+  rig_extrinsics: {
+    label: "RigExtrinsics",
+    schema: rigExtrinsicsConfigSchema,
+    supported: true,
+  },
+  rig_handeye: {
+    label: "RigHandeye",
+    schema: rigHandeyeConfigSchema,
+    supported: true,
+  },
+  rig_laserline_device: {
+    label: "RigLaserlineDevice",
+    schema: null,
+    supported: false,
+    unsupportedReason: "Laser topologies await the laser-frame manifest design.",
+  },
+};
+
+/** Lookup with a graceful fallback for unknown / misspelled topologies. */
+export function topologyInfo(topology: string): TopologyInfo {
+  return (
+    TOPOLOGY_INFO[topology] ?? {
+      label: topology || "unknown",
+      schema: null,
+      supported: false,
+      unsupportedReason: `Unknown topology "${topology}" — check the manifest.`,
+    }
+  );
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,6 +106,16 @@ puzzleboard / ringgrid) are supported.
   `ScheimpflugIntrinsicsExport`, and `LaserlineDeviceExport`.
   **Sequencing (2026-06-11): RigHandeye + RigLaserlineDevice + charuco
   detector first** — they serve the V-track (rtv3d) directly.
+  - **B3c-1 (2026-06-12, PRs #51–#54):** charuco detector
+    (`vision-calibration-detect`), robot-pose loading + view pairing +
+    rig converters in `dataset_runner`, topology dispatch in the Tauri
+    runner (+`default_config_cmd`), TS topology selector + presets.
+    Covers PlanarIntrinsics, ScheimpflugIntrinsics (incl. its export's
+    `image_manifest`), RigExtrinsics, RigHandeye.
+  - **B3c-2 (next):** SingleCamHandeye (~free after B3c-1's pose
+    loader; kuka_1 needs a pose-file conversion), laser topologies
+    (need the laser-frame manifest ADR), puzzleboard + ringgrid
+    detectors, bench/examples-private charuco dedup.
 - **B-laser — laserline visualization.** Laser-pixel overlay in
   Diagnose; laser plane-fit residuals (point-to-plane mm) alongside
   reprojection residuals; laser planes rendered in the 3D rig viewer.


### PR DESCRIPTION
Final PR of the **B3c-1** iteration (stacked on #53).

## What
- **`topologies.ts`**: `TOPOLOGY_INFO` map over all seven `Topology` wire names → label, config schema (the four supported ones import their schemars-emitted schemas from `app/src/schemas/`), supported flag, and unsupported reason. Mirrors the Rust dispatch.
- **`index.tsx`**: the config schema now follows the manifest's topology. On topology change (form edit, JSON-editor blur, preset load) the config resets via the `default_config_cmd` IPC — Rust `Config::default()` is the single source of truth; the hand-copied `DEFAULT_PLANAR_CONFIG` survives only as a plain-browser-dev fallback. Dynamic header subtitle, Run button disabled-with-reason for unsupported topologies.
- **`presets.ts`**: `stereo-rig` (RigExtrinsics + chessboard, by_index) and `stereo-charuco` (Planar + charuco) flip to **enabled**; new `stereo-charuco-rig` preset exercises RigExtrinsics + charuco with `shared_filename_token` pairing over genuinely unequal view sets (28 vs 27 images). Backing TOML manifests live under `data/stereo*` — gitignored local scaffolding, same as the image data (per the existing DEV NOTE).
- **App crate**: `#[ignore]`d local-data E2E test driving all three presets through `run_blocking`.
- **ROADMAP.md**: records B3c-1 (PRs #51–#54) and the B3c-2 remainder.

## Verification
- `bun run build` (tsc + vite) green; app crate `cargo test` + `clippy -D warnings` green.
- **Real-data E2E passed** (`cargo test -- --ignored`, release): stereo rig (by_index), ChArUco cam1 (planar), ChArUco rig (token pairing) all return `Ok` with ≥10 usable views, rig exports carry `cameras[]` + `image_manifest.frames`. 3.9 s total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)