### PR TITLE
feat(app): SingleCamHandeye end-to-end in the Run workspace (B3c-2)

### DIFF
--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -5,9 +5,9 @@
 //! right `CalibrationSession`, runs detection (cached) + calibration on
 //! a `tauri::async_runtime::spawn_blocking` task, and returns the
 //! export plus run metrics. Supported topologies: `PlanarIntrinsics`,
-//! `ScheimpflugIntrinsics`, `RigExtrinsics`, `RigHandeye`. The laser
-//! topologies await the laser-frame manifest design; `SingleCamHandeye`
-//! follows in B3c-2.
+//! `ScheimpflugIntrinsics`, `SingleCamHandeye`, `RigExtrinsics`,
+//! `RigHandeye`. The laser topologies await the laser-frame manifest
+//! design.
 //!
 //! Per ADR 0019, ambiguity that the runtime cannot auto-resolve is
 //! surfaced as a structured `RunResponse::AskUser` so the Run workspace
@@ -24,6 +24,7 @@ use vision_calibration_dataset::{DatasetSpec, Topology};
 use vision_calibration_detect::FsDetectionCache;
 use vision_calibration_pipeline::dataset_runner::{
     RunError, build_planar_input, build_rig_extrinsics_input, build_rig_handeye_input,
+    build_single_cam_handeye_input,
 };
 use vision_calibration_pipeline::laserline_device::LaserlineDeviceConfig;
 use vision_calibration_pipeline::planar_intrinsics::{
@@ -41,7 +42,10 @@ use vision_calibration_pipeline::scheimpflug_intrinsics::{
     run_calibration as run_scheimpflug_calibration,
 };
 use vision_calibration_pipeline::session::{CalibrationSession, ProblemType};
-use vision_calibration_pipeline::single_cam_handeye::SingleCamHandeyeConfig;
+use vision_calibration_pipeline::single_cam_handeye::{
+    SingleCamHandeyeConfig, SingleCamHandeyeProblem,
+    run_calibration as run_single_cam_handeye_calibration,
+};
 
 use crate::export_cache::ExportCache;
 
@@ -196,16 +200,18 @@ fn run_blocking(
             build_rig_handeye_input,
             run_rig_handeye_calibration,
         ),
-        other @ (Topology::SingleCamHandeye
-        | Topology::LaserlineDevice
-        | Topology::RigLaserlineDevice) => RunResponse::Failed {
-            category: "unsupported_topology".into(),
-            message: format!(
-                "topology {other:?} is not wired into the Run workspace yet \
-                 (the laser topologies land with the laser-frame manifest \
-                 design; single_cam_handeye follows in B3c-2)"
-            ),
-        },
+        Topology::SingleCamHandeye => {
+            run_single_cam_handeye_topology(&spec, config_json, base_dir, &detection_cache, started)
+        }
+        other @ (Topology::LaserlineDevice | Topology::RigLaserlineDevice) => {
+            RunResponse::Failed {
+                category: "unsupported_topology".into(),
+                message: format!(
+                    "topology {other:?} is not wired into the Run workspace yet \
+                     (the laser topologies land with the laser-frame manifest design)"
+                ),
+            }
+        }
     }
 }
 
@@ -317,6 +323,48 @@ where
         duration_ms: started.elapsed().as_millis() as u64,
         usable_views: planar_run.usable_views,
         total_views: planar_run.total_views,
+        cache_used,
+    })
+}
+
+fn run_single_cam_handeye_topology(
+    spec: &DatasetSpec,
+    config_json: serde_json::Value,
+    base_dir: &Path,
+    detection_cache: &FsDetectionCache,
+    started: Instant,
+) -> RunResponse {
+    let handeye_run =
+        match build_single_cam_handeye_input(spec, base_dir, detection_cache, false) {
+            Ok(r) => r,
+            Err(e) => return run_error_to_response(e),
+        };
+    let cache_used = handeye_run.usable_views > 0; // refined in B3e with hit/miss counts
+    let usable_views = handeye_run.usable_views;
+    let total_views = handeye_run.total_views;
+
+    let mut export = match run_session::<SingleCamHandeyeProblem>(
+        handeye_run.input,
+        config_json,
+        run_single_cam_handeye_calibration,
+    ) {
+        Ok(v) => v,
+        Err(boxed) => return *boxed,
+    };
+    // Single camera ⇒ the planar manifest shape (pose = kept-view
+    // index, camera = 0) applies directly.
+    if let Err(boxed) = splice_image_manifest(
+        &mut export,
+        planar_image_manifest(&handeye_run.view_paths, base_dir),
+    ) {
+        return *boxed;
+    }
+
+    RunResponse::Ok(RunSuccess {
+        export,
+        duration_ms: started.elapsed().as_millis() as u64,
+        usable_views,
+        total_views,
         cache_used,
     })
 }
@@ -505,11 +553,7 @@ mod tests {
 
     #[test]
     fn unsupported_topologies_name_the_roadmap() {
-        for topology in [
-            "single_cam_handeye",
-            "laserline_device",
-            "rig_laserline_device",
-        ] {
+        for topology in ["laserline_device", "rig_laserline_device"] {
             let manifest = json!({
                 "version": 1,
                 "topology": topology,
@@ -640,5 +684,25 @@ mod tests {
             );
             assert!(s.export["cameras"].is_array(), "rig export has cameras[]");
         }
+    }
+
+    /// End-to-end hand-eye run over the committed `data/kuka_1` dataset
+    /// (30 chessboard views + rowmajor4x4 robot poses). Ignored for
+    /// time, not data availability — kuka_1 ships with the repo.
+    #[test]
+    #[ignore = "full detection + solve takes tens of seconds; run with --ignored"]
+    fn kuka_handeye_end_to_end() {
+        let s = run_local_preset("data/kuka_1/dataset.toml")
+            .expect("data/kuka_1 is committed; the manifest must be present");
+        assert!(s.usable_views >= 20, "kuka_1: {} usable", s.usable_views);
+        assert_eq!(s.total_views, 30);
+        let mean_px = s.export["mean_reproj_error"].as_f64().unwrap();
+        assert!(
+            mean_px < 2.0,
+            "kuka_1 mean reprojection error {mean_px:.3} px (expected ~1.2)"
+        );
+        assert!(s.export["gripper_se3_camera"].is_object(), "eye-in-hand");
+        let frames = s.export["image_manifest"]["frames"].as_array().unwrap();
+        assert_eq!(frames.len(), s.usable_views);
     }
 }

--- a/app/src/schemas/dataset_spec.json
+++ b/app/src/schemas/dataset_spec.json
@@ -198,6 +198,11 @@
           "const": "jsonl",
           "description": "JSONL (one JSON object per line).",
           "type": "string"
+        },
+        {
+          "const": "rowmajor4x4",
+          "description": "Headerless text: each non-empty line is 16 whitespace-separated\nfloats forming a row-major 4×4 homogeneous transform (KUKA-style\nexports). Requires `pose_convention.rotation_format =\n\"matrix4x4_row_major\"` and no `columns` mapping.",
+          "type": "string"
         }
       ]
     },
@@ -206,8 +211,15 @@
       "description": "Where and how robot poses are stored on disk.",
       "properties": {
         "columns": {
-          "$ref": "#/$defs/PoseColumnMap",
-          "description": "Column / field mapping from the user's file to the canonical\nfields the converter consumes."
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PoseColumnMap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Column / field mapping from the user's file to the canonical\nfields the converter consumes. Required for the tabular formats\n(`csv` / `json` / `jsonl`); must be absent for `rowmajor4x4`,\nwhose 16-values-per-line layout is fixed."
         },
         "format": {
           "$ref": "#/$defs/RobotPoseFormat",
@@ -220,8 +232,7 @@
       },
       "required": [
         "path",
-        "format",
-        "columns"
+        "format"
       ],
       "type": "object"
     },

--- a/app/src/workspaces/RunWorkspace/presets.ts
+++ b/app/src/workspaces/RunWorkspace/presets.ts
@@ -109,18 +109,16 @@ export const BUILTIN_PRESETS: Preset[] = [
     manifestPath: `${REPO_ROOT}/data/stereo_charuco/dataset_rig.toml`,
   },
 
-  // ── Disabled: KUKA handeye ───────────────────────────────────────────────
+  // ── Enabled: KUKA handeye (committed dataset) ────────────────────────────
   {
     id: "kuka-handeye",
-    disabled: true,
     name: "KUKA handeye",
     group: "kuka_1 dataset",
     topology: "SingleCamHandeye",
     targetKind: "chessboard",
-    targetSummary: "chessboard, robot poses CSV",
-    imageCount: null,
-    disabledReason: "Hand-eye calibration topology is not wired into Run yet.",
-    milestone: "planned",
+    targetSummary: "chessboard 17×28, 20 mm · robot poses 4×4",
+    imageCount: 30,
+    manifestPath: `${REPO_ROOT}/data/kuka_1/dataset.toml`,
   },
 
   // ── Disabled: DS8 Scheimpflug ────────────────────────────────────────────

--- a/app/src/workspaces/RunWorkspace/topologies.ts
+++ b/app/src/workspaces/RunWorkspace/topologies.ts
@@ -12,11 +12,13 @@ import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json"
 import rigExtrinsicsConfigSchemaJson from "../../schemas/rig_extrinsics_config.json";
 import rigHandeyeConfigSchemaJson from "../../schemas/rig_handeye_config.json";
 import scheimpflugConfigSchemaJson from "../../schemas/scheimpflug_intrinsics_config.json";
+import singleCamHandeyeConfigSchemaJson from "../../schemas/single_cam_handeye_config.json";
 
 // schemars-emitted JSON Schemas; cast through unknown since both shapes
 // are JSON-compatible (our JsonSchema interface is intentionally loose).
 const planarConfigSchema = planarConfigSchemaJson as unknown as JsonSchema;
 const scheimpflugConfigSchema = scheimpflugConfigSchemaJson as unknown as JsonSchema;
+const singleCamHandeyeConfigSchema = singleCamHandeyeConfigSchemaJson as unknown as JsonSchema;
 const rigExtrinsicsConfigSchema = rigExtrinsicsConfigSchemaJson as unknown as JsonSchema;
 const rigHandeyeConfigSchema = rigHandeyeConfigSchemaJson as unknown as JsonSchema;
 
@@ -45,9 +47,8 @@ export const TOPOLOGY_INFO: Record<string, TopologyInfo> = {
   },
   single_cam_handeye: {
     label: "SingleCamHandeye",
-    schema: null,
-    supported: false,
-    unsupportedReason: "SingleCamHandeye lands in B3c-2.",
+    schema: singleCamHandeyeConfigSchema,
+    supported: true,
   },
   laserline_device: {
     label: "LaserlineDevice",

--- a/crates/vision-calibration-dataset/src/spec.rs
+++ b/crates/vision-calibration-dataset/src/spec.rs
@@ -186,12 +186,15 @@ pub struct RobotPoseSource {
     /// File-format selector.
     pub format: RobotPoseFormat,
     /// Column / field mapping from the user's file to the canonical
-    /// fields the converter consumes.
-    pub columns: PoseColumnMap,
+    /// fields the converter consumes. Required for the tabular formats
+    /// (`csv` / `json` / `jsonl`); must be absent for `rowmajor4x4`,
+    /// whose 16-values-per-line layout is fixed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub columns: Option<PoseColumnMap>,
 }
 
 /// Robot-pose file format.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum RobotPoseFormat {
@@ -201,6 +204,11 @@ pub enum RobotPoseFormat {
     Json,
     /// JSONL (one JSON object per line).
     Jsonl,
+    /// Headerless text: each non-empty line is 16 whitespace-separated
+    /// floats forming a row-major 4×4 homogeneous transform (KUKA-style
+    /// exports). Requires `pose_convention.rotation_format =
+    /// "matrix4x4_row_major"` and no `columns` mapping.
+    Rowmajor4x4,
 }
 
 /// Mapping from user-defined column / field names to the canonical

--- a/crates/vision-calibration-dataset/src/validator.rs
+++ b/crates/vision-calibration-dataset/src/validator.rs
@@ -1,7 +1,9 @@
 //! Manifest validation. Catches structural errors that would
 //! otherwise surface as a fail-fast `AskUser` event downstream.
 
-use crate::spec::{DatasetSpec, ImagePattern, RobotPoseSource, RotationFormat, Topology};
+use crate::spec::{
+    DatasetSpec, ImagePattern, RobotPoseFormat, RobotPoseSource, RotationFormat, Topology,
+};
 use thiserror::Error;
 
 /// Validation failure modes.
@@ -56,6 +58,23 @@ pub enum ValidationError {
         got: usize,
         /// How many were expected.
         expected: usize,
+    },
+
+    /// A tabular pose format (csv / json / jsonl) needs a `columns`
+    /// mapping to find the pose fields, but none was given.
+    #[error("pose format {format:?} requires a columns mapping but none was given")]
+    MissingPoseColumns {
+        /// The declared pose-file format.
+        format: RobotPoseFormat,
+    },
+
+    /// The headerless `rowmajor4x4` format has a fixed 16-values-per-line
+    /// layout; a `columns` mapping or a non-matrix rotation format would
+    /// be silently ignored, so both are rejected up front (ADR 0019).
+    #[error("pose format rowmajor4x4 {problem}")]
+    BadMatrixPoseConfig {
+        /// What is inconsistent (human-readable).
+        problem: String,
     },
 
     /// An ROI rectangle has zero width or height.
@@ -162,8 +181,30 @@ fn validate_pose_columns(
         // if `pose_convention` is `None` while `robot_poses` is set.
         return Ok(());
     };
+
+    if robot.format == RobotPoseFormat::Rowmajor4x4 {
+        if robot.columns.is_some() {
+            return Err(ValidationError::BadMatrixPoseConfig {
+                problem: "is headerless (16 values per line); remove the columns mapping".into(),
+            });
+        }
+        if format != RotationFormat::Matrix4x4RowMajor {
+            return Err(ValidationError::BadMatrixPoseConfig {
+                problem: format!(
+                    "requires pose_convention.rotation_format = matrix4x4_row_major, got {format:?}"
+                ),
+            });
+        }
+        return Ok(());
+    }
+
+    let Some(columns) = &robot.columns else {
+        return Err(ValidationError::MissingPoseColumns {
+            format: robot.format,
+        });
+    };
     let expected = expected_rotation_columns(format);
-    let got = robot.columns.rotation.len();
+    let got = columns.rotation.len();
     if got != expected {
         return Err(ValidationError::BadRotationColumnCount {
             format,
@@ -295,14 +336,14 @@ mod tests {
         let robot = RobotPoseSource {
             path: "poses.csv".into(),
             format: RobotPoseFormat::Csv,
-            columns: PoseColumnMap {
+            columns: Some(PoseColumnMap {
                 pose_id: None,
                 tx: "x".into(),
                 ty: "y".into(),
                 tz: "z".into(),
                 // QuatXyzw needs 4 columns; supply 3 to trigger.
                 rotation: vec!["rx".into(), "ry".into(), "rz".into()],
-            },
+            }),
         };
         let convention = PoseConvention {
             transform: TransformConvention::TBaseTcp,
@@ -322,6 +363,86 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    fn handeye_spec_with(robot: RobotPoseSource, rotation_format: RotationFormat) -> DatasetSpec {
+        let mut spec = planar_chessboard_minimal();
+        spec.topology = Topology::SingleCamHandeye;
+        spec.robot_poses = Some(robot);
+        spec.pose_convention = Some(PoseConvention {
+            transform: TransformConvention::TBaseTcp,
+            rotation_format,
+            translation_units: TranslationUnits::M,
+        });
+        spec
+    }
+
+    #[test]
+    fn tabular_format_requires_columns() {
+        let robot = RobotPoseSource {
+            path: "poses.csv".into(),
+            format: RobotPoseFormat::Csv,
+            columns: None,
+        };
+        let err = validate(&handeye_spec_with(robot, RotationFormat::QuatXyzw)).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::MissingPoseColumns {
+                format: RobotPoseFormat::Csv
+            }
+        ));
+    }
+
+    #[test]
+    fn rowmajor4x4_validates_without_columns() {
+        let robot = RobotPoseSource {
+            path: "RobotPosesVec.txt".into(),
+            format: RobotPoseFormat::Rowmajor4x4,
+            columns: None,
+        };
+        validate(&handeye_spec_with(robot, RotationFormat::Matrix4x4RowMajor)).unwrap();
+    }
+
+    #[test]
+    fn rowmajor4x4_rejects_columns_mapping() {
+        let robot = RobotPoseSource {
+            path: "RobotPosesVec.txt".into(),
+            format: RobotPoseFormat::Rowmajor4x4,
+            columns: Some(PoseColumnMap {
+                pose_id: None,
+                tx: "x".into(),
+                ty: "y".into(),
+                tz: "z".into(),
+                rotation: vec![],
+            }),
+        };
+        let err =
+            validate(&handeye_spec_with(robot, RotationFormat::Matrix4x4RowMajor)).unwrap_err();
+        match err {
+            ValidationError::BadMatrixPoseConfig { problem } => {
+                assert!(problem.contains("columns"), "got: {problem}");
+            }
+            other => panic!("expected BadMatrixPoseConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rowmajor4x4_rejects_non_matrix_rotation_format() {
+        let robot = RobotPoseSource {
+            path: "RobotPosesVec.txt".into(),
+            format: RobotPoseFormat::Rowmajor4x4,
+            columns: None,
+        };
+        let err = validate(&handeye_spec_with(robot, RotationFormat::QuatXyzw)).unwrap_err();
+        match err {
+            ValidationError::BadMatrixPoseConfig { problem } => {
+                assert!(
+                    problem.contains("matrix4x4_row_major"),
+                    "error must name the required format, got: {problem}"
+                );
+            }
+            other => panic!("expected BadMatrixPoseConfig, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/dataset_runner/handeye.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/handeye.rs
@@ -1,0 +1,388 @@
+//! `DatasetSpec → SingleCamHandeyeInput` converter for the
+//! `SingleCamHandeye` topology.
+//!
+//! Detection mirrors the planar converter (one camera, ROI-aware,
+//! cached); pose loading and pose-to-view matching are shared with the
+//! rig hand-eye converter (`poses.rs`). Views with fewer than 4
+//! features are dropped — `by_index` pose alignment is preserved
+//! because poses pair with the *pre-drop* image index.
+
+use std::path::{Path, PathBuf};
+
+use vision_calibration_core::View;
+use vision_calibration_dataset::{DatasetSpec, Topology, validate};
+use vision_calibration_detect::DetectionCache;
+
+use crate::single_cam_handeye::{HandeyeMeta, SingleCamHandeyeInput};
+
+use super::pairing::pair_views;
+use super::poses::{load_robot_poses, match_poses_to_tokens};
+use super::{
+    RunError, augment_config_with_roi, detect_features, expand_camera_images, features_to_obs,
+    pattern_repr, pick_detector, target_to_detector_config,
+};
+
+/// Result of a single-camera hand-eye dataset conversion.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct HandeyeRunResult {
+    /// The IR ready to feed into `CalibrationSession::set_input`.
+    pub input: SingleCamHandeyeInput,
+    /// One source image path per accepted view, in the same order.
+    /// Used to populate the export's `image_manifest` after the solve.
+    pub view_paths: Vec<PathBuf>,
+    /// Number of views where detection produced ≥4 features.
+    pub usable_views: usize,
+    /// Total number of images attempted.
+    pub total_views: usize,
+}
+
+/// Convert a single-camera + robot-poses manifest + cache into a
+/// [`SingleCamHandeyeInput`] for `SingleCamHandeye`.
+pub fn build_single_cam_handeye_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<HandeyeRunResult, RunError> {
+    // Same gate ordering as the other converters: topology + target +
+    // validation + pairing config before any filesystem access.
+    if spec.topology != Topology::SingleCamHandeye {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let (detector_name, detector_config) = target_to_detector_config(&spec.target)?;
+    let detector = pick_detector(detector_name)?;
+    validate(spec)?;
+
+    if spec.pose_pairing.is_none() {
+        return Err(RunError::AskUser {
+            field: "pose_pairing".into(),
+            prompt: "Hand-eye topologies need to know how images align with robot poses. \
+                     Pick by_index (pose row i pairs with the i-th image in natural-sort \
+                     order) or shared_filename_token (a regex extracts the pose id from \
+                     filenames)."
+                .into(),
+            suggestions: vec!["by_index".into(), "shared_filename_token".into()],
+        });
+    }
+
+    // The validator enforces exactly one camera and the presence of
+    // robot_poses + pose_convention for this topology.
+    let camera = spec
+        .cameras
+        .first()
+        .expect("validate guarantees exactly one camera for SingleCamHandeye");
+    let images = expand_camera_images(camera, base_dir)?;
+    if images.is_empty() {
+        return Err(RunError::EmptyImageMatch {
+            camera_id: camera.id.clone(),
+            pattern: pattern_repr(&camera.images),
+            base: base_dir.to_path_buf(),
+        });
+    }
+
+    // Reuse the multi-camera pairing machinery with a single camera:
+    // it produces one token per image (index or filename token), which
+    // is exactly what pose matching needs.
+    let pairing = spec
+        .pose_pairing
+        .as_ref()
+        .expect("checked above; pose_pairing is present");
+    let paired = pair_views(
+        std::slice::from_ref(&images),
+        std::slice::from_ref(&camera.id),
+        pairing,
+    )?;
+    let total_views = paired.paths.len();
+
+    let source = spec
+        .robot_poses
+        .as_ref()
+        .expect("validate guarantees robot_poses for SingleCamHandeye");
+    let convention = spec
+        .pose_convention
+        .as_ref()
+        .expect("validate guarantees pose_convention for SingleCamHandeye");
+    let poses = load_robot_poses(source, convention, base_dir)?;
+
+    let roi = camera.roi_xywh;
+    let key_config = augment_config_with_roi(&detector_config, roi);
+
+    let mut kept_obs = Vec::new();
+    let mut kept_tokens: Vec<String> = Vec::new();
+    let mut view_paths: Vec<PathBuf> = Vec::new();
+    for (paths, token) in paired.paths.iter().zip(&paired.tokens) {
+        let path = paths[0]
+            .as_ref()
+            .expect("single-camera pairing never produces gap slots");
+        let (features, _cache_hit) = detect_features(
+            detector.as_ref(),
+            detector_name,
+            &detector_config,
+            &key_config,
+            roi,
+            path,
+            cache,
+            force_redetect,
+        )?;
+        if features.len() < 4 {
+            // Too few features for a homography — drop the view (still
+            // counted in total_views, keeping by_index pose alignment).
+            continue;
+        }
+        kept_obs.push(features_to_obs(&features));
+        kept_tokens.push(token.clone());
+        view_paths.push(path.clone());
+    }
+
+    if kept_obs.is_empty() {
+        return Err(RunError::InsufficientUsableViews {
+            camera_id: camera.id.clone(),
+            usable: 0,
+            total: total_views,
+        });
+    }
+
+    let matched = match_poses_to_tokens(&kept_tokens, &poses, spec, total_views)?;
+    let views: Vec<View<HandeyeMeta>> = kept_obs
+        .into_iter()
+        .zip(matched)
+        .map(|(obs, base_se3_gripper)| View {
+            obs,
+            meta: HandeyeMeta { base_se3_gripper },
+        })
+        .collect();
+
+    let usable_views = views.len();
+    let input = SingleCamHandeyeInput::new(views).map_err(|e| RunError::AskUser {
+        field: "cameras[0].images".into(),
+        prompt: format!("hand-eye input rejected: {e}"),
+        suggestions: vec![],
+    })?;
+
+    Ok(HandeyeRunResult {
+        input,
+        view_paths,
+        usable_views,
+        total_views,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use vision_calibration_dataset::{
+        CameraSource, ImagePattern, PoseColumnMap, PoseConvention, PosePairing, RobotPoseFormat,
+        RobotPoseSource, RotationFormat, TargetSpec, TransformConvention, TranslationUnits,
+    };
+    use vision_calibration_detect::{CacheKey, CachedFeatures, Feature, FsDetectionCache};
+
+    fn grid_features(n: usize) -> Vec<Feature> {
+        (0..n)
+            .map(|i| Feature {
+                image_xy: [100.0 + 10.0 * i as f64, 200.0 + 5.0 * i as f64],
+                world_xyz: [0.025 * i as f64, 0.0, 0.0],
+            })
+            .collect()
+    }
+
+    fn detector_config() -> serde_json::Value {
+        json!({"rows": 9, "cols": 6, "square_size_m": 0.025})
+    }
+
+    /// Write a dummy "image" file and pre-seed the cache for it, so the
+    /// runner takes the cache-hit path and never decodes the bytes.
+    fn seed_image(
+        dir: &Path,
+        cache: &FsDetectionCache,
+        rel_path: &str,
+        features: Vec<Feature>,
+    ) -> PathBuf {
+        let path = dir.join(rel_path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = rel_path.as_bytes();
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(bytes).unwrap();
+        let key = CacheKey::from_inputs(bytes, "chessboard", &detector_config());
+        cache.put(&key, &CachedFeatures { features }).unwrap();
+        path
+    }
+
+    fn handeye_spec(dir: &Path, image_paths: &[&str], pose_lines: &str) -> DatasetSpec {
+        let pose_path = dir.join("poses.txt");
+        std::fs::write(&pose_path, pose_lines).unwrap();
+        DatasetSpec {
+            version: 1,
+            cameras: vec![CameraSource {
+                id: "cam0".into(),
+                images: ImagePattern::List {
+                    paths: image_paths.iter().map(PathBuf::from).collect(),
+                },
+                roi_xywh: None,
+            }],
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: Some(RobotPoseSource {
+                path: PathBuf::from("poses.txt"),
+                format: RobotPoseFormat::Rowmajor4x4,
+                columns: None,
+            }),
+            topology: Topology::SingleCamHandeye,
+            pose_pairing: Some(PosePairing::ByIndex),
+            pose_convention: Some(PoseConvention {
+                transform: TransformConvention::TBaseTcp,
+                rotation_format: RotationFormat::Matrix4x4RowMajor,
+                translation_units: TranslationUnits::M,
+            }),
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    fn identity_pose_line(tx: f64) -> String {
+        format!("1 0 0 {tx}  0 1 0 0  0 0 1 0  0 0 0 1\n")
+    }
+
+    #[test]
+    fn by_index_builds_input_with_poses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for view in 0..3 {
+            seed_image(
+                tmp.path(),
+                &cache,
+                &format!("img_{view}.png"),
+                grid_features(6),
+            );
+        }
+        let poses: String = (0..3)
+            .map(|i| identity_pose_line((i + 1) as f64 / 10.0))
+            .collect();
+        let spec = handeye_spec(tmp.path(), &["img_0.png", "img_1.png", "img_2.png"], &poses);
+        let result = build_single_cam_handeye_input(&spec, tmp.path(), &cache, false).unwrap();
+        assert_eq!(result.input.num_views(), 3);
+        assert_eq!((result.usable_views, result.total_views), (3, 3));
+        let xs: Vec<f64> = result
+            .input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper.translation.x)
+            .collect();
+        assert_eq!(xs, vec![0.1, 0.2, 0.3]);
+        assert!(result.view_paths[2].ends_with("img_2.png"));
+    }
+
+    #[test]
+    fn weak_view_dropped_but_pose_alignment_kept() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_image(tmp.path(), &cache, "img_0.png", grid_features(6));
+        // Middle view: too few features → dropped.
+        seed_image(tmp.path(), &cache, "img_1.png", grid_features(3));
+        seed_image(tmp.path(), &cache, "img_2.png", grid_features(6));
+        let poses: String = (0..3)
+            .map(|i| identity_pose_line((i + 1) as f64 / 10.0))
+            .collect();
+        let spec = handeye_spec(tmp.path(), &["img_0.png", "img_1.png", "img_2.png"], &poses);
+        let result = build_single_cam_handeye_input(&spec, tmp.path(), &cache, false).unwrap();
+        assert_eq!((result.usable_views, result.total_views), (2, 3));
+        // The surviving views must keep poses 0 and 2 — not 0 and 1.
+        let xs: Vec<f64> = result
+            .input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper.translation.x)
+            .collect();
+        assert_eq!(xs, vec![0.1, 0.3]);
+    }
+
+    #[test]
+    fn pose_count_mismatch_is_actionable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_image(tmp.path(), &cache, "img_0.png", grid_features(6));
+        seed_image(tmp.path(), &cache, "img_1.png", grid_features(6));
+        let spec = handeye_spec(
+            tmp.path(),
+            &["img_0.png", "img_1.png"],
+            &identity_pose_line(0.1),
+        );
+        let err = build_single_cam_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::PoseCountMismatch { poses, views } => assert_eq!((poses, views), (1, 2)),
+            other => panic!("expected PoseCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_topology_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let mut spec = handeye_spec(tmp.path(), &["a.png"], &identity_pose_line(0.1));
+        spec.topology = Topology::PlanarIntrinsics;
+        let err = build_single_cam_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        assert!(matches!(err, RunError::UnsupportedTopology { .. }));
+    }
+
+    #[test]
+    fn missing_pose_pairing_asks_user() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let mut spec = handeye_spec(tmp.path(), &["a.png"], &identity_pose_line(0.1));
+        spec.pose_pairing = None;
+        let err = build_single_cam_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
+        match err {
+            RunError::AskUser { field, .. } => assert_eq!(field, "pose_pairing"),
+            other => panic!("expected AskUser, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_pairing_matches_poses_by_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_image(tmp.path(), &cache, "img_0.png", grid_features(6));
+        seed_image(tmp.path(), &cache, "img_1.png", grid_features(6));
+        // CSV with pose ids deliberately out of file order.
+        let csv = "view,tx,ty,tz,qx,qy,qz,qw\n\
+                   1,0.2,0,0,0,0,0,1\n\
+                   0,0.1,0,0,0,0,0,1";
+        let mut spec = handeye_spec(tmp.path(), &["img_0.png", "img_1.png"], "");
+        std::fs::write(tmp.path().join("poses.csv"), csv).unwrap();
+        spec.robot_poses = Some(RobotPoseSource {
+            path: PathBuf::from("poses.csv"),
+            format: RobotPoseFormat::Csv,
+            columns: Some(PoseColumnMap {
+                pose_id: Some("view".into()),
+                tx: "tx".into(),
+                ty: "ty".into(),
+                tz: "tz".into(),
+                rotation: vec!["qx".into(), "qy".into(), "qz".into(), "qw".into()],
+            }),
+        });
+        spec.pose_convention = Some(PoseConvention {
+            transform: TransformConvention::TBaseTcp,
+            rotation_format: RotationFormat::QuatXyzw,
+            translation_units: TranslationUnits::M,
+        });
+        spec.pose_pairing = Some(PosePairing::SharedFilenameToken {
+            regex: r"^img_(?<view>\d+)\.png$".into(),
+            group: "view".into(),
+        });
+        let result = build_single_cam_handeye_input(&spec, tmp.path(), &cache, false).unwrap();
+        let xs: Vec<f64> = result
+            .input
+            .views
+            .iter()
+            .map(|v| v.meta.base_se3_gripper.translation.x)
+            .collect();
+        assert_eq!(xs, vec![0.1, 0.2]);
+    }
+}

--- a/crates/vision-calibration-pipeline/src/dataset_runner/mod.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/mod.rs
@@ -10,9 +10,11 @@
 //! - [`build_rig_handeye_input`] — `RigHandeye`
 //!   (`RigDataset<RobotPoseMeta>`, robot poses loaded from the manifest's
 //!   [`RobotPoseSource`](vision_calibration_dataset::RobotPoseSource)).
+//! - [`build_single_cam_handeye_input`] — `SingleCamHandeye`
+//!   (`SingleCamHandeyeInput`, single camera + robot poses).
 //!
 //! The laser topologies (`LaserlineDevice`, `RigLaserlineDevice`) await
-//! the laser-frame manifest design; `SingleCamHandeye` follows in B3c-2.
+//! the laser-frame manifest design.
 //!
 //! Per ADR 0019, any ambiguity that cannot be auto-resolved at
 //! conversion time is surfaced as a [`RunError::AskUser`] event so
@@ -30,11 +32,13 @@ use vision_calibration_detect::{
     Feature, validate_charuco_layout,
 };
 
+mod handeye;
 mod pairing;
 mod planar;
 mod poses;
 mod rig;
 
+pub use handeye::{HandeyeRunResult, build_single_cam_handeye_input};
 pub use pairing::PairedViews;
 pub use planar::{PlanarRunResult, build_planar_input};
 pub use rig::{RigRunResult, build_rig_extrinsics_input, build_rig_handeye_input};

--- a/crates/vision-calibration-pipeline/src/dataset_runner/poses.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/poses.rs
@@ -17,8 +17,8 @@ use serde_json::Value;
 
 use vision_calibration_core::Iso3;
 use vision_calibration_dataset::{
-    PoseConvention, RobotPoseFormat, RobotPoseSource, RotationFormat, TransformConvention,
-    TranslationUnits,
+    DatasetSpec, PoseConvention, PosePairing, RobotPoseFormat, RobotPoseSource, RotationFormat,
+    TransformConvention, TranslationUnits,
 };
 
 use super::RunError;
@@ -46,6 +46,17 @@ pub(crate) fn load_robot_poses(
         base_dir.join(&source.path)
     };
     let text = std::fs::read_to_string(&path)?;
+
+    // The headerless matrix format has no column mapping — parse it
+    // directly instead of funnelling through `RawRow`.
+    if source.format == RobotPoseFormat::Rowmajor4x4 {
+        return text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .enumerate()
+            .map(|(i, line)| parse_matrix_row(line, i, convention, &path))
+            .collect();
+    }
 
     let rows: Vec<RawRow> = match source.format {
         RobotPoseFormat::Csv => parse_csv_rows(&text, &path)?,
@@ -75,6 +86,9 @@ pub(crate) fn load_robot_poses(
                 object_to_row(v, i, &path)
             })
             .collect::<Result<_, _>>()?,
+        RobotPoseFormat::Rowmajor4x4 => {
+            unreachable!("handled by the early return above")
+        }
     };
 
     rows.iter()
@@ -172,7 +186,10 @@ fn parse_pose_row(
     convention: &PoseConvention,
     path: &Path,
 ) -> Result<ParsedPose, RunError> {
-    let columns = &source.columns;
+    let columns = source.columns.as_ref().expect(
+        "validate guarantees a columns mapping for the tabular pose formats, \
+         and Rowmajor4x4 never reaches this row parser",
+    );
     let get = |name: &str| -> Result<&str, RunError> {
         row.fields
             .get(name)
@@ -235,6 +252,158 @@ fn parse_pose_row(
 
     Ok(ParsedPose {
         id,
+        base_se3_gripper,
+    })
+}
+
+/// Match one robot pose to every kept view, identified by its pairing
+/// token. Shared by the rig and single-camera hand-eye converters.
+///
+/// - `by_index`: poses pair with *paired* views (pre-drop): pose `i`
+///   belongs to view token `i` even when that view was later dropped,
+///   so the pose count must equal `total_views`.
+/// - `shared_filename_token`: poses pair by their `pose_id` column
+///   equalling the view token; requires a `pose_id` mapping and
+///   unique ids.
+///
+/// Returns one `T_B_G` per token, in token order.
+pub(crate) fn match_poses_to_tokens(
+    tokens: &[String],
+    poses: &[ParsedPose],
+    spec: &DatasetSpec,
+    total_views: usize,
+) -> Result<Vec<Iso3>, RunError> {
+    let pairing = spec
+        .pose_pairing
+        .as_ref()
+        .expect("converters require pose_pairing before matching poses");
+
+    match pairing {
+        PosePairing::ByIndex => {
+            if poses.len() != total_views {
+                return Err(RunError::PoseCountMismatch {
+                    poses: poses.len(),
+                    views: total_views,
+                });
+            }
+            tokens
+                .iter()
+                .map(|token| {
+                    let index: usize = token
+                        .parse()
+                        .expect("by_index pairing tokens are stringified indices");
+                    Ok(poses[index].base_se3_gripper)
+                })
+                .collect()
+        }
+        PosePairing::SharedFilenameToken { .. } => {
+            if spec
+                .robot_poses
+                .as_ref()
+                .and_then(|s| s.columns.as_ref())
+                .is_none_or(|c| c.pose_id.is_none())
+            {
+                return Err(RunError::AskUser {
+                    field: "robot_poses.columns.pose_id".into(),
+                    prompt: "shared_filename_token pairing needs a pose_id column mapping \
+                             so each pose row can be matched to its view token."
+                        .into(),
+                    suggestions: vec![],
+                });
+            }
+            // Collecting straight into a HashMap would silently keep only
+            // the last row for a repeated pose_id, attaching an arbitrary
+            // pose to the matching view. A duplicate id is an ambiguous
+            // manifest, so reject it up front like a missing token.
+            let mut by_id: std::collections::HashMap<&str, &ParsedPose> =
+                std::collections::HashMap::with_capacity(poses.len());
+            for pose in poses {
+                if let Some(id) = pose.id.as_deref()
+                    && by_id.insert(id, pose).is_some()
+                {
+                    return Err(RunError::PairingTokenMismatch {
+                        message: format!(
+                            "duplicate pose_id {id:?} in the robot-pose table; each \
+                             pose_id must be unique so views pair unambiguously"
+                        ),
+                    });
+                }
+            }
+            tokens
+                .iter()
+                .map(|token| {
+                    let pose = by_id.get(token.as_str()).ok_or_else(|| {
+                        RunError::PairingTokenMismatch {
+                            message: format!(
+                                "no pose row with pose_id {token:?} (the cameras produced a \
+                                 view with this token)"
+                            ),
+                        }
+                    })?;
+                    Ok(pose.base_se3_gripper)
+                })
+                .collect()
+        }
+    }
+}
+
+/// Parse one headerless `rowmajor4x4` line: 16 whitespace-separated
+/// floats forming a row-major 4×4 homogeneous transform. Rotation is
+/// re-orthonormalized (KUKA exports carry float noise); translation
+/// comes from the matrix's fourth column, scaled by the declared
+/// units. `id` is always `None` — a headerless file has no pose-id
+/// column, so only `by_index` pairing can consume it.
+fn parse_matrix_row(
+    line: &str,
+    index: usize,
+    convention: &PoseConvention,
+    path: &Path,
+) -> Result<ParsedPose, RunError> {
+    let values: Vec<f64> = line
+        .split_whitespace()
+        .map(|tok| {
+            tok.parse::<f64>().map_err(|_| RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: index,
+                message: format!("{tok:?} is not a number"),
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    if values.len() != 16 {
+        return Err(RunError::PoseParse {
+            path: path.to_path_buf(),
+            row: index,
+            message: format!(
+                "rowmajor4x4 expects 16 whitespace-separated values per line, got {}",
+                values.len()
+            ),
+        });
+    }
+
+    // The validator pinned `rotation_format` to `Matrix4x4RowMajor`,
+    // so the shared rotation builder applies directly.
+    let rotation =
+        rotation_from_values(RotationFormat::Matrix4x4RowMajor, &values).map_err(|message| {
+            RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: index,
+                message,
+            }
+        })?;
+    let scale = match convention.translation_units {
+        TranslationUnits::M => 1.0,
+        TranslationUnits::Mm => 1e-3,
+    };
+    let translation = Vector3::new(values[3] * scale, values[7] * scale, values[11] * scale);
+
+    let pose = Iso3::from_parts(translation.into(), rotation);
+    let base_se3_gripper = match convention.transform {
+        TransformConvention::TBaseTcp | TransformConvention::TWorldTcp => pose,
+        TransformConvention::TTcpBase | TransformConvention::TTcpWorld => pose.inverse(),
+    };
+
+    Ok(ParsedPose {
+        id: None,
         base_se3_gripper,
     })
 }
@@ -358,7 +527,7 @@ mod tests {
         RobotPoseSource {
             path: path.to_path_buf(),
             format,
-            columns,
+            columns: Some(columns),
         }
     }
 
@@ -465,6 +634,113 @@ mod tests {
         let got = &poses[0].base_se3_gripper;
         assert!((got.translation.vector - t_b_g.translation.vector).norm() < 1e-9);
         assert!(got.rotation.angle_to(&t_b_g.rotation) < 1e-9);
+    }
+
+    fn matrix_source(path: &Path) -> RobotPoseSource {
+        RobotPoseSource {
+            path: path.to_path_buf(),
+            format: RobotPoseFormat::Rowmajor4x4,
+            columns: None,
+        }
+    }
+
+    #[test]
+    fn rowmajor4x4_parses_kuka_style_lines() {
+        // Two near-identity rows with KUKA-grade float noise in the
+        // rotation block (mirrors data/kuka_1/RobotPosesVec.txt).
+        let text = "1.000000000\t0.000012689\t0.000002112\t1.204997681\t\
+                    -0.000012689\t1.000000000\t-0.000003979\t-0.808000305\t\
+                    -0.000002112\t0.000003979\t1.000000000\t0.523998047\t\
+                    0.000000000\t0.000000000\t0.000000000\t1.000000000\n\
+                    \n\
+                    1 0 0 0.5  0 1 0 -0.6  0 0 1 0.7  0 0 0 1\n";
+        let (_dir, path) = write_temp(text, "txt");
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::M,
+        );
+        let poses = load_robot_poses(&matrix_source(&path), &conv, path.parent().unwrap()).unwrap();
+        assert_eq!(poses.len(), 2, "blank lines are skipped");
+        let p0 = &poses[0].base_se3_gripper;
+        assert!(
+            (p0.translation.vector - Vector3::new(1.204997681, -0.808000305, 0.523998047)).norm()
+                < 1e-12
+        );
+        // Noisy rotation re-orthonormalizes to near-identity.
+        assert!(p0.rotation.angle() < 1e-4);
+        assert!(poses.iter().all(|p| p.id.is_none()), "headerless ⇒ no ids");
+        assert!((poses[1].base_se3_gripper.translation.y + 0.6).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rowmajor4x4_applies_units_and_inversion() {
+        let q = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), 0.7);
+        let t_b_g = Iso3::from_parts(Vector3::new(0.4, -0.1, 1.2).into(), q);
+        let t_g_b = t_b_g.inverse();
+        let m = t_g_b.to_homogeneous();
+        // Row-major flatten, translation in millimetres.
+        let mut row = String::new();
+        for r in 0..4 {
+            for c in 0..4 {
+                let v = if c == 3 && r < 3 {
+                    m[(r, c)] * 1000.0
+                } else {
+                    m[(r, c)]
+                };
+                row.push_str(&format!("{v:.9} "));
+            }
+        }
+        let (_dir, path) = write_temp(&row, "txt");
+        let conv = convention(
+            TransformConvention::TTcpBase,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::Mm,
+        );
+        let poses = load_robot_poses(&matrix_source(&path), &conv, path.parent().unwrap()).unwrap();
+        let got = &poses[0].base_se3_gripper;
+        assert!((got.translation.vector - t_b_g.translation.vector).norm() < 1e-6);
+        assert!(got.rotation.angle_to(&t_b_g.rotation) < 1e-6);
+    }
+
+    #[test]
+    fn rowmajor4x4_wrong_value_count_is_actionable() {
+        let (_dir, path) = write_temp("1 0 0 0 1 0 0 0 1\n", "txt");
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::M,
+        );
+        let err =
+            load_robot_poses(&matrix_source(&path), &conv, path.parent().unwrap()).unwrap_err();
+        match err {
+            RunError::PoseParse { row, message, .. } => {
+                assert_eq!(row, 0);
+                assert!(
+                    message.contains("16") && message.contains("9"),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected PoseParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rowmajor4x4_non_numeric_token_is_actionable() {
+        let (_dir, path) = write_temp("1 0 0 oops 0 1 0 0 0 0 1 0 0 0 0 1\n", "txt");
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::M,
+        );
+        let err =
+            load_robot_poses(&matrix_source(&path), &conv, path.parent().unwrap()).unwrap_err();
+        match err {
+            RunError::PoseParse { message, .. } => {
+                assert!(message.contains("oops"), "got: {message}");
+            }
+            other => panic!("expected PoseParse, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
@@ -13,12 +13,12 @@
 use std::path::{Path, PathBuf};
 
 use vision_calibration_core::{CorrespondenceView, NoMeta, RigDataset, RigView, RigViewObs};
-use vision_calibration_dataset::{DatasetSpec, PosePairing, Topology, validate};
+use vision_calibration_dataset::{DatasetSpec, Topology, validate};
 use vision_calibration_detect::DetectionCache;
 use vision_calibration_optim::RobotPoseMeta;
 
 use super::pairing::pair_views;
-use super::poses::{ParsedPose, load_robot_poses};
+use super::poses::{ParsedPose, load_robot_poses, match_poses_to_tokens};
 use super::{
     RunError, augment_config_with_roi, detect_features, expand_camera_images, features_to_obs,
     pattern_repr, pick_detector, target_to_detector_config,
@@ -206,97 +206,24 @@ fn build_rig_core(
     })
 }
 
-/// Attach one robot pose to every kept view.
+/// Attach one robot pose to every kept view (matching logic shared
+/// with the single-camera hand-eye converter in `poses.rs`).
 fn pair_poses_to_views(
     views: Vec<(RigViewObs, String)>,
     poses: &[ParsedPose],
     spec: &DatasetSpec,
     total_views: usize,
 ) -> Result<Vec<RigView<RobotPoseMeta>>, RunError> {
-    let pairing = spec
-        .pose_pairing
-        .as_ref()
-        .expect("build_rig_core already required pose_pairing");
-
-    match pairing {
-        PosePairing::ByIndex => {
-            // Poses pair with *paired* views (pre-drop): pose[i] belongs
-            // to view token i even when that view was later dropped.
-            if poses.len() != total_views {
-                return Err(RunError::PoseCountMismatch {
-                    poses: poses.len(),
-                    views: total_views,
-                });
-            }
-            views
-                .into_iter()
-                .map(|(obs, token)| {
-                    let index: usize = token
-                        .parse()
-                        .expect("by_index pairing tokens are stringified indices");
-                    Ok(RigView {
-                        obs,
-                        meta: RobotPoseMeta {
-                            base_se3_gripper: poses[index].base_se3_gripper,
-                        },
-                    })
-                })
-                .collect()
-        }
-        PosePairing::SharedFilenameToken { .. } => {
-            // Poses pair by their pose_id column equalling the view token.
-            if spec
-                .robot_poses
-                .as_ref()
-                .is_none_or(|s| s.columns.pose_id.is_none())
-            {
-                return Err(RunError::AskUser {
-                    field: "robot_poses.columns.pose_id".into(),
-                    prompt: "shared_filename_token pairing needs a pose_id column mapping \
-                             so each pose row can be matched to its view token."
-                        .into(),
-                    suggestions: vec![],
-                });
-            }
-            // Collecting straight into a HashMap would silently keep only
-            // the last row for a repeated pose_id, attaching an arbitrary
-            // pose to the matching view. A duplicate id is an ambiguous
-            // manifest, so reject it up front like a missing token.
-            let mut by_id: std::collections::HashMap<&str, &ParsedPose> =
-                std::collections::HashMap::with_capacity(poses.len());
-            for pose in poses {
-                if let Some(id) = pose.id.as_deref()
-                    && by_id.insert(id, pose).is_some()
-                {
-                    return Err(RunError::PairingTokenMismatch {
-                        message: format!(
-                            "duplicate pose_id {id:?} in the robot-pose table; each \
-                             pose_id must be unique so views pair unambiguously"
-                        ),
-                    });
-                }
-            }
-            views
-                .into_iter()
-                .map(|(obs, token)| {
-                    let pose = by_id.get(token.as_str()).ok_or_else(|| {
-                        RunError::PairingTokenMismatch {
-                            message: format!(
-                                "no pose row with pose_id {token:?} (the cameras produced a \
-                                 view with this token)"
-                            ),
-                        }
-                    })?;
-                    Ok(RigView {
-                        obs,
-                        meta: RobotPoseMeta {
-                            base_se3_gripper: pose.base_se3_gripper,
-                        },
-                    })
-                })
-                .collect()
-        }
-    }
+    let tokens: Vec<String> = views.iter().map(|(_, token)| token.clone()).collect();
+    let matched = match_poses_to_tokens(&tokens, poses, spec, total_views)?;
+    Ok(views
+        .into_iter()
+        .zip(matched)
+        .map(|((obs, _token), base_se3_gripper)| RigView {
+            obs,
+            meta: RobotPoseMeta { base_se3_gripper },
+        })
+        .collect())
 }
 
 fn finish<Meta>(
@@ -324,7 +251,7 @@ mod tests {
     use serde_json::json;
     use std::io::Write;
     use vision_calibration_dataset::{
-        CameraSource, ImagePattern, PoseColumnMap, PoseConvention, RobotPoseFormat,
+        CameraSource, ImagePattern, PoseColumnMap, PoseConvention, PosePairing, RobotPoseFormat,
         RobotPoseSource, RotationFormat, TargetSpec, TransformConvention, TranslationUnits,
     };
     use vision_calibration_detect::{CacheKey, CachedFeatures, Feature, FsDetectionCache};
@@ -494,13 +421,13 @@ mod tests {
         spec.robot_poses = Some(RobotPoseSource {
             path: PathBuf::from("poses.csv"),
             format: RobotPoseFormat::Csv,
-            columns: PoseColumnMap {
+            columns: Some(PoseColumnMap {
                 pose_id: None,
                 tx: "tx".into(),
                 ty: "ty".into(),
                 tz: "tz".into(),
                 rotation: vec!["qx".into(), "qy".into(), "qz".into(), "qw".into()],
-            },
+            }),
         });
         spec.pose_convention = Some(PoseConvention {
             transform: TransformConvention::TBaseTcp,
@@ -623,7 +550,7 @@ mod tests {
             group: "view".into(),
         });
         if let Some(rp) = &mut spec.robot_poses {
-            rp.columns.pose_id = Some("view".into());
+            rp.columns.as_mut().unwrap().pose_id = Some("view".into());
         }
         let result = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap();
         assert_eq!(result.dataset.num_views(), 2);
@@ -668,7 +595,7 @@ mod tests {
             group: "view".into(),
         });
         if let Some(rp) = &mut spec.robot_poses {
-            rp.columns.pose_id = Some("view".into());
+            rp.columns.as_mut().unwrap().pose_id = Some("view".into());
         }
         let err = build_rig_handeye_input(&spec, tmp.path(), &cache, false).unwrap_err();
         match err {

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
@@ -6,7 +6,7 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    Iso3, PerFeatureResiduals, PinholeCamera, View, build_feature_histogram,
+    ImageManifest, Iso3, PerFeatureResiduals, PinholeCamera, View, build_feature_histogram,
     compute_planar_target_residuals_views,
 };
 use vision_calibration_optim::{
@@ -199,6 +199,13 @@ pub struct SingleCamHandeyeExport {
     /// (see [`handeye_observer_se3_target`](vision_calibration_optim::handeye_observer_se3_target)).
     #[serde(default)]
     pub per_feature_residuals: PerFeatureResiduals,
+
+    /// Optional pointer to the source images behind this export. When
+    /// populated, downstream viewers (the diagnose UI) can locate the
+    /// source image for each view. `None` means "no images shipped";
+    /// the calibration pipeline never reads this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_manifest: Option<ImageManifest>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -372,6 +379,7 @@ impl ProblemType for SingleCamHandeyeProblem {
             mean_reproj_error: output.mean_reproj_error,
             per_cam_reproj_errors: output.per_cam_reproj_errors.clone(),
             per_feature_residuals,
+            image_manifest: None,
         })
     }
 }

--- a/data/kuka_1/dataset.toml
+++ b/data/kuka_1/dataset.toml
@@ -1,0 +1,33 @@
+# KUKA single-camera hand-eye dataset (eye-in-hand).
+#
+# 30 chessboard views (`01.png`–`30.png`); `RobotPosesVec.txt` carries
+# one row-major 4×4 `T_base_tcp` homogeneous matrix per line, in
+# metres. Image `NN.png` pairs with pose row `NN` (by_index after
+# natural sort). Board: 17×28 interior corners, 20 mm squares
+# (`squaresize.txt`; mirrors the bench registry entry `kuka_1`).
+
+version = 1
+topology = "single_cam_handeye"
+description = "kuka_1"
+
+[[cameras]]
+id = "cam0"
+images = { kind = "glob", pattern = "*.png" }
+
+[target]
+kind = "chessboard"
+rows = 17
+cols = 28
+square_size_m = 0.02
+
+[robot_poses]
+path = "RobotPosesVec.txt"
+format = "rowmajor4x4"
+
+[pose_pairing]
+kind = "by_index"
+
+[pose_convention]
+transform = "t_base_tcp"
+rotation_format = "matrix4x4_row_major"
+translation_units = "m"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -112,10 +112,14 @@ puzzleboard / ringgrid) are supported.
     runner (+`default_config_cmd`), TS topology selector + presets.
     Covers PlanarIntrinsics, ScheimpflugIntrinsics (incl. its export's
     `image_manifest`), RigExtrinsics, RigHandeye.
-  - **B3c-2 (next):** SingleCamHandeye (~free after B3c-1's pose
-    loader; kuka_1 needs a pose-file conversion), laser topologies
-    (need the laser-frame manifest ADR), puzzleboard + ringgrid
-    detectors, bench/examples-private charuco dedup.
+  - **B3c-2 (in flight):** SingleCamHandeye **shipped 2026-06-12** —
+    `rowmajor4x4` headerless pose-file format (`DatasetSpec`), shared
+    pose-to-view matching, `build_single_cam_handeye_input`,
+    `image_manifest` on `SingleCamHandeyeExport`, Tauri dispatch arm,
+    KUKA preset enabled over the committed `data/kuka_1` manifest
+    (no pose-file conversion needed after all). Remainder: laser
+    topologies (need the laser-frame manifest ADR), puzzleboard +
+    ringgrid detectors, bench/examples-private charuco dedup.
 - **B-laser — laserline visualization.** Laser-pixel overlay in
   Diagnose; laser plane-fit residuals (point-to-plane mm) alongside
   reprojection residuals; laser planes rendered in the 3D rig viewer.


### PR DESCRIPTION
## Summary

First B3c-2 slice (per `docs/ROADMAP.md`): the `SingleCamHandeye` topology now runs end-to-end through the app's Run workspace — manifest → cached detection → pose loading → hand-eye solve → export with `image_manifest` → Diagnose.

- **`rowmajor4x4` pose-file format** (`vision-calibration-dataset`): headerless text, one row-major 4×4 homogeneous matrix (16 whitespace-separated floats) per line — the KUKA export style. `RobotPoseSource.columns` becomes `Option`: required for csv/json/jsonl (`MissingPoseColumns`), rejected for `rowmajor4x4` (`BadMatrixPoseConfig`, fail-fast per ADR 0019). The matrix rotation path reuses the existing `Matrix4x4RowMajor` builder (re-orthonormalizing).
- **`build_single_cam_handeye_input`** (`dataset_runner/handeye.rs`): single camera, ROI-aware cached detection; weak views (<4 features) drop without breaking `by_index` pose alignment. Pose-to-view matching is extracted from the rig converter into a shared `match_poses_to_tokens` (−90 LoC in `rig.rs`, no copy-paste).
- **`SingleCamHandeyeExport.image_manifest`** — one of the three remaining B3c manifest-sweep items.
- **Tauri runner**: real `SingleCamHandeye` dispatch arm (was "follows in B3c-2"); planar-style manifest splice.
- **App**: `single_cam_handeye` marked supported with its schemars config schema; the disabled "KUKA handeye" preset card is now live over the **committed** `data/kuka_1/dataset.toml` (30 views, chessboard 17×28 @ 20 mm, eye-in-hand).

## Test plan

- [x] `cargo fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace --all-features`, `cargo doc --no-deps` — all green
- [x] New unit tests: matrix pose parsing (noise, units, inversion, malformed rows), validator rules for the new format, handeye converter (by-index, weak-view alignment, pose-count mismatch, token pairing)
- [x] `cargo xtask emit-schemas` regenerated `dataset_spec.json`; `bun run build` compiles
- [x] E2E (release, `--ignored`): `kuka_handeye_end_to_end` passes on the committed dataset — 30/30 usable views, mean reprojection < 2 px, eye-in-hand transform + image manifest present; existing stereo/charuco preset suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)