### PR TITLE
B3c-3: laser topologies end-to-end in the Run workspace (ADR 0021)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "vision-calibration-dataset",
  "vision-calibration-detect",
  "vision-calibration-pipeline",
+ "vision-metrology",
 ]
 
 [[package]]
@@ -6469,6 +6470,66 @@ dependencies = [
  "vision-calibration-detect",
  "vision-calibration-linear",
  "vision-calibration-optim",
+]
+
+[[package]]
+name = "vision-metrology"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+dependencies = [
+ "vm-contour",
+ "vm-core",
+ "vm-edge",
+ "vm-laser",
+ "vm-morph",
+ "vm-pyr",
+]
+
+[[package]]
+name = "vm-contour"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+dependencies = [
+ "vm-core",
+ "vm-edge",
+]
+
+[[package]]
+name = "vm-core"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+
+[[package]]
+name = "vm-edge"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+dependencies = [
+ "vm-core",
+]
+
+[[package]]
+name = "vm-laser"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+dependencies = [
+ "vm-core",
+ "vm-edge",
+]
+
+[[package]]
+name = "vm-morph"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+dependencies = [
+ "vm-core",
+]
+
+[[package]]
+name = "vm-pyr"
+version = "0.1.0"
+source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
+dependencies = [
+ "vm-core",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -36,6 +36,11 @@ vision-calibration-core = { path = "../../crates/vision-calibration-core" }
 vision-calibration-pipeline = { path = "../../crates/vision-calibration-pipeline" }
 vision-calibration-dataset = { path = "../../crates/vision-calibration-dataset" }
 vision-calibration-detect = { path = "../../crates/vision-calibration-detect" }
+# Laser-line extraction (ADR 0021). vision-metrology is not on
+# crates.io, so the published pipeline crates only define the
+# `LaserPixelExtractor` trait; this (unpublished) app provides the
+# implementation. Same pin as vision-calibration-bench.
+vision-metrology = { git = "https://github.com/VitalyVorobyev/vision-metrology.git", tag = "v0.1.0" }
 dirs = "5"
 
 [dev-dependencies]

--- a/app/src-tauri/src/laser.rs
+++ b/app/src-tauri/src/laser.rs
@@ -1,0 +1,112 @@
+//! `vision-metrology`-backed laser-line extraction (ADR 0021).
+//!
+//! The pipeline's laser converters take an injected
+//! [`LaserPixelExtractor`] because `vision-metrology` is not on
+//! crates.io and the published crates cannot depend on it. This app is
+//! unpublished, so the reference implementation lives here.
+
+use vision_calibration_dataset::{LaserExtractionSpec, LaserScanAxis};
+use vision_calibration_pipeline::dataset_runner::LaserPixelExtractor;
+use vision_metrology::{
+    ColAccess, Edge1DConfig, ImageView, LaserExtractConfig, LaserExtractor, ScanAxis,
+};
+
+/// Subpixel DoG-edge laser-line extractor wrapping
+/// `vision_metrology::LaserExtractor` — the implementation validated
+/// against the rtv3d oracle in the V-track.
+pub struct VmLaserExtractor;
+
+impl LaserPixelExtractor for VmLaserExtractor {
+    fn name(&self) -> &str {
+        // Part of the detection-cache key (`laser:<name>`); bump when
+        // the wrapped extractor changes behaviour.
+        "vision-metrology-v0.1"
+    }
+
+    fn extract(
+        &self,
+        image: &image::DynamicImage,
+        spec: &LaserExtractionSpec,
+    ) -> anyhow::Result<Vec<[f64; 2]>> {
+        let luma = image.to_luma8();
+        let width = luma.width() as usize;
+        let height = luma.height() as usize;
+        let view = ImageView::<u8>::from_slice(width, height, width, luma.as_raw())
+            .map_err(|e| anyhow::anyhow!("image view ({width}x{height}): {e:?}"))?;
+
+        let (axis, scan_len) = match spec.scan_axis {
+            LaserScanAxis::Cols => (
+                ScanAxis::Cols {
+                    access: ColAccess::Gather,
+                },
+                width,
+            ),
+            LaserScanAxis::Rows => (ScanAxis::Rows, height),
+        };
+        let cfg = LaserExtractConfig {
+            axis,
+            edge_cfg: Edge1DConfig {
+                sigma: spec.sigma as f32,
+                pos_thresh: spec.pos_thresh as f32,
+                neg_thresh: spec.neg_thresh as f32,
+                ..Edge1DConfig::default()
+            },
+            ..LaserExtractConfig::default()
+        };
+        let mut extractor = LaserExtractor::new(cfg.edge_cfg.sigma);
+        let line = extractor.extract_line_u8(&view, 0..scan_len, &cfg, None);
+
+        Ok(line
+            .points
+            .into_iter()
+            .map(|p| [p.x as f64, p.y as f64])
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_a_synthetic_stripe() {
+        // Bright 3-px horizontal stripe across a dark image.
+        let mut img = image::GrayImage::new(80, 48);
+        for x in 5..75 {
+            let y = 20 + (x as i32 - 40).abs() / 16;
+            for dy in -1..=1 {
+                img.put_pixel(x, (y + dy) as u32, image::Luma([220]));
+            }
+        }
+        let dynamic = image::DynamicImage::ImageLuma8(img);
+        let points = VmLaserExtractor
+            .extract(&dynamic, &LaserExtractionSpec::default())
+            .unwrap();
+        assert!(points.len() >= 20, "got {} points", points.len());
+        // One point per column at most, near the stripe centre.
+        for p in &points {
+            assert!((p[1] - 21.0).abs() < 4.0, "outlier at {p:?}");
+        }
+    }
+
+    #[test]
+    fn rows_axis_scans_vertical_stripes() {
+        // Bright vertical stripe → one detection per row.
+        let mut img = image::GrayImage::new(48, 80);
+        for y in 5..75 {
+            for dx in -1i32..=1 {
+                img.put_pixel((24 + dx) as u32, y, image::Luma([220]));
+            }
+        }
+        let dynamic = image::DynamicImage::ImageLuma8(img);
+        let spec = LaserExtractionSpec {
+            scan_axis: LaserScanAxis::Rows,
+            ..Default::default()
+        };
+        let points = VmLaserExtractor.extract(&dynamic, &spec).unwrap();
+        assert!(points.len() >= 20, "got {} points", points.len());
+        for p in &points {
+            assert!((p[0] - 24.0).abs() < 4.0, "outlier at {p:?}");
+        }
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@
 mod commands;
 mod epipolar;
 mod export_cache;
+mod laser;
 mod run;
 
 use export_cache::ExportCache;

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -4,10 +4,9 @@
 //! per-problem `*Config`, dispatches on the manifest's topology to the
 //! right `CalibrationSession`, runs detection (cached) + calibration on
 //! a `tauri::async_runtime::spawn_blocking` task, and returns the
-//! export plus run metrics. Supported topologies: `PlanarIntrinsics`,
-//! `ScheimpflugIntrinsics`, `SingleCamHandeye`, `RigExtrinsics`,
-//! `RigHandeye`. The laser topologies await the laser-frame manifest
-//! design.
+//! export plus run metrics. All seven topologies are supported; the
+//! laser topologies (ADR 0021) extract laser-line pixels through
+//! [`crate::laser::VmLaserExtractor`].
 //!
 //! Per ADR 0019, ambiguity that the runtime cannot auto-resolve is
 //! surfaced as a structured `RunResponse::AskUser` so the Run workspace
@@ -23,10 +22,13 @@ use vision_calibration_core::{FrameRef, ImageManifest, PlanarDataset, RigDataset
 use vision_calibration_dataset::{DatasetSpec, Topology};
 use vision_calibration_detect::FsDetectionCache;
 use vision_calibration_pipeline::dataset_runner::{
-    RunError, build_planar_input, build_rig_extrinsics_input, build_rig_handeye_input,
-    build_single_cam_handeye_input,
+    RunError, build_laserline_device_input, build_planar_input, build_rig_extrinsics_input,
+    build_rig_handeye_input, build_rig_laserline_device_input, build_single_cam_handeye_input,
 };
-use vision_calibration_pipeline::laserline_device::LaserlineDeviceConfig;
+use vision_calibration_pipeline::laserline_device::{
+    LaserlineDeviceConfig, LaserlineDeviceProblem,
+    run_calibration as run_laserline_device_calibration,
+};
 use vision_calibration_pipeline::planar_intrinsics::{
     PlanarIntrinsicsConfig, PlanarIntrinsicsProblem, run_calibration as run_planar_calibration,
 };
@@ -36,7 +38,10 @@ use vision_calibration_pipeline::rig_extrinsics::{
 use vision_calibration_pipeline::rig_handeye::{
     RigHandeyeConfig, RigHandeyeProblem, run_calibration as run_rig_handeye_calibration,
 };
-use vision_calibration_pipeline::rig_laserline_device::RigLaserlineDeviceConfig;
+use vision_calibration_pipeline::rig_laserline_device::{
+    RigLaserlineDeviceConfig, RigLaserlineDeviceProblem,
+    run_calibration as run_rig_laserline_device_calibration,
+};
 use vision_calibration_pipeline::scheimpflug_intrinsics::{
     ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsProblem,
     run_calibration as run_scheimpflug_calibration,
@@ -203,14 +208,11 @@ fn run_blocking(
         Topology::SingleCamHandeye => {
             run_single_cam_handeye_topology(&spec, config_json, base_dir, &detection_cache, started)
         }
-        other @ (Topology::LaserlineDevice | Topology::RigLaserlineDevice) => {
-            RunResponse::Failed {
-                category: "unsupported_topology".into(),
-                message: format!(
-                    "topology {other:?} is not wired into the Run workspace yet \
-                     (the laser topologies land with the laser-frame manifest design)"
-                ),
-            }
+        Topology::LaserlineDevice => {
+            run_laserline_topology(&spec, config_json, base_dir, &detection_cache, started)
+        }
+        Topology::RigLaserlineDevice => {
+            run_rig_laserline_topology(&spec, config_json, base_dir, &detection_cache, started)
         }
     }
 }
@@ -334,11 +336,10 @@ fn run_single_cam_handeye_topology(
     detection_cache: &FsDetectionCache,
     started: Instant,
 ) -> RunResponse {
-    let handeye_run =
-        match build_single_cam_handeye_input(spec, base_dir, detection_cache, false) {
-            Ok(r) => r,
-            Err(e) => return run_error_to_response(e),
-        };
+    let handeye_run = match build_single_cam_handeye_input(spec, base_dir, detection_cache, false) {
+        Ok(r) => r,
+        Err(e) => return run_error_to_response(e),
+    };
     let cache_used = handeye_run.usable_views > 0; // refined in B3e with hit/miss counts
     let usable_views = handeye_run.usable_views;
     let total_views = handeye_run.total_views;
@@ -357,6 +358,98 @@ fn run_single_cam_handeye_topology(
         &mut export,
         planar_image_manifest(&handeye_run.view_paths, base_dir),
     ) {
+        return *boxed;
+    }
+
+    RunResponse::Ok(RunSuccess {
+        export,
+        duration_ms: started.elapsed().as_millis() as u64,
+        usable_views,
+        total_views,
+        cache_used,
+    })
+}
+
+fn run_laserline_topology(
+    spec: &DatasetSpec,
+    config_json: serde_json::Value,
+    base_dir: &Path,
+    detection_cache: &FsDetectionCache,
+    started: Instant,
+) -> RunResponse {
+    let laser_run = match build_laserline_device_input(
+        spec,
+        base_dir,
+        detection_cache,
+        &crate::laser::VmLaserExtractor,
+        false,
+    ) {
+        Ok(r) => r,
+        Err(e) => return run_error_to_response(e),
+    };
+    let cache_used = laser_run.usable_views > 0; // refined in B3e with hit/miss counts
+    let usable_views = laser_run.usable_views;
+    let total_views = laser_run.total_views;
+
+    let mut export =
+        match run_session::<LaserlineDeviceProblem>(laser_run.input, config_json, |session| {
+            run_laserline_device_calibration(session, None)
+        }) {
+            Ok(v) => v,
+            Err(boxed) => return *boxed,
+        };
+    // Single camera ⇒ the planar manifest shape (pose = kept-view
+    // index, camera = 0) over the *target* frames; laser-frame
+    // manifest entries are deferred to B-laser (ADR 0021 §5).
+    if let Err(boxed) = splice_image_manifest(
+        &mut export,
+        planar_image_manifest(&laser_run.view_paths, base_dir),
+    ) {
+        return *boxed;
+    }
+
+    RunResponse::Ok(RunSuccess {
+        export,
+        duration_ms: started.elapsed().as_millis() as u64,
+        usable_views,
+        total_views,
+        cache_used,
+    })
+}
+
+fn run_rig_laserline_topology(
+    spec: &DatasetSpec,
+    config_json: serde_json::Value,
+    base_dir: &Path,
+    detection_cache: &FsDetectionCache,
+    started: Instant,
+) -> RunResponse {
+    let laser_run = match build_rig_laserline_device_input(
+        spec,
+        base_dir,
+        detection_cache,
+        &crate::laser::VmLaserExtractor,
+        false,
+    ) {
+        Ok(r) => r,
+        Err(e) => return run_error_to_response(e),
+    };
+    let cache_used = laser_run.usable_views > 0; // refined in B3e with hit/miss counts
+    let usable_views = laser_run.usable_views;
+    let total_views = laser_run.total_views;
+    let view_paths = laser_run.view_paths.clone();
+
+    let mut export = match run_session::<RigLaserlineDeviceProblem>(
+        laser_run.input,
+        config_json,
+        run_rig_laserline_device_calibration,
+    ) {
+        Ok(v) => v,
+        Err(boxed) => return *boxed,
+    };
+    if let Err(boxed) =
+        splice_image_manifest(&mut export, rig_image_manifest(&view_paths, base_dir))
+    {
         return *boxed;
     }
 
@@ -515,6 +608,10 @@ fn error_category(err: &RunError) -> &'static str {
         RunError::Cache(_) => "cache",
         RunError::AskUser { .. } => "ask_user",
         RunError::InsufficientUsableViews { .. } => "insufficient_views",
+        RunError::LaserPairing { .. } => "view_pairing",
+        RunError::LaserExtraction { .. } => "detection",
+        RunError::InsufficientLaserViews { .. } => "insufficient_views",
+        RunError::UpstreamCalibration { .. } => "upstream_calibration",
     }
 }
 
@@ -552,23 +649,31 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn unsupported_topologies_name_the_roadmap() {
-        for topology in ["laserline_device", "rig_laserline_device"] {
+    fn laser_topologies_dispatch_and_fail_validation_without_laser_images() {
+        // The laser arms are wired (ADR 0021); a manifest without
+        // laser_images must now fail *validation*, not dispatch.
+        for (topology, num_cams) in [("laserline_device", 1), ("rig_laserline_device", 2)] {
+            let cameras: Vec<_> = (0..num_cams)
+                .map(|i| json!({"id": format!("cam{i}"), "images": {"kind": "glob", "pattern": "*.png"}}))
+                .collect();
             let manifest = json!({
                 "version": 1,
                 "topology": topology,
-                "cameras": [
-                    {"id": "cam0", "images": {"kind": "glob", "pattern": "*.png"}},
-                ],
+                "cameras": cameras,
                 "target": {"kind": "chessboard", "rows": 9, "cols": 6, "square_size_m": 0.025},
+                "robot_poses": {"path": "poses.txt", "format": "rowmajor4x4"},
+                "pose_convention": {
+                    "transform": "t_base_tcp",
+                    "rotation_format": "matrix4x4_row_major",
+                    "translation_units": "m",
+                },
             });
             let response = run_blocking(manifest, json!({}), "/tmp");
             match response {
-                RunResponse::Failed { category, message } => {
-                    assert_eq!(category, "unsupported_topology");
-                    assert!(message.contains("not wired"), "got: {message}");
+                RunResponse::ValidationFailed { message } => {
+                    assert!(message.contains("laser_images"), "{topology}: {message}");
                 }
-                _ => panic!("expected Failed for {topology}"),
+                other => panic!("expected ValidationFailed for {topology}, got {other:?}"),
             }
         }
     }
@@ -684,6 +789,91 @@ mod tests {
             );
             assert!(s.export["cameras"].is_array(), "rig export has cameras[]");
         }
+    }
+
+    /// Two-stage laser acceptance over the local rtv3d dataset
+    /// (6-camera Scheimpflug rig, tiled strips, ChArUco + laser
+    /// frames): rig hand-eye first, then `RigLaserlineDevice` with the
+    /// stage-1 export as the frozen upstream — exactly the user
+    /// workflow the laser slice ships (ADR 0021). Skips when
+    /// `privatedata/rtv3d` is absent (gitignored, local-only).
+    #[test]
+    #[ignore = "needs the local privatedata/rtv3d dataset; 6-cam detection + two solves"]
+    fn rtv3d_laser_end_to_end() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let data_dir = repo_root.join("privatedata/rtv3d");
+        if !data_dir.exists() {
+            eprintln!("skipping: {} not present", data_dir.display());
+            return;
+        }
+        let read_manifest = |name: &str| -> serde_json::Value {
+            let raw = std::fs::read_to_string(data_dir.join(name)).unwrap();
+            serde_json::to_value(toml::from_str::<toml::Value>(&raw).unwrap()).unwrap()
+        };
+        let dir = data_dir.to_string_lossy().to_string();
+
+        // ── Stage 1: rig hand-eye (Scheimpflug, EyeToHand) ────────────────
+        // Same overrides the rtv3d_rig example settled on; every one is
+        // plain config JSON, i.e. reachable from the app's ConfigForm.
+        let mut config = default_config_cmd("rig_handeye".into()).unwrap();
+        config["sensor"] = json!({"kind": "Scheimpflug"});
+        config["handeye_init"]["handeye_mode"] = json!("EyeToHand");
+        config["solver"]["max_iters"] = json!(200);
+        config["solver"]["robust_loss"] = json!({"Huber": {"scale": 1.0}});
+        let handeye = match run_blocking(read_manifest("dataset_rig_handeye.toml"), config, &dir) {
+            RunResponse::Ok(s) => s,
+            other => panic!("rig handeye stage: expected Ok, got {other:?}"),
+        };
+        assert!(
+            handeye.usable_views >= 10,
+            "rig handeye: {} usable views",
+            handeye.usable_views
+        );
+        // The hand-eye stage lands at ~1.5-2 px on rtv3d (the example's
+        // own hand-eye stage shows 1.6-2.1 px per camera; sub-pixel
+        // needs the downstream joint BA). The oracle is ~2.2 px.
+        let mean_px = handeye.export["mean_reproj_error"].as_f64().unwrap();
+        assert!(mean_px < 2.2, "rig handeye mean reproj {mean_px:.3} px");
+        std::fs::write(
+            data_dir.join("rig_handeye_export.json"),
+            serde_json::to_string(&handeye.export).unwrap(),
+        )
+        .unwrap();
+
+        // ── Stage 2: rig laserline over the frozen export ─────────────────
+        // PointToPlane keeps the residual in metres (the example's
+        // stage-3 choice), so the σ gate below is unit-meaningful.
+        let mut laser_config = default_config_cmd("rig_laserline_device".into()).unwrap();
+        laser_config["max_iters"] = json!(200);
+        laser_config["laser_residual_type"] = json!("PointToPlane");
+        let laser = match run_blocking(read_manifest("dataset_laser.toml"), laser_config, &dir) {
+            RunResponse::Ok(s) => s,
+            other => panic!("rig laserline stage: expected Ok, got {other:?}"),
+        };
+        let planes = laser.export["laser_planes_cam"].as_array().unwrap();
+        assert_eq!(planes.len(), 6, "one laser plane per camera");
+        let stats = laser.export["per_camera_stats"].as_array().unwrap();
+        assert_eq!(stats.len(), 6);
+        for (cam, s) in stats.iter().enumerate() {
+            // Plane-fit sanity gate, not an oracle-beating gate: with
+            // the upstream frozen at ~1.5 px the plane fit lands near
+            // ~1 mm; sub-0.1 mm needs the joint BA (V5, out of scope
+            // here). 2 mm flags a broken plane / wrong chain.
+            let laser_err = s["mean_laser_error"].as_f64().unwrap();
+            eprintln!("cam {cam}: mean point-to-plane {:.4} mm", laser_err * 1e3);
+            assert!(
+                laser_err < 2e-3,
+                "cam {cam}: mean laser residual {laser_err:.6} m"
+            );
+        }
+        assert!(
+            laser.export["image_manifest"]["frames"].is_array(),
+            "laser export carries the target-frame manifest"
+        );
+        eprintln!(
+            "rtv3d laser E2E: handeye {mean_px:.3} px over {} views; laser stage {} views in {} ms",
+            handeye.usable_views, laser.usable_views, laser.duration_ms
+        );
     }
 
     /// End-to-end hand-eye run over the committed `data/kuka_1` dataset

--- a/app/src/schemas/dataset_spec.json
+++ b/app/src/schemas/dataset_spec.json
@@ -12,6 +12,17 @@
           "$ref": "#/$defs/ImagePattern",
           "description": "Glob pattern (e.g. `\"cam0/*.png\"`) or explicit list of image\npaths, relative to the manifest's directory unless absolute."
         },
+        "laser_images": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImagePattern"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Laser-frame image source for the laser topologies (ADR 0021).\nOne laser image per view, captured by the same sensor with the\nline projector on; `roi_xywh` applies to laser frames too.\nLaser images pair with target views through `pose_pairing`."
+        },
         "roi_xywh": {
           "description": "Optional rectangular ROI in source-image pixels — `[x, y, w, h]`.\nWhen set, only the cropped region is fed to the detector and\nstored in the export's image manifest.",
           "items": {
@@ -74,6 +85,58 @@
             "paths"
           ],
           "type": "object"
+        }
+      ]
+    },
+    "LaserExtractionSpec": {
+      "additionalProperties": false,
+      "description": "Laser-line extraction parameters (ADR 0021). Consumed by the\nrunner's injected `LaserPixelExtractor`; hashed (canonical JSON)\ninto the detection-cache key so edits re-extract.",
+      "properties": {
+        "min_points": {
+          "default": 20,
+          "description": "Minimum extracted points for a usable laser view. Views below\nthe bar are dropped (single camera) or become gap slots (rig).",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "neg_thresh": {
+          "default": 4.0,
+          "description": "Negative-edge response threshold.",
+          "format": "double",
+          "type": "number"
+        },
+        "pos_thresh": {
+          "default": 4.0,
+          "description": "Positive-edge response threshold.",
+          "format": "double",
+          "type": "number"
+        },
+        "scan_axis": {
+          "$ref": "#/$defs/LaserScanAxis",
+          "default": "cols",
+          "description": "Scan direction. `cols` walks image columns (one point per\ncolumn; for laser lines running mostly left-to-right), `rows`\nwalks image rows."
+        },
+        "sigma": {
+          "default": 1.2,
+          "description": "Gaussian derivative sigma in pixels for the edge detector.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "LaserScanAxis": {
+      "description": "Laser scan direction.",
+      "oneOf": [
+        {
+          "const": "cols",
+          "description": "One detection per image column.",
+          "type": "string"
+        },
+        {
+          "const": "rows",
+          "description": "One detection per image row.",
+          "type": "string"
         }
       ]
     },
@@ -219,11 +282,18 @@
               "type": "null"
             }
           ],
-          "description": "Column / field mapping from the user's file to the canonical\nfields the converter consumes. Required for the tabular formats\n(`csv` / `json` / `jsonl`); must be absent for `rowmajor4x4`,\nwhose 16-values-per-line layout is fixed."
+          "description": "Column / field mapping from the user's file to the canonical\nfields the converter consumes. Required for the tabular formats\n(`csv` / `json` / `jsonl`) unless `matrix_field` is set; must be\nabsent for `rowmajor4x4`, whose 16-values-per-line layout is\nfixed."
         },
         "format": {
           "$ref": "#/$defs/RobotPoseFormat",
           "description": "File-format selector."
+        },
+        "matrix_field": {
+          "description": "For `json` / `jsonl` files whose rows store the whole pose as a\nsingle nested 4×4 (or flat-16) array field, names that field\n(e.g. `\"tcp2base\"`). Mutually exclusive with `columns`; requires\n`pose_convention.rotation_format = matrix4x4_row_major`.\nTranslation comes from the matrix's fourth column, scaled by\n`translation_units`. No `pose_id` ⇒ `by_index` pairing only.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "path": {
           "description": "Path to the pose file, relative to the manifest directory\nunless absolute.",
@@ -538,6 +608,17 @@
         "null"
       ]
     },
+    "laser": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LaserExtractionSpec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Laser-line extraction parameters for the laser topologies.\n`None` means defaults (ADR 0021) — extraction tuning has safe\ndefaults and is not a fail-fast ambiguity. Rejected on\nnon-laser topologies."
+    },
     "pose_convention": {
       "anyOf": [
         {
@@ -578,6 +659,13 @@
     "topology": {
       "$ref": "#/$defs/Topology",
       "description": "Calibration topology — selects which problem type the runner\nwill dispatch to."
+    },
+    "upstream_calibration": {
+      "description": "Path to a frozen upstream `RigHandeyeExport` JSON, relative to\nthe manifest directory unless absolute. Required for\n`Topology::RigLaserlineDevice`, rejected elsewhere.",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "version": {
       "default": 1,

--- a/app/src/schemas/dataset_spec.json
+++ b/app/src/schemas/dataset_spec.json
@@ -94,9 +94,9 @@
       "properties": {
         "min_points": {
           "default": 20,
-          "description": "Minimum extracted points for a usable laser view. Views below\nthe bar are dropped (single camera) or become gap slots (rig).",
+          "description": "Minimum extracted points for a usable laser view. Views below\nthe bar are dropped (single camera) or become gap slots (rig).\nMust be at least 2 (a line needs two points); 0/1 would let an\nempty extraction pass as usable and leave the plane\nunconstrained.",
           "format": "uint32",
-          "minimum": 0,
+          "minimum": 2,
           "type": "integer"
         },
         "neg_thresh": {

--- a/app/src/workspaces/RunWorkspace/index.tsx
+++ b/app/src/workspaces/RunWorkspace/index.tsx
@@ -29,7 +29,7 @@ import datasetSchemaJson from "../../schemas/dataset_spec.json";
 import { useStore } from "../../store";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { PresetCard } from "./PresetCard";
-import { BUILTIN_PRESETS, type EnabledPreset } from "./presets";
+import { BUILTIN_PRESETS, mergeConfig, type EnabledPreset } from "./presets";
 import { topologyInfo } from "./topologies";
 
 // schemars-emitted JSON Schema; cast through unknown since both shapes
@@ -206,8 +206,13 @@ export function RunWorkspace() {
       setManifest(parsed);
       // Reset config to the preset topology's defaults (the topology
       // effect above only fires on topology *changes*, and switching
-      // between same-topology presets must still reset).
-      const defaults = await fetchDefaultConfig(topologyOf(parsed), inTauri);
+      // between same-topology presets must still reset), then apply
+      // the preset's overrides — datasets like rtv3d need non-default
+      // config (Scheimpflug sensors, EyeToHand).
+      let defaults = await fetchDefaultConfig(topologyOf(parsed), inTauri);
+      if (preset.configOverrides) {
+        defaults = mergeConfig(defaults, preset.configOverrides);
+      }
       prevTopologyRef.current = topologyOf(parsed);
       setConfig(defaults);
       setActivePresetId(preset.id);

--- a/app/src/workspaces/RunWorkspace/presets.ts
+++ b/app/src/workspaces/RunWorkspace/presets.ts
@@ -29,6 +29,37 @@ export interface EnabledPreset {
   imageCount: number;
   /** Absolute path to the TOML manifest file. */
   manifestPath: string;
+  /**
+   * Optional config patch deep-merged over the topology's
+   * `default_config_cmd` defaults when the preset is applied — for
+   * datasets whose defaults are wrong (e.g. rtv3d needs Scheimpflug
+   * sensors and EyeToHand). Keys mirror the Rust `*Config` JSON.
+   */
+  configOverrides?: Record<string, unknown>;
+}
+
+/** Recursively merge `patch` over `base` (objects only; arrays and
+ *  scalars are replaced). Used to apply preset config overrides. */
+export function mergeConfig(base: unknown, patch: Record<string, unknown>): unknown {
+  if (typeof base !== "object" || base === null || Array.isArray(base)) {
+    return patch;
+  }
+  const out: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value) &&
+      typeof out[key] === "object" &&
+      out[key] !== null &&
+      !Array.isArray(out[key])
+    ) {
+      out[key] = mergeConfig(out[key], value as Record<string, unknown>);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 export interface DisabledPreset {
@@ -119,6 +150,40 @@ export const BUILTIN_PRESETS: Preset[] = [
     targetSummary: "chessboard 17×28, 20 mm · robot poses 4×4",
     imageCount: 30,
     manifestPath: `${REPO_ROOT}/data/kuka_1/dataset.toml`,
+  },
+
+  // ── Enabled: rtv3d rig hand-eye (local-only dataset) ─────────────────────
+  {
+    id: "rtv3d-rig-handeye",
+    name: "rtv3d rig hand-eye",
+    group: "rtv3d 6-device Scheimpflug rig (local)",
+    topology: "RigHandeye",
+    targetKind: "charuco",
+    targetSummary: "ChArUco 22×22, 5.2 mm · 6 tiled cameras · EyeToHand",
+    imageCount: 20,
+    manifestPath: `${REPO_ROOT}/privatedata/rtv3d/dataset_rig_handeye.toml`,
+    configOverrides: {
+      sensor: { kind: "Scheimpflug" },
+      handeye_init: { handeye_mode: "EyeToHand" },
+      solver: { max_iters: 200, robust_loss: { Huber: { scale: 1.0 } } },
+    },
+  },
+
+  // ── Enabled: rtv3d rig laserline (ADR 0021) ──────────────────────────────
+  {
+    id: "rtv3d-laser",
+    name: "rtv3d laser planes",
+    group: "rtv3d 6-device Scheimpflug rig (local)",
+    topology: "RigLaserlineDevice",
+    targetKind: "charuco",
+    targetSummary:
+      "6 laser planes over the frozen hand-eye export (run the hand-eye preset first; needs rig_handeye_export.json)",
+    imageCount: 20,
+    manifestPath: `${REPO_ROOT}/privatedata/rtv3d/dataset_laser.toml`,
+    configOverrides: {
+      max_iters: 200,
+      laser_residual_type: "PointToPlane",
+    },
   },
 
   // ── Disabled: DS8 Scheimpflug ────────────────────────────────────────────

--- a/app/src/workspaces/RunWorkspace/topologies.ts
+++ b/app/src/workspaces/RunWorkspace/topologies.ts
@@ -8,9 +8,11 @@
  */
 import type { JsonSchema } from "../../lib/configForm";
 
+import laserlineDeviceConfigSchemaJson from "../../schemas/laserline_device_config.json";
 import planarConfigSchemaJson from "../../schemas/planar_intrinsics_config.json";
 import rigExtrinsicsConfigSchemaJson from "../../schemas/rig_extrinsics_config.json";
 import rigHandeyeConfigSchemaJson from "../../schemas/rig_handeye_config.json";
+import rigLaserlineDeviceConfigSchemaJson from "../../schemas/rig_laserline_device_config.json";
 import scheimpflugConfigSchemaJson from "../../schemas/scheimpflug_intrinsics_config.json";
 import singleCamHandeyeConfigSchemaJson from "../../schemas/single_cam_handeye_config.json";
 
@@ -19,8 +21,11 @@ import singleCamHandeyeConfigSchemaJson from "../../schemas/single_cam_handeye_c
 const planarConfigSchema = planarConfigSchemaJson as unknown as JsonSchema;
 const scheimpflugConfigSchema = scheimpflugConfigSchemaJson as unknown as JsonSchema;
 const singleCamHandeyeConfigSchema = singleCamHandeyeConfigSchemaJson as unknown as JsonSchema;
+const laserlineDeviceConfigSchema = laserlineDeviceConfigSchemaJson as unknown as JsonSchema;
 const rigExtrinsicsConfigSchema = rigExtrinsicsConfigSchemaJson as unknown as JsonSchema;
 const rigHandeyeConfigSchema = rigHandeyeConfigSchemaJson as unknown as JsonSchema;
+const rigLaserlineDeviceConfigSchema =
+  rigLaserlineDeviceConfigSchemaJson as unknown as JsonSchema;
 
 export interface TopologyInfo {
   /** Human-readable label for headers and summaries. */
@@ -52,9 +57,8 @@ export const TOPOLOGY_INFO: Record<string, TopologyInfo> = {
   },
   laserline_device: {
     label: "LaserlineDevice",
-    schema: null,
-    supported: false,
-    unsupportedReason: "Laser topologies await the laser-frame manifest design.",
+    schema: laserlineDeviceConfigSchema,
+    supported: true,
   },
   rig_extrinsics: {
     label: "RigExtrinsics",
@@ -68,9 +72,8 @@ export const TOPOLOGY_INFO: Record<string, TopologyInfo> = {
   },
   rig_laserline_device: {
     label: "RigLaserlineDevice",
-    schema: null,
-    supported: false,
-    unsupportedReason: "Laser topologies await the laser-frame manifest design.",
+    schema: rigLaserlineDeviceConfigSchema,
+    supported: true,
   },
 };
 

--- a/crates/vision-calibration-bench/src/registry.rs
+++ b/crates/vision-calibration-bench/src/registry.rs
@@ -650,6 +650,7 @@ mod tests {
                     pattern: "cam0/*.png".into(),
                 },
                 roi_xywh: None,
+                laser_images: None,
             }],
             target: TargetSpec::Chessboard {
                 rows: 7,
@@ -657,6 +658,8 @@ mod tests {
                 square_size_m: 0.03,
             },
             robot_poses: None,
+            laser: None,
+            upstream_calibration: None,
             topology: Topology::RigHandeye,
             pose_pairing: None,
             pose_convention: None,

--- a/crates/vision-calibration-dataset/src/lib.rs
+++ b/crates/vision-calibration-dataset/src/lib.rs
@@ -30,8 +30,8 @@ mod spec;
 mod validator;
 
 pub use spec::{
-    CameraSource, DatasetSpec, ImagePattern, PoseColumnMap, PoseConvention, PosePairing,
-    RobotPoseFormat, RobotPoseSource, RotationFormat, TargetSpec, Topology, TransformConvention,
-    TranslationUnits,
+    CameraSource, DatasetSpec, ImagePattern, LaserExtractionSpec, LaserScanAxis, PoseColumnMap,
+    PoseConvention, PosePairing, RobotPoseFormat, RobotPoseSource, RotationFormat, TargetSpec,
+    Topology, TransformConvention, TranslationUnits,
 };
 pub use validator::{ValidationError, validate};

--- a/crates/vision-calibration-dataset/src/spec.rs
+++ b/crates/vision-calibration-dataset/src/spec.rs
@@ -155,6 +155,10 @@ pub struct LaserExtractionSpec {
     pub neg_thresh: f64,
     /// Minimum extracted points for a usable laser view. Views below
     /// the bar are dropped (single camera) or become gap slots (rig).
+    /// Must be at least 2 (a line needs two points); 0/1 would let an
+    /// empty extraction pass as usable and leave the plane
+    /// unconstrained.
+    #[cfg_attr(feature = "schemars", schemars(range(min = 2)))]
     pub min_points: u32,
 }
 

--- a/crates/vision-calibration-dataset/src/spec.rs
+++ b/crates/vision-calibration-dataset/src/spec.rs
@@ -40,6 +40,19 @@ pub struct DatasetSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub robot_poses: Option<RobotPoseSource>,
 
+    /// Laser-line extraction parameters for the laser topologies.
+    /// `None` means defaults (ADR 0021) — extraction tuning has safe
+    /// defaults and is not a fail-fast ambiguity. Rejected on
+    /// non-laser topologies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub laser: Option<LaserExtractionSpec>,
+
+    /// Path to a frozen upstream `RigHandeyeExport` JSON, relative to
+    /// the manifest directory unless absolute. Required for
+    /// `Topology::RigLaserlineDevice`, rejected elsewhere.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_calibration: Option<PathBuf>,
+
     /// Calibration topology — selects which problem type the runner
     /// will dispatch to.
     pub topology: Topology,
@@ -92,6 +105,13 @@ pub struct CameraSource {
     /// stored in the export's image manifest.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub roi_xywh: Option<[u32; 4]>,
+
+    /// Laser-frame image source for the laser topologies (ADR 0021).
+    /// One laser image per view, captured by the same sensor with the
+    /// line projector on; `roi_xywh` applies to laser frames too.
+    /// Laser images pair with target views through `pose_pairing`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub laser_images: Option<ImagePattern>,
 }
 
 /// How image paths for a camera are listed.
@@ -110,6 +130,55 @@ pub enum ImagePattern {
         /// Paths relative to the manifest directory unless absolute.
         paths: Vec<PathBuf>,
     },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Laser extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Laser-line extraction parameters (ADR 0021). Consumed by the
+/// runner's injected `LaserPixelExtractor`; hashed (canonical JSON)
+/// into the detection-cache key so edits re-extract.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields, default)]
+pub struct LaserExtractionSpec {
+    /// Scan direction. `cols` walks image columns (one point per
+    /// column; for laser lines running mostly left-to-right), `rows`
+    /// walks image rows.
+    pub scan_axis: LaserScanAxis,
+    /// Gaussian derivative sigma in pixels for the edge detector.
+    pub sigma: f64,
+    /// Positive-edge response threshold.
+    pub pos_thresh: f64,
+    /// Negative-edge response threshold.
+    pub neg_thresh: f64,
+    /// Minimum extracted points for a usable laser view. Views below
+    /// the bar are dropped (single camera) or become gap slots (rig).
+    pub min_points: u32,
+}
+
+impl Default for LaserExtractionSpec {
+    fn default() -> Self {
+        Self {
+            scan_axis: LaserScanAxis::Cols,
+            sigma: 1.2,
+            pos_thresh: 4.0,
+            neg_thresh: 4.0,
+            min_points: 20,
+        }
+    }
+}
+
+/// Laser scan direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum LaserScanAxis {
+    /// One detection per image column.
+    Cols,
+    /// One detection per image row.
+    Rows,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -187,10 +256,19 @@ pub struct RobotPoseSource {
     pub format: RobotPoseFormat,
     /// Column / field mapping from the user's file to the canonical
     /// fields the converter consumes. Required for the tabular formats
-    /// (`csv` / `json` / `jsonl`); must be absent for `rowmajor4x4`,
-    /// whose 16-values-per-line layout is fixed.
+    /// (`csv` / `json` / `jsonl`) unless `matrix_field` is set; must be
+    /// absent for `rowmajor4x4`, whose 16-values-per-line layout is
+    /// fixed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub columns: Option<PoseColumnMap>,
+    /// For `json` / `jsonl` files whose rows store the whole pose as a
+    /// single nested 4×4 (or flat-16) array field, names that field
+    /// (e.g. `"tcp2base"`). Mutually exclusive with `columns`; requires
+    /// `pose_convention.rotation_format = matrix4x4_row_major`.
+    /// Translation comes from the matrix's fourth column, scaled by
+    /// `translation_units`. No `pose_id` ⇒ `by_index` pairing only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matrix_field: Option<String>,
 }
 
 /// Robot-pose file format.

--- a/crates/vision-calibration-dataset/src/validator.rs
+++ b/crates/vision-calibration-dataset/src/validator.rs
@@ -85,6 +85,39 @@ pub enum ValidationError {
         /// The ROI as declared in the manifest (`[x, y, w, h]`).
         roi: [u32; 4],
     },
+
+    /// A laser-only manifest field is set on a topology that does not
+    /// use it. Per ADR 0019 an ignored field is a fail-fast event —
+    /// the user almost certainly selected the wrong topology.
+    #[error("topology {topology:?} does not use {field}")]
+    FieldUnusedByTopology {
+        /// The offending topology.
+        topology: Topology,
+        /// Dotted path of the unused field (e.g. `"cameras[cam0].laser_images"`).
+        field: String,
+    },
+
+    /// A laser topology camera is missing its laser-frame source.
+    #[error("camera {0:?} needs laser_images for a laser topology")]
+    MissingLaserImages(String),
+
+    /// A camera's `laser_images` glob pattern or path list is empty.
+    #[error("camera {0:?} has an empty laser_images pattern")]
+    EmptyLaserImagePattern(String),
+
+    /// `RigLaserlineDevice` needs a frozen upstream rig hand-eye export.
+    #[error(
+        "topology {topology:?} requires upstream_calibration \
+         (path to a frozen rig hand-eye export JSON) but none was given"
+    )]
+    MissingUpstreamCalibration {
+        /// The offending topology.
+        topology: Topology,
+    },
+
+    /// Laser extraction parameters are out of range.
+    #[error("laser extraction: {0}")]
+    BadLaserExtraction(String),
 }
 
 /// Validate the structural invariants of a manifest. Does not touch
@@ -141,6 +174,8 @@ pub fn validate(spec: &DatasetSpec) -> Result<(), ValidationError> {
         }
     }
 
+    validate_laser_fields(spec)?;
+
     if let Some(robot) = &spec.robot_poses {
         validate_pose_columns(
             robot,
@@ -151,8 +186,90 @@ pub fn validate(spec: &DatasetSpec) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// Laser-field rules (ADR 0021): laser topologies require laser
+/// sources everywhere; non-laser topologies must not carry any of the
+/// laser-only fields (an ignored field is a fail-fast event).
+fn validate_laser_fields(spec: &DatasetSpec) -> Result<(), ValidationError> {
+    let uses_laser = matches!(
+        spec.topology,
+        Topology::LaserlineDevice | Topology::RigLaserlineDevice
+    );
+
+    if !uses_laser {
+        if spec.laser.is_some() {
+            return Err(ValidationError::FieldUnusedByTopology {
+                topology: spec.topology,
+                field: "laser".into(),
+            });
+        }
+        if spec.upstream_calibration.is_some() {
+            return Err(ValidationError::FieldUnusedByTopology {
+                topology: spec.topology,
+                field: "upstream_calibration".into(),
+            });
+        }
+        if let Some(cam) = spec.cameras.iter().find(|c| c.laser_images.is_some()) {
+            return Err(ValidationError::FieldUnusedByTopology {
+                topology: spec.topology,
+                field: format!("cameras[{}].laser_images", cam.id),
+            });
+        }
+        return Ok(());
+    }
+
+    // Every camera in a laser topology needs a laser source — a rig
+    // camera with no laser views would leave its plane unconstrained.
+    for cam in &spec.cameras {
+        match &cam.laser_images {
+            None => return Err(ValidationError::MissingLaserImages(cam.id.clone())),
+            Some(ImagePattern::Glob { pattern }) if pattern.is_empty() => {
+                return Err(ValidationError::EmptyLaserImagePattern(cam.id.clone()));
+            }
+            Some(ImagePattern::List { paths }) if paths.is_empty() => {
+                return Err(ValidationError::EmptyLaserImagePattern(cam.id.clone()));
+            }
+            Some(_) => {}
+        }
+    }
+
+    if let Some(laser) = &spec.laser {
+        if laser.sigma <= 0.0 {
+            return Err(ValidationError::BadLaserExtraction(format!(
+                "sigma must be positive, got {}",
+                laser.sigma
+            )));
+        }
+        if laser.pos_thresh <= 0.0 || laser.neg_thresh <= 0.0 {
+            return Err(ValidationError::BadLaserExtraction(format!(
+                "edge thresholds must be positive, got pos={} neg={}",
+                laser.pos_thresh, laser.neg_thresh
+            )));
+        }
+    }
+
+    match spec.topology {
+        Topology::RigLaserlineDevice if spec.upstream_calibration.is_none() => {
+            Err(ValidationError::MissingUpstreamCalibration {
+                topology: spec.topology,
+            })
+        }
+        Topology::LaserlineDevice if spec.upstream_calibration.is_some() => {
+            // Single-camera laserline calibrates its own intrinsics —
+            // an upstream export here means the wrong topology.
+            Err(ValidationError::FieldUnusedByTopology {
+                topology: spec.topology,
+                field: "upstream_calibration".into(),
+            })
+        }
+        _ => Ok(()),
+    }
+}
+
 fn topology_needs_robot(t: Topology) -> bool {
-    matches!(t, Topology::SingleCamHandeye | Topology::RigHandeye)
+    matches!(
+        t,
+        Topology::SingleCamHandeye | Topology::RigHandeye | Topology::RigLaserlineDevice
+    )
 }
 
 fn topology_camera_range(t: Topology) -> (usize, usize) {
@@ -188,10 +305,42 @@ fn validate_pose_columns(
                 problem: "is headerless (16 values per line); remove the columns mapping".into(),
             });
         }
+        if robot.matrix_field.is_some() {
+            return Err(ValidationError::BadMatrixPoseConfig {
+                problem: "is headerless (16 values per line); remove matrix_field".into(),
+            });
+        }
         if format != RotationFormat::Matrix4x4RowMajor {
             return Err(ValidationError::BadMatrixPoseConfig {
                 problem: format!(
                     "requires pose_convention.rotation_format = matrix4x4_row_major, got {format:?}"
+                ),
+            });
+        }
+        return Ok(());
+    }
+
+    if let Some(field) = &robot.matrix_field {
+        if robot.format == RobotPoseFormat::Csv {
+            return Err(ValidationError::BadMatrixPoseConfig {
+                problem: format!(
+                    "matrix_field {field:?} requires a json or jsonl pose file \
+                     (CSV rows cannot hold a nested matrix)"
+                ),
+            });
+        }
+        if robot.columns.is_some() {
+            return Err(ValidationError::BadMatrixPoseConfig {
+                problem: format!(
+                    "matrix_field {field:?} and a columns mapping are mutually exclusive"
+                ),
+            });
+        }
+        if format != RotationFormat::Matrix4x4RowMajor {
+            return Err(ValidationError::BadMatrixPoseConfig {
+                problem: format!(
+                    "matrix_field {field:?} requires pose_convention.rotation_format = \
+                     matrix4x4_row_major, got {format:?}"
                 ),
             });
         }
@@ -245,6 +394,7 @@ mod tests {
                     pattern: "cam0/*.png".into(),
                 },
                 roi_xywh: None,
+                laser_images: None,
             }],
             target: TargetSpec::Chessboard {
                 rows: 9,
@@ -252,6 +402,8 @@ mod tests {
                 square_size_m: 0.025,
             },
             robot_poses: None,
+            laser: None,
+            upstream_calibration: None,
             topology: Topology::PlanarIntrinsics,
             pose_pairing: None,
             pose_convention: None,
@@ -289,6 +441,7 @@ mod tests {
                 pattern: "cam1/*.png".into(),
             },
             roi_xywh: None,
+            laser_images: None,
         });
         let err = validate(&spec).unwrap_err();
         assert!(matches!(err, ValidationError::MissingRobotPoses { .. }));
@@ -303,6 +456,7 @@ mod tests {
                 pattern: "cam1/*.png".into(),
             },
             roi_xywh: None,
+            laser_images: None,
         });
         let err = validate(&spec).unwrap_err();
         assert!(matches!(
@@ -326,6 +480,7 @@ mod tests {
                 pattern: "cam_dup/*.png".into(),
             },
             roi_xywh: None,
+            laser_images: None,
         });
         let err = validate(&spec).unwrap_err();
         assert!(matches!(err, ValidationError::DuplicateCameraId(_)));
@@ -344,6 +499,7 @@ mod tests {
                 // QuatXyzw needs 4 columns; supply 3 to trigger.
                 rotation: vec!["rx".into(), "ry".into(), "rz".into()],
             }),
+            matrix_field: None,
         };
         let convention = PoseConvention {
             transform: TransformConvention::TBaseTcp,
@@ -383,6 +539,7 @@ mod tests {
             path: "poses.csv".into(),
             format: RobotPoseFormat::Csv,
             columns: None,
+            matrix_field: None,
         };
         let err = validate(&handeye_spec_with(robot, RotationFormat::QuatXyzw)).unwrap_err();
         assert!(matches!(
@@ -399,6 +556,7 @@ mod tests {
             path: "RobotPosesVec.txt".into(),
             format: RobotPoseFormat::Rowmajor4x4,
             columns: None,
+            matrix_field: None,
         };
         validate(&handeye_spec_with(robot, RotationFormat::Matrix4x4RowMajor)).unwrap();
     }
@@ -415,6 +573,7 @@ mod tests {
                 tz: "z".into(),
                 rotation: vec![],
             }),
+            matrix_field: None,
         };
         let err =
             validate(&handeye_spec_with(robot, RotationFormat::Matrix4x4RowMajor)).unwrap_err();
@@ -432,6 +591,7 @@ mod tests {
             path: "RobotPosesVec.txt".into(),
             format: RobotPoseFormat::Rowmajor4x4,
             columns: None,
+            matrix_field: None,
         };
         let err = validate(&handeye_spec_with(robot, RotationFormat::QuatXyzw)).unwrap_err();
         match err {
@@ -460,5 +620,214 @@ mod tests {
         let back: DatasetSpec = serde_json::from_str(&s).unwrap();
         assert_eq!(back.cameras.len(), 1);
         assert!(back.unresolved.is_empty());
+    }
+
+    // ── Laser fields (ADR 0021) ─────────────────────────────────────────
+
+    /// Minimal valid single-camera laserline manifest.
+    fn laserline_minimal() -> DatasetSpec {
+        let mut spec = planar_chessboard_minimal();
+        spec.topology = Topology::LaserlineDevice;
+        spec.cameras[0].laser_images = Some(ImagePattern::Glob {
+            pattern: "cam0/laser_*.png".into(),
+        });
+        spec
+    }
+
+    /// Minimal valid rig laserline manifest (2 cameras, rowmajor poses).
+    fn rig_laserline_minimal() -> DatasetSpec {
+        let mut spec = laserline_minimal();
+        spec.topology = Topology::RigLaserlineDevice;
+        spec.cameras.push(CameraSource {
+            id: "cam1".into(),
+            images: ImagePattern::Glob {
+                pattern: "cam1/*.png".into(),
+            },
+            roi_xywh: None,
+            laser_images: Some(ImagePattern::Glob {
+                pattern: "cam1/laser_*.png".into(),
+            }),
+        });
+        spec.robot_poses = Some(RobotPoseSource {
+            path: "poses.txt".into(),
+            format: RobotPoseFormat::Rowmajor4x4,
+            columns: None,
+            matrix_field: None,
+        });
+        spec.pose_convention = Some(PoseConvention {
+            transform: TransformConvention::TBaseTcp,
+            rotation_format: RotationFormat::Matrix4x4RowMajor,
+            translation_units: TranslationUnits::M,
+        });
+        spec.upstream_calibration = Some("rig_handeye_export.json".into());
+        spec
+    }
+
+    #[test]
+    fn laserline_manifests_validate() {
+        validate(&laserline_minimal()).unwrap();
+        validate(&rig_laserline_minimal()).unwrap();
+    }
+
+    #[test]
+    fn laser_fields_rejected_on_non_laser_topology() {
+        let mut spec = planar_chessboard_minimal();
+        spec.laser = Some(crate::spec::LaserExtractionSpec::default());
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::FieldUnusedByTopology { .. }
+        ));
+
+        let mut spec = planar_chessboard_minimal();
+        spec.upstream_calibration = Some("export.json".into());
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::FieldUnusedByTopology { .. }
+        ));
+
+        let mut spec = planar_chessboard_minimal();
+        spec.cameras[0].laser_images = Some(ImagePattern::Glob {
+            pattern: "laser_*.png".into(),
+        });
+        match validate(&spec).unwrap_err() {
+            ValidationError::FieldUnusedByTopology { field, .. } => {
+                assert_eq!(field, "cameras[cam0].laser_images");
+            }
+            other => panic!("expected FieldUnusedByTopology, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn laser_topology_requires_laser_images_on_every_camera() {
+        let mut spec = laserline_minimal();
+        spec.cameras[0].laser_images = None;
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::MissingLaserImages(_)
+        ));
+
+        let mut spec = rig_laserline_minimal();
+        spec.cameras[1].laser_images = None;
+        match validate(&spec).unwrap_err() {
+            ValidationError::MissingLaserImages(id) => assert_eq!(id, "cam1"),
+            other => panic!("expected MissingLaserImages, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rig_laserline_requires_upstream_and_robot_poses() {
+        let mut spec = rig_laserline_minimal();
+        spec.upstream_calibration = None;
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::MissingUpstreamCalibration { .. }
+        ));
+
+        let mut spec = rig_laserline_minimal();
+        spec.robot_poses = None;
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::MissingRobotPoses { .. }
+        ));
+    }
+
+    #[test]
+    fn single_cam_laserline_rejects_upstream() {
+        let mut spec = laserline_minimal();
+        spec.upstream_calibration = Some("export.json".into());
+        match validate(&spec).unwrap_err() {
+            ValidationError::FieldUnusedByTopology { field, .. } => {
+                assert_eq!(field, "upstream_calibration");
+            }
+            other => panic!("expected FieldUnusedByTopology, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bad_laser_extraction_params_rejected() {
+        let mut spec = laserline_minimal();
+        spec.laser = Some(crate::spec::LaserExtractionSpec {
+            sigma: 0.0,
+            ..Default::default()
+        });
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::BadLaserExtraction(_)
+        ));
+    }
+
+    #[test]
+    fn empty_laser_pattern_rejected() {
+        let mut spec = laserline_minimal();
+        spec.cameras[0].laser_images = Some(ImagePattern::List { paths: vec![] });
+        assert!(matches!(
+            validate(&spec).unwrap_err(),
+            ValidationError::EmptyLaserImagePattern(_)
+        ));
+    }
+
+    // ── matrix_field (ADR 0021) ─────────────────────────────────────────
+
+    fn matrix_field_robot() -> RobotPoseSource {
+        RobotPoseSource {
+            path: "poses.json".into(),
+            format: RobotPoseFormat::Json,
+            columns: None,
+            matrix_field: Some("tcp2base".into()),
+        }
+    }
+
+    #[test]
+    fn matrix_field_json_validates() {
+        validate(&handeye_spec_with(
+            matrix_field_robot(),
+            RotationFormat::Matrix4x4RowMajor,
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn matrix_field_rejects_csv_and_columns_and_non_matrix_rotation() {
+        let mut robot = matrix_field_robot();
+        robot.format = RobotPoseFormat::Csv;
+        assert!(matches!(
+            validate(&handeye_spec_with(robot, RotationFormat::Matrix4x4RowMajor)).unwrap_err(),
+            ValidationError::BadMatrixPoseConfig { .. }
+        ));
+
+        let mut robot = matrix_field_robot();
+        robot.columns = Some(PoseColumnMap {
+            pose_id: None,
+            tx: "x".into(),
+            ty: "y".into(),
+            tz: "z".into(),
+            rotation: vec![],
+        });
+        assert!(matches!(
+            validate(&handeye_spec_with(robot, RotationFormat::Matrix4x4RowMajor)).unwrap_err(),
+            ValidationError::BadMatrixPoseConfig { .. }
+        ));
+
+        assert!(matches!(
+            validate(&handeye_spec_with(
+                matrix_field_robot(),
+                RotationFormat::QuatXyzw
+            ))
+            .unwrap_err(),
+            ValidationError::BadMatrixPoseConfig { .. }
+        ));
+    }
+
+    #[test]
+    fn laser_spec_json_roundtrip_with_defaults() {
+        // An omitted `[laser]` table and an explicit default must
+        // deserialize identically; partial tables fill from defaults.
+        let spec = rig_laserline_minimal();
+        let s = serde_json::to_string(&spec).unwrap();
+        assert!(!s.contains("\"laser\":"), "None laser stays off the wire");
+        let partial: crate::spec::LaserExtractionSpec =
+            serde_json::from_str(r#"{"min_points": 120}"#).unwrap();
+        assert_eq!(partial.min_points, 120);
+        assert_eq!(partial.sigma, 1.2);
     }
 }

--- a/crates/vision-calibration-dataset/src/validator.rs
+++ b/crates/vision-calibration-dataset/src/validator.rs
@@ -245,6 +245,18 @@ fn validate_laser_fields(spec: &DatasetSpec) -> Result<(), ValidationError> {
                 laser.pos_thresh, laser.neg_thresh
             )));
         }
+        // `min_points == 0` makes the runner's `pixels.len() <
+        // min_points` drop-bar vacuously false, so an empty extraction
+        // counts as a usable view (rig path even increments
+        // `per_camera_usable`) and the laser plane is left
+        // unconstrained — a misleading "success". Require at least the
+        // two points a line needs.
+        if laser.min_points < 2 {
+            return Err(ValidationError::BadLaserExtraction(format!(
+                "min_points must be at least 2, got {}",
+                laser.min_points
+            )));
+        }
     }
 
     match spec.topology {
@@ -754,6 +766,26 @@ mod tests {
             validate(&spec).unwrap_err(),
             ValidationError::BadLaserExtraction(_)
         ));
+    }
+
+    #[test]
+    fn zero_min_points_rejected() {
+        // A zero (or one) drop-bar would let empty extractions pass as
+        // usable views, leaving the laser plane unconstrained.
+        for min_points in [0, 1] {
+            let mut spec = laserline_minimal();
+            spec.laser = Some(crate::spec::LaserExtractionSpec {
+                min_points,
+                ..Default::default()
+            });
+            assert!(
+                matches!(
+                    validate(&spec).unwrap_err(),
+                    ValidationError::BadLaserExtraction(_)
+                ),
+                "min_points={min_points} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/vision-calibration-detect/src/cache.rs
+++ b/crates/vision-calibration-detect/src/cache.rs
@@ -60,12 +60,38 @@ impl CacheKey {
     }
 
     /// Filename-safe encoding (`<image>-<detector>-<config>.json`).
+    ///
+    /// The detector segment is sanitized so the result is a legal file
+    /// name on every supported OS — notably Windows/NTFS, which rejects
+    /// `< > : " / \ | ? *`. Laser namespaces use a `laser:<name>` form
+    /// (ADR 0021), so the `:` must be stripped or the on-disk cache
+    /// write fails with `ERROR_INVALID_NAME` (OS error 87).
     pub fn file_name(&self) -> String {
         format!(
             "{:016x}-{}-{:016x}.json",
-            self.image_hash, self.detector, self.config_hash
+            self.image_hash,
+            sanitize_detector(&self.detector),
+            self.config_hash
         )
     }
+}
+
+/// Replace any character that is not alphanumeric, `_`, `-`, or `.`
+/// with `_`, so the detector id is a portable file-name segment. The
+/// detector ids are a controlled, in-tree set of stable strings, so
+/// this mapping stays injective in practice — there is no
+/// `laser:fake`/`laser_fake` pair to collide.
+fn sanitize_detector(detector: &str) -> String {
+    detector
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// Hash raw image bytes with FNV-1a (64-bit). Cheap, allocation-free,
@@ -216,6 +242,34 @@ mod tests {
         let back = cache.get(&key).unwrap().expect("cache hit expected");
         assert_eq!(back.features.len(), 1);
         assert_eq!(back.features[0].image_xy, [10.0, 20.0]);
+    }
+
+    #[test]
+    fn file_name_is_windows_safe_for_laser_namespace() {
+        // `laser:<name>` namespaces (ADR 0021) must not leak the colon
+        // into the file name — NTFS rejects it (OS error 87).
+        let key = CacheKey::from_inputs(b"img", "laser:fake", &json!({}));
+        let name = key.file_name();
+        assert!(
+            !name.contains(':'),
+            "detector segment must be sanitized, got {name}"
+        );
+        assert!(name.contains("laser_fake"), "got {name}");
+    }
+
+    #[test]
+    fn fs_cache_roundtrip_with_colon_detector() {
+        let dir = tempdir().unwrap();
+        let cache = FsDetectionCache::new(dir.path());
+        let key = CacheKey::from_inputs(b"img", "laser:fake", &json!({"x": 1}));
+        let entry = CachedFeatures {
+            features: vec![Feature {
+                image_xy: [1.0, 2.0],
+                world_xyz: [0.0, 0.0, 0.0],
+            }],
+        };
+        cache.put(&key, &entry).unwrap();
+        assert_eq!(cache.get(&key).unwrap().unwrap().features.len(), 1);
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/dataset_runner/handeye.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/handeye.rs
@@ -223,6 +223,7 @@ mod tests {
                     paths: image_paths.iter().map(PathBuf::from).collect(),
                 },
                 roi_xywh: None,
+                laser_images: None,
             }],
             target: TargetSpec::Chessboard {
                 rows: 9,
@@ -233,7 +234,10 @@ mod tests {
                 path: PathBuf::from("poses.txt"),
                 format: RobotPoseFormat::Rowmajor4x4,
                 columns: None,
+                matrix_field: None,
             }),
+            laser: None,
+            upstream_calibration: None,
             topology: Topology::SingleCamHandeye,
             pose_pairing: Some(PosePairing::ByIndex),
             pose_convention: Some(PoseConvention {
@@ -366,6 +370,7 @@ mod tests {
                 tz: "tz".into(),
                 rotation: vec!["qx".into(), "qy".into(), "qz".into(), "qw".into()],
             }),
+            matrix_field: None,
         });
         spec.pose_convention = Some(PoseConvention {
             transform: TransformConvention::TBaseTcp,

--- a/crates/vision-calibration-pipeline/src/dataset_runner/laser.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/laser.rs
@@ -1,0 +1,1170 @@
+//! `DatasetSpec → LaserlineDeviceInput / RigLaserlineDeviceInput`
+//! converters for the laser topologies (ADR 0021).
+//!
+//! Laser-line extraction is *injected* via [`LaserPixelExtractor`]:
+//! the reference implementation wraps `vision-metrology`, which is not
+//! on crates.io, so published crates cannot depend on it. The pipeline
+//! owns everything around the extractor call — cache lookup, decode,
+//! ROI crop, coordinate lift, cache store — mirroring the target
+//! detection path (`detect_features`).
+//!
+//! Laser frames pair with target views through the manifest's
+//! `pose_pairing` (no second pairing config): `by_index` requires one
+//! laser image per paired view; `shared_filename_token` applies the
+//! same regex to laser filenames. A laser token with no target view is
+//! an error (the regex is almost certainly wrong); a target view
+//! without a laser image is a gap — `None` laser slot for rigs, a
+//! dropped view for the single-camera topology.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use vision_calibration_core::{Iso3, Pt2, View};
+use vision_calibration_dataset::{
+    DatasetSpec, ImagePattern, LaserExtractionSpec, PosePairing, Topology, validate,
+};
+use vision_calibration_detect::{CacheKey, CachedFeatures, DetectionCache, Feature};
+use vision_calibration_optim::{HandEyeMode, LaserlineMeta, RigLaserlineDataset, RigLaserlineView};
+
+use crate::laserline_device::LaserlineDeviceInput;
+use crate::rig_handeye::RigHandeyeExport;
+use crate::rig_laserline_device::RigLaserlineDeviceInput;
+
+use super::pairing::pair_views;
+use super::poses::{load_robot_poses, match_poses_to_tokens};
+use super::{
+    RunError, augment_config_with_roi, detect_features, expand_camera_images, expand_image_pattern,
+    features_to_obs, pattern_repr, pick_detector, rig::build_rig_core, target_to_detector_config,
+};
+
+/// Injected laser-line extractor (ADR 0021).
+///
+/// Unlike the sealed [`Detector`](vision_calibration_detect::Detector)
+/// trait this one is **open**: the reference implementation lives in
+/// the (unpublished) Tauri app and wraps `vision-metrology`, which is
+/// not on crates.io. Implementations only extract; caching, ROI
+/// cropping, and coordinate lifting are handled by the runner.
+pub trait LaserPixelExtractor: Send + Sync {
+    /// Stable implementation id. Part of the cache key
+    /// (`laser:<name>`), so switching implementations re-extracts
+    /// instead of serving another extractor's pixels.
+    fn name(&self) -> &str;
+
+    /// Extract subpixel laser-line points `[x, y]` from `image`
+    /// (already ROI-cropped by the runner; coordinates are in the
+    /// cropped frame).
+    fn extract(
+        &self,
+        image: &image::DynamicImage,
+        spec: &LaserExtractionSpec,
+    ) -> anyhow::Result<Vec<[f64; 2]>>;
+}
+
+/// Result of a single-camera laserline dataset conversion.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct LaserlineRunResult {
+    /// The IR ready to feed into `CalibrationSession::set_input`.
+    pub input: LaserlineDeviceInput,
+    /// One *target* image path per accepted view, in the same order.
+    /// Used to populate the export's `image_manifest` after the solve.
+    pub view_paths: Vec<PathBuf>,
+    /// One *laser* image path per accepted view, aligned with
+    /// `view_paths`. Not yet rendered anywhere (B-laser).
+    pub laser_paths: Vec<PathBuf>,
+    /// Number of views with ≥4 target features and ≥`min_points`
+    /// laser pixels.
+    pub usable_views: usize,
+    /// Total number of paired views attempted.
+    pub total_views: usize,
+}
+
+/// Result of a rig laserline dataset conversion.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct RigLaserlineRunResult {
+    /// The IR (dataset + frozen upstream calibration) ready to feed
+    /// into `CalibrationSession::set_input`.
+    pub input: RigLaserlineDeviceInput,
+    /// `view_paths[view][camera]` — *target* image path per kept view
+    /// and camera; `None` where the camera contributed no usable
+    /// target observation.
+    pub view_paths: Vec<Vec<Option<PathBuf>>>,
+    /// Number of kept views (≥1 camera with ≥4 target features).
+    pub usable_views: usize,
+    /// Total number of paired views attempted.
+    pub total_views: usize,
+}
+
+/// Convert a single-camera laserline manifest + cache into a
+/// [`LaserlineDeviceInput`] for `LaserlineDevice`.
+pub fn build_laserline_device_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    laser_extractor: &dyn LaserPixelExtractor,
+    force_redetect: bool,
+) -> Result<LaserlineRunResult, RunError> {
+    // Same gate ordering as the other converters: topology + target +
+    // validation + pairing config before any filesystem access.
+    if spec.topology != Topology::LaserlineDevice {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let (detector_name, detector_config) = target_to_detector_config(&spec.target)?;
+    let detector = pick_detector(detector_name)?;
+    validate(spec)?;
+
+    let Some(pairing) = &spec.pose_pairing else {
+        return Err(RunError::AskUser {
+            field: "pose_pairing".into(),
+            prompt: "Laser topologies need to know how laser frames align with target \
+                     frames. Pick by_index (the i-th laser image pairs with the i-th \
+                     target image in natural-sort order) or shared_filename_token (a \
+                     regex extracts a shared view token from both filename sets)."
+                .into(),
+            suggestions: vec!["by_index".into(), "shared_filename_token".into()],
+        });
+    };
+
+    // The validator enforces exactly one camera with laser_images.
+    let camera = spec
+        .cameras
+        .first()
+        .expect("validate guarantees exactly one camera for LaserlineDevice");
+    let images = expand_camera_images(camera, base_dir)?;
+    if images.is_empty() {
+        return Err(RunError::EmptyImageMatch {
+            camera_id: camera.id.clone(),
+            pattern: pattern_repr(&camera.images),
+            base: base_dir.to_path_buf(),
+        });
+    }
+    let paired = pair_views(
+        std::slice::from_ref(&images),
+        std::slice::from_ref(&camera.id),
+        pairing,
+    )?;
+    let total_views = paired.paths.len();
+
+    let laser_images = camera
+        .laser_images
+        .as_ref()
+        .expect("validate guarantees laser_images for LaserlineDevice");
+    let laser_by_token =
+        laser_paths_by_token(laser_images, &camera.id, pairing, &paired.tokens, base_dir)?;
+
+    let laser_spec = spec.laser.unwrap_or_default();
+    let roi = camera.roi_xywh;
+    let key_config = augment_config_with_roi(&detector_config, roi);
+    let laser_key_config = laser_key_config(&laser_spec, roi);
+
+    let mut views: Vec<View<LaserlineMeta>> = Vec::new();
+    let mut view_paths: Vec<PathBuf> = Vec::new();
+    let mut laser_paths: Vec<PathBuf> = Vec::new();
+    for (paths, token) in paired.paths.iter().zip(&paired.tokens) {
+        let path = paths[0]
+            .as_ref()
+            .expect("single-camera pairing never produces gap slots");
+        let (features, _cache_hit) = detect_features(
+            detector.as_ref(),
+            detector_name,
+            &detector_config,
+            &key_config,
+            roi,
+            path,
+            cache,
+            force_redetect,
+        )?;
+        if features.len() < 4 {
+            continue; // too few corners for a homography — drop the view
+        }
+        // The single-camera problem needs laser pixels in *every* view
+        // (LaserlineMeta validates non-empty), so a view without a
+        // usable laser frame is dropped rather than gapped.
+        let Some(laser_path) = laser_by_token.get(token) else {
+            continue;
+        };
+        let pixels = extract_laser_pixels(
+            laser_extractor,
+            &laser_spec,
+            &laser_key_config,
+            roi,
+            laser_path,
+            cache,
+            force_redetect,
+        )?;
+        if pixels.len() < laser_spec.min_points as usize {
+            continue;
+        }
+        views.push(View {
+            obs: features_to_obs(&features),
+            meta: LaserlineMeta {
+                laser_pixels: pixels,
+                laser_weights: vec![],
+            },
+        });
+        view_paths.push(path.clone());
+        laser_paths.push(laser_path.clone());
+    }
+
+    let usable_views = views.len();
+    // The problem type needs ≥3 views; fail here with view counts
+    // rather than letting set_input produce a less actionable error.
+    if usable_views < 3 {
+        return Err(RunError::InsufficientUsableViews {
+            camera_id: camera.id.clone(),
+            usable: usable_views,
+            total: total_views,
+        });
+    }
+
+    Ok(LaserlineRunResult {
+        input: views,
+        view_paths,
+        laser_paths,
+        usable_views,
+        total_views,
+    })
+}
+
+/// Convert a rig laserline manifest + cache + frozen upstream rig
+/// hand-eye export into a [`RigLaserlineDeviceInput`] for
+/// `RigLaserlineDevice`.
+pub fn build_rig_laserline_device_input(
+    spec: &DatasetSpec,
+    base_dir: &Path,
+    cache: &dyn DetectionCache,
+    laser_extractor: &dyn LaserPixelExtractor,
+    force_redetect: bool,
+) -> Result<RigLaserlineRunResult, RunError> {
+    if spec.topology != Topology::RigLaserlineDevice {
+        return Err(RunError::UnsupportedTopology {
+            topology: spec.topology,
+        });
+    }
+    let core = build_rig_core(spec, base_dir, cache, force_redetect)?;
+    let num_cameras = spec.cameras.len();
+
+    // `validate` (inside build_rig_core) guarantees pose_pairing,
+    // robot_poses, pose_convention, upstream_calibration, and
+    // laser_images on every camera for this topology.
+    let pairing = spec
+        .pose_pairing
+        .as_ref()
+        .expect("build_rig_core checked pose_pairing");
+
+    // Laser frames pair against *all* view tokens (pre-drop) — a laser
+    // image for a view that was later dropped is not an error.
+    let laser_spec = spec.laser.unwrap_or_default();
+    let mut laser_by_token: Vec<HashMap<String, PathBuf>> = Vec::with_capacity(num_cameras);
+    for camera in &spec.cameras {
+        let laser_images = camera
+            .laser_images
+            .as_ref()
+            .expect("validate guarantees laser_images for RigLaserlineDevice");
+        laser_by_token.push(laser_paths_by_token(
+            laser_images,
+            &camera.id,
+            pairing,
+            &core.all_tokens,
+            base_dir,
+        )?);
+    }
+
+    // Per-camera laser extraction over the kept views.
+    let laser_key_configs: Vec<Value> = spec
+        .cameras
+        .iter()
+        .map(|c| laser_key_config(&laser_spec, c.roi_xywh))
+        .collect();
+    let mut laser_per_view: Vec<Vec<Option<Vec<Pt2>>>> = Vec::with_capacity(core.views.len());
+    let mut per_camera_usable = vec![0usize; num_cameras];
+    for (_obs, token) in &core.views {
+        let mut slots: Vec<Option<Vec<Pt2>>> = Vec::with_capacity(num_cameras);
+        for cam_idx in 0..num_cameras {
+            let Some(laser_path) = laser_by_token[cam_idx].get(token) else {
+                slots.push(None);
+                continue;
+            };
+            let pixels = extract_laser_pixels(
+                laser_extractor,
+                &laser_spec,
+                &laser_key_configs[cam_idx],
+                spec.cameras[cam_idx].roi_xywh,
+                laser_path,
+                cache,
+                force_redetect,
+            )?;
+            if pixels.len() < laser_spec.min_points as usize {
+                slots.push(None);
+                continue;
+            }
+            per_camera_usable[cam_idx] += 1;
+            slots.push(Some(pixels));
+        }
+        laser_per_view.push(slots);
+    }
+    for (cam_idx, usable) in per_camera_usable.iter().enumerate() {
+        if *usable == 0 {
+            // A camera with zero laser observations leaves its plane
+            // unconstrained — fail fast instead of solving garbage.
+            return Err(RunError::InsufficientLaserViews {
+                camera_id: spec.cameras[cam_idx].id.clone(),
+                usable: 0,
+                total: core.views.len(),
+            });
+        }
+    }
+
+    // Robot poses → per-kept-view T_B_G, matched by pairing token.
+    let source = spec
+        .robot_poses
+        .as_ref()
+        .expect("validate guarantees robot_poses for RigLaserlineDevice");
+    let convention = spec
+        .pose_convention
+        .as_ref()
+        .expect("validate guarantees pose_convention for RigLaserlineDevice");
+    let poses = load_robot_poses(source, convention, base_dir)?;
+    let kept_tokens: Vec<String> = core.views.iter().map(|(_, t)| t.clone()).collect();
+    let matched = match_poses_to_tokens(&kept_tokens, &poses, spec, core.total_views)?;
+
+    // Frozen upstream rig hand-eye export → per-view rig_se3_target
+    // through the hand-eye chain (ADR 0021 §4).
+    let upstream_path = spec
+        .upstream_calibration
+        .as_ref()
+        .expect("validate guarantees upstream_calibration for RigLaserlineDevice");
+    let upstream_path = if upstream_path.is_absolute() {
+        upstream_path.clone()
+    } else {
+        base_dir.join(upstream_path)
+    };
+    let export = load_upstream_export(&upstream_path)?;
+    if export.cameras.len() != num_cameras {
+        return Err(RunError::UpstreamCalibration {
+            path: upstream_path,
+            message: format!(
+                "export has {} cameras but the manifest declares {num_cameras}",
+                export.cameras.len()
+            ),
+        });
+    }
+    let rig_se3_target: Vec<Iso3> = matched
+        .iter()
+        .map(|base_se3_gripper| {
+            rig_se3_target_from_chain(&export, base_se3_gripper, &upstream_path)
+        })
+        .collect::<Result<_, _>>()?;
+    let upstream = export
+        .to_upstream_calibration(rig_se3_target)
+        .map_err(|e| RunError::UpstreamCalibration {
+            path: upstream_path,
+            message: e.to_string(),
+        })?;
+
+    let views: Vec<RigLaserlineView> = core
+        .views
+        .into_iter()
+        .zip(laser_per_view)
+        .map(|((obs, _token), laser_pixels)| RigLaserlineView {
+            cameras: obs.cameras,
+            laser_pixels,
+        })
+        .collect();
+    let usable_views = views.len();
+    let dataset = RigLaserlineDataset::new(views, num_cameras).expect(
+        "RigLaserlineDataset::new failed after the runner enforced non-empty views \
+         and per-view camera counts; this indicates an optim-crate regression",
+    );
+
+    Ok(RigLaserlineRunResult {
+        input: RigLaserlineDeviceInput {
+            dataset,
+            upstream,
+            initial_planes_cam: None,
+        },
+        view_paths: core.view_paths,
+        usable_views,
+        total_views: core.total_views,
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Cache-key config for laser extraction: the canonical
+/// `LaserExtractionSpec` JSON plus the `_roi` splice (same scheme as
+/// target detection).
+fn laser_key_config(laser_spec: &LaserExtractionSpec, roi: Option<[u32; 4]>) -> Value {
+    let config =
+        serde_json::to_value(laser_spec).expect("LaserExtractionSpec serializes to a JSON object");
+    augment_config_with_roi(&config, roi)
+}
+
+/// Map each view token to the camera's laser image path, using the
+/// same pairing strategy as the target frames.
+fn laser_paths_by_token(
+    laser_images: &ImagePattern,
+    camera_id: &str,
+    pairing: &PosePairing,
+    view_tokens: &[String],
+    base_dir: &Path,
+) -> Result<HashMap<String, PathBuf>, RunError> {
+    let paths = expand_image_pattern(laser_images, camera_id, base_dir)?;
+    if paths.is_empty() {
+        return Err(RunError::LaserPairing {
+            message: format!(
+                "camera {camera_id:?}: laser_images {} matched no files under {}",
+                pattern_repr(laser_images),
+                base_dir.display()
+            ),
+        });
+    }
+    match pairing {
+        PosePairing::ByIndex => {
+            if paths.len() != view_tokens.len() {
+                return Err(RunError::LaserPairing {
+                    message: format!(
+                        "camera {camera_id:?}: by_index pairing requires one laser image \
+                         per view, got {} laser images for {} views",
+                        paths.len(),
+                        view_tokens.len()
+                    ),
+                });
+            }
+            Ok(view_tokens.iter().cloned().zip(paths).collect())
+        }
+        PosePairing::SharedFilenameToken { regex, group } => {
+            let re = regex::Regex::new(regex).map_err(|e| RunError::BadPairingRegex {
+                regex: regex.clone(),
+                message: e.to_string(),
+            })?;
+            let known: std::collections::HashSet<&str> =
+                view_tokens.iter().map(String::as_str).collect();
+            let mut map = HashMap::new();
+            for path in paths {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let token = re
+                    .captures(&name)
+                    .and_then(|c| c.name(group))
+                    .map(|m| m.as_str().to_string())
+                    .ok_or_else(|| RunError::LaserPairing {
+                        message: format!(
+                            "camera {camera_id:?}: laser filename {name:?} does not match \
+                             the pairing regex (or group {group:?} did not participate)"
+                        ),
+                    })?;
+                if !known.contains(token.as_str()) {
+                    return Err(RunError::LaserPairing {
+                        message: format!(
+                            "camera {camera_id:?}: laser token {token:?} (from {name:?}) \
+                             matches no target view — the pairing regex is probably wrong"
+                        ),
+                    });
+                }
+                if let Some(previous) = map.insert(token.clone(), path.clone()) {
+                    return Err(RunError::LaserPairing {
+                        message: format!(
+                            "camera {camera_id:?}: laser token {token:?} extracted from two \
+                             files ({} and {})",
+                            previous.display(),
+                            path.display()
+                        ),
+                    });
+                }
+            }
+            Ok(map)
+        }
+    }
+}
+
+/// Run one laser image through the cache-or-extract path: read bytes →
+/// cache lookup → on miss, decode, crop to ROI, extract, lift pixels
+/// back to source coordinates, store. Mirrors `detect_features`; laser
+/// pixels are cached as `Feature`s with a zero-filled (meaningless)
+/// `world_xyz`.
+fn extract_laser_pixels(
+    extractor: &dyn LaserPixelExtractor,
+    laser_spec: &LaserExtractionSpec,
+    key_config: &Value,
+    roi: Option<[u32; 4]>,
+    image_path: &Path,
+    cache: &dyn DetectionCache,
+    force_redetect: bool,
+) -> Result<Vec<Pt2>, RunError> {
+    let bytes = std::fs::read(image_path)?;
+    let detector_name = format!("laser:{}", extractor.name());
+    let key = CacheKey::from_inputs(&bytes, &detector_name, key_config);
+
+    let cached: Option<CachedFeatures> = if force_redetect {
+        None
+    } else {
+        cache.get(&key)?
+    };
+    if let Some(entry) = cached {
+        return Ok(entry
+            .features
+            .iter()
+            .map(|f| Pt2::new(f.image_xy[0], f.image_xy[1]))
+            .collect());
+    }
+
+    let img = image::load_from_memory(&bytes).map_err(|e| RunError::Decode {
+        path: image_path.to_path_buf(),
+        source: e,
+    })?;
+    let img_for_extract = if let Some([x, y, w, h]) = roi {
+        img.crop_imm(x, y, w, h)
+    } else {
+        img
+    };
+    let mut points = extractor
+        .extract(&img_for_extract, laser_spec)
+        .map_err(|e| RunError::LaserExtraction {
+            path: image_path.to_path_buf(),
+            source: e,
+        })?;
+    // Extracted pixels are in the cropped frame; lift them back into
+    // source-image coordinates like the target detection path.
+    if let Some([x, y, _w, _h]) = roi {
+        for p in points.iter_mut() {
+            p[0] += x as f64;
+            p[1] += y as f64;
+        }
+    }
+    cache.put(
+        &key,
+        &CachedFeatures {
+            features: points
+                .iter()
+                .map(|p| Feature {
+                    image_xy: *p,
+                    world_xyz: [0.0, 0.0, 0.0],
+                })
+                .collect(),
+        },
+    )?;
+    Ok(points.into_iter().map(|p| Pt2::new(p[0], p[1])).collect())
+}
+
+fn load_upstream_export(path: &Path) -> Result<RigHandeyeExport, RunError> {
+    let text = std::fs::read_to_string(path).map_err(|e| RunError::UpstreamCalibration {
+        path: path.to_path_buf(),
+        message: format!("read failed: {e}"),
+    })?;
+    serde_json::from_str(&text).map_err(|e| RunError::UpstreamCalibration {
+        path: path.to_path_buf(),
+        message: format!("not a rig hand-eye export: {e}"),
+    })
+}
+
+/// Per-view rig→target pose through the frozen hand-eye chain
+/// (ADR 0021 §4, same math as the rtv3d example):
+///
+/// - `EyeInHand`:  `T_R_T = T_G_R⁻¹ · T_B_G⁻¹ · T_B_T`
+/// - `EyeToHand`:  `T_R_T = T_R_B · T_B_G · T_G_T`
+fn rig_se3_target_from_chain(
+    export: &RigHandeyeExport,
+    base_se3_gripper: &Iso3,
+    path: &Path,
+) -> Result<Iso3, RunError> {
+    let missing = |field: &str| RunError::UpstreamCalibration {
+        path: path.to_path_buf(),
+        message: format!("{:?} export is missing {field}", export.handeye_mode),
+    };
+    match export.handeye_mode {
+        HandEyeMode::EyeInHand => {
+            let gripper_se3_rig = export
+                .gripper_se3_rig
+                .ok_or_else(|| missing("gripper_se3_rig"))?;
+            let base_se3_target = export
+                .base_se3_target
+                .ok_or_else(|| missing("base_se3_target"))?;
+            Ok(gripper_se3_rig.inverse() * base_se3_gripper.inverse() * base_se3_target)
+        }
+        HandEyeMode::EyeToHand => {
+            let rig_se3_base = export.rig_se3_base.ok_or_else(|| missing("rig_se3_base"))?;
+            let gripper_se3_target = export
+                .gripper_se3_target
+                .ok_or_else(|| missing("gripper_se3_target"))?;
+            Ok(rig_se3_base * base_se3_gripper * gripper_se3_target)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use vision_calibration_core::{
+        BrownConrady5, FxFyCxCySkew, PerFeatureResiduals, make_pinhole_camera,
+    };
+    use vision_calibration_dataset::{
+        CameraSource, PoseConvention, RobotPoseFormat, RobotPoseSource, RotationFormat, TargetSpec,
+        TransformConvention, TranslationUnits,
+    };
+    use vision_calibration_detect::FsDetectionCache;
+
+    /// Deterministic extractor: `n` points along a horizontal line.
+    /// Counts calls so tests can assert the cache-hit path.
+    struct FakeLaser {
+        n: usize,
+        calls: AtomicUsize,
+    }
+
+    impl FakeLaser {
+        fn new(n: usize) -> Self {
+            Self {
+                n,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl LaserPixelExtractor for FakeLaser {
+        fn name(&self) -> &str {
+            "fake"
+        }
+        fn extract(
+            &self,
+            _image: &image::DynamicImage,
+            _spec: &LaserExtractionSpec,
+        ) -> anyhow::Result<Vec<[f64; 2]>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok((0..self.n).map(|i| [i as f64, 100.0]).collect())
+        }
+    }
+
+    fn grid_features(n: usize) -> Vec<Feature> {
+        (0..n)
+            .map(|i| Feature {
+                image_xy: [100.0 + 10.0 * i as f64, 200.0 + 5.0 * i as f64],
+                world_xyz: [0.025 * i as f64, 0.0, 0.0],
+            })
+            .collect()
+    }
+
+    fn detector_config() -> Value {
+        json!({"rows": 9, "cols": 6, "square_size_m": 0.025})
+    }
+
+    fn laser_features(n: usize) -> Vec<Feature> {
+        (0..n)
+            .map(|i| Feature {
+                image_xy: [i as f64, 50.0],
+                world_xyz: [0.0, 0.0, 0.0],
+            })
+            .collect()
+    }
+
+    /// Write a dummy "image" file and pre-seed the target-detection
+    /// cache for it, so the runner takes the cache-hit path and never
+    /// decodes the bytes.
+    fn seed_target(
+        dir: &Path,
+        cache: &FsDetectionCache,
+        rel_path: &str,
+        features: Vec<Feature>,
+    ) -> PathBuf {
+        let path = dir.join(rel_path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = rel_path.as_bytes();
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(bytes).unwrap();
+        let key = CacheKey::from_inputs(bytes, "chessboard", &detector_config());
+        cache.put(&key, &CachedFeatures { features }).unwrap();
+        path
+    }
+
+    /// Write a dummy laser "image" and pre-seed the laser cache under
+    /// the `laser:fake` namespace with default extraction params.
+    fn seed_laser(
+        dir: &Path,
+        cache: &FsDetectionCache,
+        rel_path: &str,
+        features: Vec<Feature>,
+    ) -> PathBuf {
+        let path = dir.join(rel_path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = rel_path.as_bytes();
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(bytes).unwrap();
+        let key_config = laser_key_config(&LaserExtractionSpec::default(), None);
+        let key = CacheKey::from_inputs(bytes, "laser:fake", &key_config);
+        cache.put(&key, &CachedFeatures { features }).unwrap();
+        path
+    }
+
+    fn laserline_spec(image_paths: &[&str], laser_paths: &[&str]) -> DatasetSpec {
+        DatasetSpec {
+            version: 1,
+            cameras: vec![CameraSource {
+                id: "cam0".into(),
+                images: ImagePattern::List {
+                    paths: image_paths.iter().map(PathBuf::from).collect(),
+                },
+                roi_xywh: None,
+                laser_images: Some(ImagePattern::List {
+                    paths: laser_paths.iter().map(PathBuf::from).collect(),
+                }),
+            }],
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: None,
+            laser: None,
+            upstream_calibration: None,
+            topology: Topology::LaserlineDevice,
+            pose_pairing: Some(PosePairing::ByIndex),
+            pose_convention: None,
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    #[test]
+    fn by_index_builds_laserline_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for view in 0..3 {
+            seed_target(
+                tmp.path(),
+                &cache,
+                &format!("target_{view}.png"),
+                grid_features(6),
+            );
+            seed_laser(
+                tmp.path(),
+                &cache,
+                &format!("laser_{view}.png"),
+                laser_features(30),
+            );
+        }
+        let spec = laserline_spec(
+            &["target_0.png", "target_1.png", "target_2.png"],
+            &["laser_0.png", "laser_1.png", "laser_2.png"],
+        );
+        let fake = FakeLaser::new(30);
+        let result = build_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap();
+        assert_eq!((result.usable_views, result.total_views), (3, 3));
+        assert_eq!(result.input.len(), 3);
+        assert_eq!(result.input[0].meta.laser_pixels.len(), 30);
+        assert!(result.input[0].meta.laser_weights.is_empty());
+        assert!(result.view_paths[2].ends_with("target_2.png"));
+        assert!(result.laser_paths[2].ends_with("laser_2.png"));
+        // Everything was served from the cache.
+        assert_eq!(fake.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn weak_laser_view_dropped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for view in 0..4 {
+            seed_target(
+                tmp.path(),
+                &cache,
+                &format!("target_{view}.png"),
+                grid_features(6),
+            );
+            // View 1 has too few laser pixels (< default min_points 20).
+            let n = if view == 1 { 5 } else { 30 };
+            seed_laser(
+                tmp.path(),
+                &cache,
+                &format!("laser_{view}.png"),
+                laser_features(n),
+            );
+        }
+        let spec = laserline_spec(
+            &[
+                "target_0.png",
+                "target_1.png",
+                "target_2.png",
+                "target_3.png",
+            ],
+            &["laser_0.png", "laser_1.png", "laser_2.png", "laser_3.png"],
+        );
+        let fake = FakeLaser::new(30);
+        let result = build_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap();
+        assert_eq!((result.usable_views, result.total_views), (3, 4));
+        assert!(
+            result
+                .view_paths
+                .iter()
+                .all(|p| !p.ends_with("target_1.png"))
+        );
+    }
+
+    #[test]
+    fn by_index_laser_count_mismatch_is_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for view in 0..3 {
+            seed_target(
+                tmp.path(),
+                &cache,
+                &format!("target_{view}.png"),
+                grid_features(6),
+            );
+        }
+        seed_laser(tmp.path(), &cache, "laser_0.png", laser_features(30));
+        let spec = laserline_spec(
+            &["target_0.png", "target_1.png", "target_2.png"],
+            &["laser_0.png"],
+        );
+        let fake = FakeLaser::new(30);
+        let err =
+            build_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err();
+        match err {
+            RunError::LaserPairing { message } => {
+                assert!(
+                    message.contains("1 laser images for 3 views"),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected LaserPairing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_pairing_gaps_drop_views_and_orphans_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        for view in 0..4 {
+            seed_target(
+                tmp.path(),
+                &cache,
+                &format!("target_{view}.png"),
+                grid_features(6),
+            );
+        }
+        // Laser frames only for views 0, 2, 3 — view 1 is a gap.
+        for view in [0usize, 2, 3] {
+            seed_laser(
+                tmp.path(),
+                &cache,
+                &format!("laser_{view}.png"),
+                laser_features(30),
+            );
+        }
+        let mut spec = laserline_spec(
+            &[
+                "target_0.png",
+                "target_1.png",
+                "target_2.png",
+                "target_3.png",
+            ],
+            &["laser_0.png", "laser_2.png", "laser_3.png"],
+        );
+        spec.pose_pairing = Some(PosePairing::SharedFilenameToken {
+            regex: r"^(?:target|laser)_(?<view>\d+)\.png$".into(),
+            group: "view".into(),
+        });
+        let fake = FakeLaser::new(30);
+        let result = build_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap();
+        assert_eq!((result.usable_views, result.total_views), (3, 4));
+
+        // An orphan laser token (no matching target view) must error.
+        seed_laser(tmp.path(), &cache, "laser_9.png", laser_features(30));
+        if let Some(CameraSource { laser_images, .. }) = spec.cameras.first_mut() {
+            *laser_images = Some(ImagePattern::List {
+                paths: ["laser_0.png", "laser_2.png", "laser_3.png", "laser_9.png"]
+                    .iter()
+                    .map(PathBuf::from)
+                    .collect(),
+            });
+        }
+        let err =
+            build_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err();
+        match err {
+            RunError::LaserPairing { message } => {
+                assert!(message.contains("\"9\""), "got: {message}");
+            }
+            other => panic!("expected LaserPairing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn real_extraction_path_lifts_roi_and_caches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        // A real decodable PNG so the miss path reaches the extractor.
+        let img_path = tmp.path().join("laser_real.png");
+        image::DynamicImage::new_luma8(64, 64)
+            .save(&img_path)
+            .unwrap();
+
+        let laser_spec = LaserExtractionSpec::default();
+        let roi = Some([10u32, 20, 16, 16]);
+        let key_config = laser_key_config(&laser_spec, roi);
+        let fake = FakeLaser::new(25);
+
+        let pixels = extract_laser_pixels(
+            &fake,
+            &laser_spec,
+            &key_config,
+            roi,
+            &img_path,
+            &cache,
+            false,
+        )
+        .unwrap();
+        assert_eq!(pixels.len(), 25);
+        // FakeLaser emits x = i, y = 100 in the cropped frame; the
+        // runner must lift back to source coordinates.
+        assert_eq!((pixels[0].x, pixels[0].y), (10.0, 120.0));
+        assert_eq!(fake.calls.load(Ordering::SeqCst), 1);
+
+        // Second call must be served from the cache, lift preserved.
+        let again = extract_laser_pixels(
+            &fake,
+            &laser_spec,
+            &key_config,
+            roi,
+            &img_path,
+            &cache,
+            false,
+        )
+        .unwrap();
+        assert_eq!(fake.calls.load(Ordering::SeqCst), 1);
+        assert_eq!((again[0].x, again[0].y), (10.0, 120.0));
+    }
+
+    // ── Rig converter ───────────────────────────────────────────────────
+
+    fn identity_pose_line(tx: f64) -> String {
+        format!("1 0 0 {tx}  0 1 0 0  0 0 1 0  0 0 0 1\n")
+    }
+
+    /// Minimal eye-in-hand rig hand-eye export with identity hand-eye
+    /// transforms and a target 1 m up the base Z axis.
+    fn upstream_export(num_cameras: usize) -> RigHandeyeExport {
+        let k = FxFyCxCySkew {
+            fx: 800.0,
+            fy: 800.0,
+            cx: 320.0,
+            cy: 240.0,
+            skew: 0.0,
+        };
+        RigHandeyeExport {
+            cameras: (0..num_cameras)
+                .map(|_| make_pinhole_camera(k, BrownConrady5::default()))
+                .collect(),
+            sensors: None,
+            cam_se3_rig: vec![Iso3::identity(); num_cameras],
+            rig_se3_target: vec![],
+            handeye_mode: HandEyeMode::EyeInHand,
+            gripper_se3_rig: Some(Iso3::identity()),
+            rig_se3_base: None,
+            base_se3_target: Some(Iso3::translation(0.0, 0.0, 1.0)),
+            gripper_se3_target: None,
+            robot_deltas: None,
+            mean_reproj_error: 0.5,
+            per_cam_reproj_errors: vec![0.5; num_cameras],
+            per_feature_residuals: PerFeatureResiduals::default(),
+            image_manifest: None,
+        }
+    }
+
+    fn rig_laserline_spec(dir: &Path, num_views: usize) -> DatasetSpec {
+        let poses: String = (0..num_views)
+            .map(|i| identity_pose_line((i + 1) as f64 / 10.0))
+            .collect();
+        std::fs::write(dir.join("poses.txt"), poses).unwrap();
+        std::fs::write(
+            dir.join("rig_handeye_export.json"),
+            serde_json::to_string(&upstream_export(2)).unwrap(),
+        )
+        .unwrap();
+        let cam = |idx: usize| CameraSource {
+            id: format!("cam{idx}"),
+            images: ImagePattern::List {
+                paths: (0..num_views)
+                    .map(|v| PathBuf::from(format!("cam{idx}/target_{v}.png")))
+                    .collect(),
+            },
+            roi_xywh: None,
+            laser_images: Some(ImagePattern::List {
+                paths: (0..num_views)
+                    .map(|v| PathBuf::from(format!("cam{idx}/laser_{v}.png")))
+                    .collect(),
+            }),
+        };
+        DatasetSpec {
+            version: 1,
+            cameras: vec![cam(0), cam(1)],
+            target: TargetSpec::Chessboard {
+                rows: 9,
+                cols: 6,
+                square_size_m: 0.025,
+            },
+            robot_poses: Some(RobotPoseSource {
+                path: PathBuf::from("poses.txt"),
+                format: RobotPoseFormat::Rowmajor4x4,
+                columns: None,
+                matrix_field: None,
+            }),
+            laser: None,
+            upstream_calibration: Some(PathBuf::from("rig_handeye_export.json")),
+            topology: Topology::RigLaserlineDevice,
+            pose_pairing: Some(PosePairing::ByIndex),
+            pose_convention: Some(PoseConvention {
+                transform: TransformConvention::TBaseTcp,
+                rotation_format: RotationFormat::Matrix4x4RowMajor,
+                translation_units: TranslationUnits::M,
+            }),
+            unresolved: vec![],
+            description: None,
+        }
+    }
+
+    fn seed_rig_views(dir: &Path, cache: &FsDetectionCache, num_views: usize) {
+        for cam in 0..2 {
+            for view in 0..num_views {
+                seed_target(
+                    dir,
+                    cache,
+                    &format!("cam{cam}/target_{view}.png"),
+                    grid_features(6),
+                );
+                seed_laser(
+                    dir,
+                    cache,
+                    &format!("cam{cam}/laser_{view}.png"),
+                    laser_features(30),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rig_laserline_builds_input_with_upstream_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_rig_views(tmp.path(), &cache, 3);
+        let spec = rig_laserline_spec(tmp.path(), 3);
+        let fake = FakeLaser::new(30);
+        let result =
+            build_rig_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap();
+        assert_eq!((result.usable_views, result.total_views), (3, 3));
+        let input = &result.input;
+        assert_eq!(input.dataset.num_cameras, 2);
+        assert_eq!(input.dataset.num_views(), 3);
+        assert_eq!(
+            input.dataset.views[0].laser_pixels[1]
+                .as_ref()
+                .unwrap()
+                .len(),
+            30
+        );
+        assert_eq!(input.upstream.intrinsics.len(), 2);
+        assert!(
+            input.upstream.sensors[0].tilt_x.abs() < 1e-12,
+            "pinhole upstream gets zero Scheimpflug tilt"
+        );
+        // EyeInHand chain with identity T_G_R:
+        //   T_R_T_i = T_B_G_i^-1 * T_B_T = (-tx_i, 0, 1).
+        let t = input.upstream.rig_se3_target[1].translation.vector;
+        assert!(
+            (t - nalgebra::Vector3::new(-0.2, 0.0, 1.0)).norm() < 1e-12,
+            "got {t:?}"
+        );
+        assert!(input.initial_planes_cam.is_none());
+    }
+
+    #[test]
+    fn rig_laserline_camera_without_laser_is_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_rig_views(tmp.path(), &cache, 3);
+        // Re-seed cam1's laser views below the min_points bar.
+        for view in 0..3 {
+            seed_laser(
+                tmp.path(),
+                &cache,
+                &format!("cam1/laser_{view}.png"),
+                laser_features(3),
+            );
+        }
+        let spec = rig_laserline_spec(tmp.path(), 3);
+        let fake = FakeLaser::new(30);
+        let err =
+            build_rig_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err();
+        match err {
+            RunError::InsufficientLaserViews { camera_id, .. } => assert_eq!(camera_id, "cam1"),
+            other => panic!("expected InsufficientLaserViews, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rig_laserline_upstream_camera_count_mismatch_is_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_rig_views(tmp.path(), &cache, 3);
+        let spec = rig_laserline_spec(tmp.path(), 3);
+        // Overwrite the upstream export with a 3-camera one.
+        std::fs::write(
+            tmp.path().join("rig_handeye_export.json"),
+            serde_json::to_string(&upstream_export(3)).unwrap(),
+        )
+        .unwrap();
+        let fake = FakeLaser::new(30);
+        let err =
+            build_rig_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err();
+        match err {
+            RunError::UpstreamCalibration { message, .. } => {
+                assert!(message.contains("3 cameras"), "got: {message}");
+            }
+            other => panic!("expected UpstreamCalibration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rig_laserline_missing_upstream_file_is_actionable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        seed_rig_views(tmp.path(), &cache, 3);
+        let mut spec = rig_laserline_spec(tmp.path(), 3);
+        spec.upstream_calibration = Some(PathBuf::from("does_not_exist.json"));
+        let fake = FakeLaser::new(30);
+        let err =
+            build_rig_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err();
+        match err {
+            RunError::UpstreamCalibration { message, .. } => {
+                assert!(message.contains("read failed"), "got: {message}");
+            }
+            other => panic!("expected UpstreamCalibration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_topology_rejected_by_both_converters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = FsDetectionCache::new(tmp.path().join("cache"));
+        let fake = FakeLaser::new(30);
+        let mut spec = laserline_spec(&["a.png"], &["b.png"]);
+        spec.topology = Topology::PlanarIntrinsics;
+        assert!(matches!(
+            build_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err(),
+            RunError::UnsupportedTopology { .. }
+        ));
+        assert!(matches!(
+            build_rig_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap_err(),
+            RunError::UnsupportedTopology { .. }
+        ));
+    }
+}

--- a/crates/vision-calibration-pipeline/src/dataset_runner/mod.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/mod.rs
@@ -12,9 +12,10 @@
 //!   [`RobotPoseSource`](vision_calibration_dataset::RobotPoseSource)).
 //! - [`build_single_cam_handeye_input`] — `SingleCamHandeye`
 //!   (`SingleCamHandeyeInput`, single camera + robot poses).
-//!
-//! The laser topologies (`LaserlineDevice`, `RigLaserlineDevice`) await
-//! the laser-frame manifest design.
+//! - [`build_laserline_device_input`] / [`build_rig_laserline_device_input`]
+//!   — the laser topologies (ADR 0021). Laser-line extraction is
+//!   *injected* via the open [`LaserPixelExtractor`] trait because the
+//!   reference implementation (`vision-metrology`) is not on crates.io.
 //!
 //! Per ADR 0019, any ambiguity that cannot be auto-resolved at
 //! conversion time is surfaced as a [`RunError::AskUser`] event so
@@ -33,12 +34,17 @@ use vision_calibration_detect::{
 };
 
 mod handeye;
+mod laser;
 mod pairing;
 mod planar;
 mod poses;
 mod rig;
 
 pub use handeye::{HandeyeRunResult, build_single_cam_handeye_input};
+pub use laser::{
+    LaserPixelExtractor, LaserlineRunResult, RigLaserlineRunResult, build_laserline_device_input,
+    build_rig_laserline_device_input,
+};
 pub use pairing::PairedViews;
 pub use planar::{PlanarRunResult, build_planar_input};
 pub use rig::{RigRunResult, build_rig_extrinsics_input, build_rig_handeye_input};
@@ -199,6 +205,47 @@ pub enum RunError {
         /// Total number of images attempted.
         total: usize,
     },
+
+    /// Laser images could not be aligned with target views (count
+    /// mismatch under `by_index`, or a laser filename token with no
+    /// matching target view).
+    #[error("laser pairing failed: {message}")]
+    LaserPairing {
+        /// Human-readable description (names the offending camera/file).
+        message: String,
+    },
+
+    /// The injected laser extractor failed on a specific image.
+    #[error("laser extraction failed on {path}: {source}")]
+    LaserExtraction {
+        /// Offending laser image.
+        path: PathBuf,
+        /// Underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+
+    /// A camera has no usable laser observations — its laser plane
+    /// would be unconstrained.
+    #[error("camera {camera_id:?}: only {usable}/{total} views had >= min_points laser pixels")]
+    InsufficientLaserViews {
+        /// Camera id.
+        camera_id: String,
+        /// Number of views meeting the `min_points` bar.
+        usable: usize,
+        /// Total number of paired views attempted.
+        total: usize,
+    },
+
+    /// The frozen upstream rig hand-eye export could not be loaded or
+    /// is inconsistent with this manifest.
+    #[error("upstream calibration {path}: {message}")]
+    UpstreamCalibration {
+        /// The export file referenced by `upstream_calibration`.
+        path: PathBuf,
+        /// What went wrong (parse error, camera-count mismatch, …).
+        message: String,
+    },
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -268,7 +315,17 @@ fn expand_camera_images(
     camera: &vision_calibration_dataset::CameraSource,
     base_dir: &Path,
 ) -> Result<Vec<PathBuf>, RunError> {
-    match &camera.images {
+    expand_image_pattern(&camera.images, &camera.id, base_dir)
+}
+
+/// Expand a glob/list image pattern into natural-sorted absolute paths.
+/// Shared by the target (`images`) and laser (`laser_images`) sources.
+fn expand_image_pattern(
+    images: &ImagePattern,
+    camera_id: &str,
+    base_dir: &Path,
+) -> Result<Vec<PathBuf>, RunError> {
+    match images {
         ImagePattern::Glob { pattern } => {
             let resolved = if Path::new(pattern).is_absolute() {
                 pattern.clone()
@@ -276,7 +333,7 @@ fn expand_camera_images(
                 base_dir.join(pattern).to_string_lossy().to_string()
             };
             let entries = glob::glob(&resolved).map_err(|e| RunError::BadGlob {
-                camera_id: camera.id.clone(),
+                camera_id: camera_id.to_string(),
                 pattern: pattern.clone(),
                 source: e,
             })?;

--- a/crates/vision-calibration-pipeline/src/dataset_runner/planar.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/planar.rs
@@ -141,6 +141,7 @@ mod tests {
                 id: "cam0".into(),
                 images: ImagePattern::List { paths: vec![] },
                 roi_xywh: None,
+                laser_images: None,
             }],
             target: TargetSpec::Chessboard {
                 rows: 9,
@@ -148,6 +149,8 @@ mod tests {
                 square_size_m: 0.025,
             },
             robot_poses: None,
+            laser: None,
+            upstream_calibration: None,
             topology: Topology::PlanarIntrinsics,
             pose_pairing: None,
             pose_convention: None,
@@ -164,6 +167,7 @@ mod tests {
             id: "cam1".into(),
             images: ImagePattern::List { paths: vec![] },
             roi_xywh: None,
+            laser_images: None,
         });
         let cache = FsDetectionCache::new(std::env::temp_dir().join("calib-test-cache"));
         let err = build_planar_input(&spec, Path::new("/tmp"), &cache, false).unwrap_err();

--- a/crates/vision-calibration-pipeline/src/dataset_runner/poses.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/poses.rs
@@ -58,33 +58,36 @@ pub(crate) fn load_robot_poses(
             .collect();
     }
 
-    let rows: Vec<RawRow> = match source.format {
-        RobotPoseFormat::Csv => parse_csv_rows(&text, &path)?,
-        RobotPoseFormat::Json => {
-            let values: Vec<Value> =
-                serde_json::from_str(&text).map_err(|e| RunError::PoseParse {
-                    path: path.clone(),
-                    row: 0,
-                    message: format!("not a JSON array of objects: {e}"),
-                })?;
-            values
-                .into_iter()
-                .enumerate()
-                .map(|(i, v)| object_to_row(v, i, &path))
-                .collect::<Result<_, _>>()?
-        }
-        RobotPoseFormat::Jsonl => text
-            .lines()
-            .filter(|l| !l.trim().is_empty())
+    // The matrix-field shape (one nested 4×4 array per row) doesn't
+    // fit the string-valued `RawRow` funnel — handle it directly. The
+    // validator pinned the format to json/jsonl and the rotation
+    // format to matrix4x4_row_major.
+    if let Some(field) = &source.matrix_field {
+        return json_values(source.format, &text, &path)?
+            .into_iter()
             .enumerate()
-            .map(|(i, line)| {
-                let v: Value = serde_json::from_str(line).map_err(|e| RunError::PoseParse {
+            .map(|(i, v)| {
+                let matrix = v.get(field).ok_or_else(|| RunError::PoseParse {
                     path: path.clone(),
                     row: i,
-                    message: format!("invalid JSON object: {e}"),
+                    message: format!("matrix_field {field:?} not found in this row"),
                 })?;
-                object_to_row(v, i, &path)
+                let flat = flatten_matrix4x4(matrix).map_err(|message| RunError::PoseParse {
+                    path: path.clone(),
+                    row: i,
+                    message,
+                })?;
+                pose_from_matrix_values(&flat, i, convention, &path)
             })
+            .collect();
+    }
+
+    let rows: Vec<RawRow> = match source.format {
+        RobotPoseFormat::Csv => parse_csv_rows(&text, &path)?,
+        RobotPoseFormat::Json | RobotPoseFormat::Jsonl => json_values(source.format, &text, &path)?
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| object_to_row(v, i, &path))
             .collect::<Result<_, _>>()?,
         RobotPoseFormat::Rowmajor4x4 => {
             unreachable!("handled by the early return above")
@@ -95,6 +98,68 @@ pub(crate) fn load_robot_poses(
         .enumerate()
         .map(|(i, row)| parse_pose_row(row, i, source, convention, &path))
         .collect()
+}
+
+/// Parse a json (array of objects) or jsonl (object per line) file
+/// into raw row values.
+fn json_values(format: RobotPoseFormat, text: &str, path: &Path) -> Result<Vec<Value>, RunError> {
+    match format {
+        RobotPoseFormat::Json => {
+            serde_json::from_str::<Vec<Value>>(text).map_err(|e| RunError::PoseParse {
+                path: path.to_path_buf(),
+                row: 0,
+                message: format!("not a JSON array of objects: {e}"),
+            })
+        }
+        RobotPoseFormat::Jsonl => text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .enumerate()
+            .map(|(i, line)| {
+                serde_json::from_str(line).map_err(|e| RunError::PoseParse {
+                    path: path.to_path_buf(),
+                    row: i,
+                    message: format!("invalid JSON object: {e}"),
+                })
+            })
+            .collect(),
+        RobotPoseFormat::Csv | RobotPoseFormat::Rowmajor4x4 => {
+            unreachable!("json_values is only called for json/jsonl formats")
+        }
+    }
+}
+
+/// Flatten a nested `[[f64; 4]; 4]` or flat `[f64; 16]` JSON array into
+/// 16 row-major values.
+fn flatten_matrix4x4(value: &Value) -> Result<Vec<f64>, String> {
+    let Value::Array(outer) = value else {
+        return Err(format!("expected a 4×4 or flat-16 array, got {value}"));
+    };
+    let mut flat = Vec::with_capacity(16);
+    if outer.len() == 4 && outer.iter().all(|v| v.is_array()) {
+        for row in outer {
+            let Value::Array(cells) = row else {
+                unreachable!("all-array check above");
+            };
+            if cells.len() != 4 {
+                return Err(format!(
+                    "nested matrix row has {} cells, expected 4",
+                    cells.len()
+                ));
+            }
+            for c in cells {
+                flat.push(c.as_f64().ok_or_else(|| format!("{c} is not a number"))?);
+            }
+        }
+    } else {
+        for c in outer {
+            flat.push(c.as_f64().ok_or_else(|| format!("{c} is not a number"))?);
+        }
+    }
+    if flat.len() != 16 {
+        return Err(format!("matrix has {} values, expected 16", flat.len()));
+    }
+    Ok(flat)
 }
 
 /// One raw row: column name → string value. CSV and JSON funnel into
@@ -379,11 +444,24 @@ fn parse_matrix_row(
             ),
         });
     }
+    pose_from_matrix_values(&values, index, convention, path)
+}
 
-    // The validator pinned `rotation_format` to `Matrix4x4RowMajor`,
-    // so the shared rotation builder applies directly.
+/// Normalize 16 row-major matrix values into a `ParsedPose`. Shared by
+/// the headerless `rowmajor4x4` format and the json `matrix_field`
+/// shape; both pin `rotation_format` to `Matrix4x4RowMajor` in the
+/// validator. Translation comes from the matrix's fourth column,
+/// scaled by the declared units. `id` is always `None` — neither shape
+/// carries a pose-id column, so only `by_index` pairing can consume
+/// them.
+fn pose_from_matrix_values(
+    values: &[f64],
+    index: usize,
+    convention: &PoseConvention,
+    path: &Path,
+) -> Result<ParsedPose, RunError> {
     let rotation =
-        rotation_from_values(RotationFormat::Matrix4x4RowMajor, &values).map_err(|message| {
+        rotation_from_values(RotationFormat::Matrix4x4RowMajor, values).map_err(|message| {
             RunError::PoseParse {
                 path: path.to_path_buf(),
                 row: index,
@@ -528,6 +606,7 @@ mod tests {
             path: path.to_path_buf(),
             format,
             columns: Some(columns),
+            matrix_field: None,
         }
     }
 
@@ -641,6 +720,7 @@ mod tests {
             path: path.to_path_buf(),
             format: RobotPoseFormat::Rowmajor4x4,
             columns: None,
+            matrix_field: None,
         }
     }
 
@@ -829,5 +909,79 @@ mod tests {
         );
         let err = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap_err();
         assert!(format!("{err}").contains("quoted CSV"));
+    }
+
+    // ── matrix_field (ADR 0021) ─────────────────────────────────────────
+
+    fn matrix_field_source(path: &Path, format: RobotPoseFormat) -> RobotPoseSource {
+        RobotPoseSource {
+            path: path.to_path_buf(),
+            format,
+            columns: None,
+            matrix_field: Some("tcp2base".into()),
+        }
+    }
+
+    #[test]
+    fn matrix_field_nested_4x4_mm_roundtrip() {
+        // rtv3d shape: nested 4×4 array, translation in millimetres,
+        // tcp2base = T_B_G directly (TBaseTcp).
+        let json = r#"[
+            {"tcp2base": [[1,0,0,290.0],[0,1,0,15.0],[0,0,1,110.0],[0,0,0,1]],
+             "target_image": "target_0.png", "type": "double_snap"}
+        ]"#;
+        let (_dir, path) = write_temp(json, "json");
+        let src = matrix_field_source(&path, RobotPoseFormat::Json);
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::Mm,
+        );
+        let poses = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap();
+        assert_eq!(poses.len(), 1);
+        let p = &poses[0].base_se3_gripper;
+        assert!((p.translation.vector - Vector3::new(0.29, 0.015, 0.11)).norm() < 1e-12);
+        assert!(p.rotation.angle() < 1e-12);
+        assert!(poses[0].id.is_none(), "matrix rows carry no pose_id");
+    }
+
+    #[test]
+    fn matrix_field_flat_16_jsonl() {
+        let jsonl = r#"{"tcp2base": [1,0,0,0.5, 0,1,0,0, 0,0,1,0, 0,0,0,1]}"#;
+        let (_dir, path) = write_temp(jsonl, "jsonl");
+        let src = matrix_field_source(&path, RobotPoseFormat::Jsonl);
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::M,
+        );
+        let poses = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap();
+        assert_eq!(poses.len(), 1);
+        assert!((poses[0].base_se3_gripper.translation.x - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn matrix_field_missing_or_malformed_is_actionable() {
+        let json = r#"[{"pose": [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]}]"#;
+        let (_dir, path) = write_temp(json, "json");
+        let src = matrix_field_source(&path, RobotPoseFormat::Json);
+        let conv = convention(
+            TransformConvention::TBaseTcp,
+            RotationFormat::Matrix4x4RowMajor,
+            TranslationUnits::M,
+        );
+        let err = load_robot_poses(&src, &conv, path.parent().unwrap()).unwrap_err();
+        match err {
+            RunError::PoseParse { message, .. } => {
+                assert!(message.contains("tcp2base"), "got: {message}");
+            }
+            other => panic!("expected PoseParse, got {other:?}"),
+        }
+
+        let json = r#"[{"tcp2base": [[1,0,0],[0,1,0],[0,0,1]]}]"#;
+        let (_dir2, path2) = write_temp(json, "json");
+        let src2 = matrix_field_source(&path2, RobotPoseFormat::Json);
+        let err2 = load_robot_poses(&src2, &conv, path2.parent().unwrap()).unwrap_err();
+        assert!(matches!(err2, RunError::PoseParse { .. }));
     }
 }

--- a/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/rig.rs
@@ -93,14 +93,18 @@ pub fn build_rig_handeye_input(
     finish(views, spec.cameras.len(), core.view_paths, core.total_views)
 }
 
-/// Kept views (observations + pairing token), pre-meta.
-struct RigCore {
-    views: Vec<(RigViewObs, String)>,
-    view_paths: Vec<Vec<Option<PathBuf>>>,
-    total_views: usize,
+/// Kept views (observations + pairing token), pre-meta. Shared with
+/// the rig laserline converter (`laser.rs`), which pairs laser frames
+/// against `all_tokens` and attaches laser pixels to the kept views.
+pub(super) struct RigCore {
+    pub(super) views: Vec<(RigViewObs, String)>,
+    pub(super) view_paths: Vec<Vec<Option<PathBuf>>>,
+    /// Tokens of *all* paired views, pre-drop, in view order.
+    pub(super) all_tokens: Vec<String>,
+    pub(super) total_views: usize,
 }
 
-fn build_rig_core(
+pub(super) fn build_rig_core(
     spec: &DatasetSpec,
     base_dir: &Path,
     cache: &dyn DetectionCache,
@@ -202,6 +206,7 @@ fn build_rig_core(
     Ok(RigCore {
         views,
         view_paths,
+        all_tokens: paired.tokens,
         total_views,
     })
 }
@@ -301,6 +306,7 @@ mod tests {
                         paths: paths.iter().map(PathBuf::from).collect(),
                     },
                     roi_xywh: None,
+                    laser_images: None,
                 })
                 .collect(),
             target: TargetSpec::Chessboard {
@@ -309,6 +315,8 @@ mod tests {
                 square_size_m: 0.025,
             },
             robot_poses: None,
+            laser: None,
+            upstream_calibration: None,
             topology: Topology::RigExtrinsics,
             pose_pairing: Some(PosePairing::ByIndex),
             pose_convention: None,
@@ -428,6 +436,7 @@ mod tests {
                 tz: "tz".into(),
                 rotation: vec!["qx".into(), "qy".into(), "qz".into(), "qw".into()],
             }),
+            matrix_field: None,
         });
         spec.pose_convention = Some(PoseConvention {
             transform: TransformConvention::TBaseTcp,

--- a/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
@@ -3,8 +3,8 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    Camera, PerFeatureResiduals, Pinhole, ScheimpflugParams, build_feature_histogram,
-    compute_planar_target_residuals_views,
+    Camera, ImageManifest, PerFeatureResiduals, Pinhole, ScheimpflugParams,
+    build_feature_histogram, compute_planar_target_residuals_views,
 };
 use vision_calibration_linear::prelude::*;
 use vision_calibration_optim::{
@@ -200,6 +200,14 @@ pub struct LaserlineDeviceExport {
     /// `Some(vec![one_entry])`.
     #[serde(default)]
     pub per_feature_residuals: PerFeatureResiduals,
+
+    /// Optional image manifest (ADR 0014, viewer-side contract). One
+    /// frame per accepted view (pose = kept-view index, camera = 0),
+    /// pointing at the *target* image; laser-frame entries are
+    /// deferred to B-laser. `None` means "no images shipped"; the
+    /// calibration pipeline never reads this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_manifest: Option<ImageManifest>,
 }
 
 impl ProblemState for LaserlineDeviceProblem {
@@ -294,6 +302,9 @@ impl ProblemType for LaserlineDeviceProblem {
             mean_reproj_error: output.stats.mean_reproj_error,
             per_cam_reproj_errors: vec![output.stats.mean_reproj_error],
             per_feature_residuals,
+            // Manifest is populated by callers that have image paths;
+            // the pipeline never does.
+            image_manifest: None,
         })
     }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -117,13 +117,31 @@ puzzleboard / ringgrid) are supported.
     pose-to-view matching, `build_single_cam_handeye_input`,
     `image_manifest` on `SingleCamHandeyeExport`, Tauri dispatch arm,
     KUKA preset enabled over the committed `data/kuka_1` manifest
-    (no pose-file conversion needed after all). Remainder: laser
-    topologies (need the laser-frame manifest ADR), puzzleboard +
-    ringgrid detectors, bench/examples-private charuco dedup.
+    (no pose-file conversion needed after all).
+  - **B3c-3 (2026-06-12): laser topologies SHIPPED** —
+    [ADR 0021](adrs/0021-laser-frame-manifest.md): `laser_images` per
+    camera + `[laser]` extraction spec + `upstream_calibration` +
+    `matrix_field` pose shape in `DatasetSpec`; injected
+    `LaserPixelExtractor` (vision-metrology is not on crates.io — the
+    app implements it, published crates only define the trait);
+    `build_laserline_device_input` / `build_rig_laserline_device_input`
+    (frozen `RigHandeyeExport` → per-view `rig_se3_target` via the
+    hand-eye chain); both Tauri dispatch arms; `image_manifest` on
+    `LaserlineDeviceExport`; rtv3d presets with per-preset
+    `configOverrides`. Two-stage rtv3d acceptance
+    (`rtv3d_laser_end_to_end`): hand-eye 1.56 px, all six planes at
+    0.85–1.15 mm point-to-plane against the frozen upstream (sub-0.1 mm
+    needs the V5 joint-BA runner). Remainder of B3c: puzzleboard +
+    ringgrid detectors, bench/examples-private charuco dedup; in-app
+    "save export to file" (needed to run the two-stage laser flow
+    without leaving the app) moves to B3e.
 - **B-laser — laserline visualization.** Laser-pixel overlay in
   Diagnose; laser plane-fit residuals (point-to-plane mm) alongside
   reprojection residuals; laser planes rendered in the 3D rig viewer.
-  No laser data is visible anywhere in the app today.
+  The laser topologies *run* in the app since B3c-3 (and the laser
+  exports carry `per_feature_residuals.laser`), but no laser pixels or
+  planes are rendered anywhere yet; `ImageManifest` also still lacks
+  laser-frame entries (ADR 0021 §5).
 - **B-explore — dataset exploration.** Browse a dataset *before*
   calibrating: image grid per camera/pose, detection overlay from the
   cache, board coverage map. Today the app only visualizes exports.

--- a/docs/adrs/0021-laser-frame-manifest.md
+++ b/docs/adrs/0021-laser-frame-manifest.md
@@ -1,0 +1,135 @@
+# ADR 0021: Laser-Frame Dataset Manifest
+
+- Status: Accepted
+- Date: 2026-06-12
+
+## Context
+
+The Run workspace covers five of the seven topologies; `LaserlineDevice`
+and `RigLaserlineDevice` still hit an `unsupported_topology` arm because
+the `DatasetSpec` manifest (ADR 0016) cannot describe laser data. Three
+gaps block them:
+
+1. **Laser images.** Laserline calibration consumes per-view laser-line
+   pixels extracted from a *second* image per `(view, camera)` slot —
+   the laser frame, captured with the line projector on (rtv3d:
+   `target_N.png` + `laser_N.png` pairs).
+2. **Laser extraction.** The validated subpixel extractor lives in
+   [`vision-metrology`](https://github.com/VitalyVorobyev/vision-metrology),
+   which is **not on crates.io**. `vision-calibration-detect` and
+   `-pipeline` are published crates; a git dependency — even optional —
+   would break `cargo publish`.
+3. **Upstream calibration.** `RigLaserlineDevice` consumes a *frozen*
+   rig hand-eye result (`RigUpstreamCalibration`). The manifest needs a
+   way to reference it, and the runner needs the per-view
+   `rig_se3_target` poses, which the frozen export alone does not carry
+   for the laser dataset's views.
+
+Additionally, the rtv3d robot-pose file (`poses.json`) stores each pose
+as a nested 4×4 matrix field (`tcp2base`), which the tabular
+`PoseColumnMap` (scalar columns only) cannot express.
+
+## Decision
+
+### 1. Manifest extensions (`vision-calibration-dataset`)
+
+- `CameraSource.laser_images: Option<ImagePattern>` — per-camera laser
+  image source. The camera's `roi_xywh` applies to laser frames too
+  (same physical sensor; rtv3d's 6-tile strips reuse one file per view
+  with per-camera ROIs, exactly like the target frames).
+- `DatasetSpec.laser: Option<LaserExtractionSpec>` — extraction
+  parameters: `scan_axis` (`cols` | `rows`, default `cols`), `sigma`
+  (1.2), `pos_thresh` / `neg_thresh` (4.0), `min_points` (20). Like
+  detector params, these are algorithm tuning with safe defaults — an
+  omitted `[laser]` table is **not** an ADR 0019 ambiguity.
+- `DatasetSpec.upstream_calibration: Option<PathBuf>` — path (relative
+  to the manifest dir) to a frozen `RigHandeyeExport` JSON. Required
+  for `RigLaserlineDevice`, rejected elsewhere.
+- `RobotPoseSource.matrix_field: Option<String>` — for `json` / `jsonl`
+  pose files whose rows carry the whole pose as one nested 4×4 (or
+  flat-16) array field. Mutually exclusive with `columns`; requires
+  `rotation_format = matrix4x4_row_major`. Translation comes from the
+  matrix's fourth column (scaled by `translation_units`), mirroring
+  `rowmajor4x4`. No `pose_id` ⇒ `by_index` pairing only.
+
+Validation (fail-fast, ADR 0019): laser fields on a non-laser topology
+are rejected, not ignored; `LaserlineDevice` requires `laser_images` on
+its camera; `RigLaserlineDevice` requires `laser_images` on **every**
+camera (a camera without laser views has an unconstrained plane), plus
+`robot_poses`, `pose_convention`, and `upstream_calibration`.
+
+### 2. Laser-frame pairing
+
+Laser images pair with target views through the existing
+`pose_pairing` mechanism — no second pairing config:
+
+- `by_index` — the camera's laser list must have exactly one image per
+  paired view (count match enforced).
+- `shared_filename_token` — the same regex/group extracts the view
+  token from laser filenames. A laser token with no target view is an
+  error (the regex is almost certainly wrong); a target view without a
+  laser image is a gap (`None` laser slot for rigs; dropped view for
+  the single-camera topology, which requires laser pixels per view).
+
+### 3. Injected laser extraction (the publishing constraint)
+
+The pipeline defines an **open** trait (unlike the sealed `Detector`):
+
+```rust
+pub trait LaserPixelExtractor: Send + Sync {
+    fn name(&self) -> &str; // stable id, part of the cache key
+    fn extract(&self, image: &DynamicImage, spec: &LaserExtractionSpec)
+        -> anyhow::Result<Vec<[f64; 2]>>;
+}
+```
+
+The laser converters take `&dyn LaserPixelExtractor`. The pipeline owns
+everything around the call: bytes → cache lookup → decode → ROI crop →
+extract → lift to source coordinates → cache store. Implementations:
+
+- **Tauri app** (`app/src-tauri`, unpublished): wraps
+  `vision_metrology::LaserExtractor` via a git dependency.
+- **Tests**: a deterministic fake.
+
+Cached laser pixels reuse the ADR 0017 cache with detector name
+`laser:<extractor-name>` and the canonical JSON of
+`LaserExtractionSpec` (+ `_roi`) as the config hash. Pixels are stored
+as `Feature`s with `world_xyz = [0,0,0]` — laser points have no target
+coordinates; the zero is documented, not meaningful.
+
+### 4. Upstream calibration loading
+
+`build_rig_laserline_device_input` reads the `RigHandeyeExport` JSON,
+checks its camera count against the manifest, computes per-view
+`rig_se3_target` from the laser dataset's **own robot poses** through
+the frozen hand-eye chain —
+
+- `EyeInHand`: `T_R_T = T_G_R⁻¹ · T_B_G⁻¹ · T_B_T`
+- `EyeToHand`: `T_R_T = T_R_B · T_B_G · T_G_T`
+
+— and calls `RigHandeyeExport::to_upstream_calibration`. The laser
+views therefore do **not** need to match the upstream calibration's
+views; only the robot must revisit poses with the target in view.
+Pinhole rigs work (zero Scheimpflug tilt = identity sensor).
+
+### 5. Export manifests
+
+`LaserlineDeviceExport` gains `image_manifest` (the last `*Export`
+without one). Both laser exports get the manifest spliced by the Tauri
+runner from the **target** frames. Laser-frame entries in
+`ImageManifest` are deferred to B-laser (the visualization slice) —
+`FrameRef` has no frame-kind discriminator yet, and nothing renders
+laser pixels today.
+
+## Consequences
+
+- The laser topologies run end-to-end in the Run workspace; B-laser
+  (overlay + plane residual visualization) is unblocked.
+- Published crates stay free of non-crates.io dependencies; if
+  vision-metrology is ever published, a default `LaserPixelExtractor`
+  impl can move into `vision-calibration-detect` behind a feature.
+- Library consumers driving the laser converters must supply an
+  extractor; there is deliberately no built-in fallback extractor in
+  published code.
+- The `laser:<name>` cache namespace means switching extractor
+  implementations re-detects rather than serving stale pixels.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -41,3 +41,4 @@ Status legend:
 - [0018 - Schema-Driven UI for Configs and Dataset Manifests](0018-schema-driven-ui.md)
 - [0019 - Fail Fast on Ambiguity (`AskUser` runtime contract)](0019-fail-fast-on-ambiguity.md)
 - [0020 - Camera Model as Data in the Factor IR](0020-camera-model-as-data-factor-ir.md)
+- [0021 - Laser-Frame Dataset Manifest](0021-laser-frame-manifest.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -13,6 +13,7 @@ authoritative reference and stays green in CI.
 | Seed prior knowledge into the pipeline (datasheet K, factory tilts, mechanical drawings) | [Manual initialization](./manual-init.md) | [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs) |
 | Drill into per-corner reprojection errors (diagnose mode) | [Per-feature residuals](./per-feature-residuals.md) | [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs) (Run A printout) |
 | Calibrate a Scheimpflug rig + laser device end-to-end on real data | [Puzzle 130×130 walkthrough](./puzzle-130x130-walkthrough.md) | [`puzzle_130x130_rig.rs`](../../crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs) (private dataset) |
+| Describe a laser dataset in `dataset.toml` and run it through the app | [Laser dataset manifest](./laser-dataset-manifest.md) | `rtv3d_laser_end_to_end` test in [`app/src-tauri/src/run.rs`](../../app/src-tauri/src/run.rs) (private dataset) |
 
 ## Structure
 

--- a/docs/tutorials/laser-dataset-manifest.md
+++ b/docs/tutorials/laser-dataset-manifest.md
@@ -1,0 +1,136 @@
+# Laser topologies from a dataset manifest
+
+How to describe a laser-triangulation dataset in `dataset.toml` so the
+Run workspace (or the `dataset_runner` API) can calibrate
+`LaserlineDevice` / `RigLaserlineDevice` end-to-end. Design record:
+[ADR 0021](../adrs/0021-laser-frame-manifest.md).
+
+## Why
+
+A laser-triangulation device captures **two frames per view**: a target
+frame (board, projector off) and a laser frame (projector on). The
+manifest describes both; the runner detects target features, extracts
+laser-line pixels (cached like detections), and assembles the problem
+input — including, for the rig topology, the frozen upstream rig
+hand-eye calibration.
+
+## Mental model
+
+- `laser_images` per camera mirrors `images` and pairs with target
+  views through the same `pose_pairing` (`by_index`: i-th laser ↔ i-th
+  target; `shared_filename_token`: same regex on both filename sets).
+  A target view without a laser frame is a gap; a laser frame without
+  a target view is an error.
+- `[laser]` tunes extraction (`scan_axis`, `sigma`, thresholds,
+  `min_points`). Omit it for defaults — extraction tuning is not a
+  fail-fast ambiguity.
+- `RigLaserlineDevice` is a *second stage*: `upstream_calibration`
+  points at a frozen `RigHandeyeExport` JSON. Per-view board poses are
+  recomputed from the laser dataset's own robot poses through the
+  frozen hand-eye chain, so the laser views do not need to match the
+  upstream run's views.
+
+## Walkthrough — rig laserline (rtv3d shape)
+
+```toml
+version = 1
+topology = "rig_laserline_device"
+upstream_calibration = "rig_handeye_export.json"
+
+[target]
+kind = "charuco"
+rows = 22
+cols = 22
+square_size_m = 0.0052
+marker_size_m = 0.0039
+dictionary = "DICT_4X4_1000"
+
+[laser]
+min_points = 120          # views below the bar become gap slots
+
+[robot_poses]
+path = "poses.json"
+format = "json"
+matrix_field = "tcp2base" # nested 4x4 per row (vendor JSON)
+
+[pose_convention]
+transform = "t_base_tcp"
+rotation_format = "matrix4x4_row_major"
+translation_units = "mm"
+
+[pose_pairing]
+kind = "by_index"
+
+[[cameras]]
+id = "cam0"
+roi_xywh = [0, 0, 720, 540]   # tile 0 of the 6-camera strip
+[cameras.images]
+kind = "glob"
+pattern = "target_*.png"
+[cameras.laser_images]
+kind = "glob"
+pattern = "laser_*.png"
+# … one [[cameras]] entry per tile …
+```
+
+Run the hand-eye stage first (`topology = "rig_handeye"`, same cameras
+and poses, no laser fields) and save its export as
+`rig_handeye_export.json`. In the app, both stages are one Run click
+each; the rtv3d presets carry the right config overrides
+(Scheimpflug sensors, EyeToHand, `PointToPlane` laser residuals).
+
+Single-camera `LaserlineDevice` is the same minus `robot_poses` /
+`upstream_calibration` — it calibrates intrinsics and the laser plane
+jointly from the target + laser frames alone.
+
+## Library consumers: inject an extractor
+
+The published crates do not ship a laser extractor (the reference
+implementation, `vision-metrology`, is not on crates.io). Implement
+the open trait and hand it to the converter:
+
+```rust
+use vision_calibration_pipeline::dataset_runner::{
+    LaserPixelExtractor, build_rig_laserline_device_input,
+};
+
+struct MyExtractor;
+impl LaserPixelExtractor for MyExtractor {
+    fn name(&self) -> &str { "my-extractor-v1" } // cache-key namespace
+    fn extract(
+        &self,
+        image: &image::DynamicImage,
+        spec: &vision_calibration_dataset::LaserExtractionSpec,
+    ) -> anyhow::Result<Vec<[f64; 2]>> {
+        // subpixel laser-line points in the (ROI-cropped) image
+        todo!()
+    }
+}
+
+let run = build_rig_laserline_device_input(
+    &spec, base_dir, &cache, &MyExtractor, false,
+)?;
+```
+
+The runner owns caching (keyed `laser:<name>` + extraction-spec hash),
+ROI cropping, and coordinate lifting — the extractor only extracts.
+The Tauri app's implementation is
+[`app/src-tauri/src/laser.rs`](../../app/src-tauri/src/laser.rs).
+
+## Common variations
+
+- **Sparse laser coverage (rig):** cameras may miss the laser in some
+  views (`None` slots), but every camera needs ≥1 usable laser view —
+  otherwise its plane is unconstrained and the runner fails fast.
+- **Vertical laser lines:** `scan_axis = "rows"` (one point per row).
+- **Re-extraction:** edit `[laser]` and the cache key changes —
+  nothing stale is served. Same contract as detector configs
+  (ADR 0017).
+
+## What to read next
+
+- [ADR 0021](../adrs/0021-laser-frame-manifest.md) — design decisions
+  and the publishing constraint behind the injected extractor.
+- [ADR 0016](../adrs/0016-dataset-manifest.md) — the manifest itself.
+- `app/src-tauri/src/run.rs` (`rtv3d_laser_end_to_end`) — the
+  two-stage acceptance test over the rtv3d dataset.


### PR DESCRIPTION
## Summary

Closes the last `unsupported_topology` arm in the Run workspace: `LaserlineDevice` and `RigLaserlineDevice` now run end-to-end from a `dataset.toml` manifest. One branch / one PR covering ADR 0021, the manifest extension, the injected laser extractor, both converters, Tauri dispatch, and the app TS side.

### Design (ADR 0021 — `docs/adrs/0021-laser-frame-manifest.md`)

- **Laser frames in the manifest**: `CameraSource.laser_images` (paired with target views via the existing `pose_pairing` — no second pairing config), top-level `[laser]` extraction spec with safe defaults, `upstream_calibration` path for the rig topology.
- **Injected extraction**: `vision-metrology` is not on crates.io and `vision-calibration-{detect,pipeline}` are published, so a git dep would break `cargo publish`. The pipeline defines an open `LaserPixelExtractor` trait and owns caching (`laser:<name>` ADR 0017 namespace), ROI cropping, and coordinate lifting; the unpublished Tauri app wraps `vision_metrology::LaserExtractor`.
- **Upstream loading**: the rig converter reads a frozen `RigHandeyeExport` JSON and computes per-view `rig_se3_target` from the laser dataset's own robot poses through the hand-eye chain (both `EyeInHand` and `EyeToHand`), so laser views need not match the upstream run's views. Pinhole rigs get zero-tilt sensors.
- **`matrix_field` pose shape**: json/jsonl rows that store the whole pose as one nested 4×4 array field (rtv3d's `tcp2base`), validated to `matrix4x4_row_major` + `by_index`.
- `LaserlineDeviceExport` gains `image_manifest` (finishing the B3c manifest sweep); laser-frame manifest entries are deferred to B-laser.

### Acceptance on real data

`rtv3d_laser_end_to_end` (ignored test, local `privatedata/rtv3d`): rig hand-eye through the app runner at **1.56 px** over 20 views (in line with the V-track example's hand-eye stage), then `RigLaserlineDevice` over the frozen export recovers **all six laser planes at 0.85–1.15 mm** point-to-plane. Sub-0.1 mm needs the joint BA (V5, out of scope). The stereo / charuco / kuka E2E presets still pass.

### App

- Both laser topology cards enabled (schemas were already emitted).
- rtv3d presets (local-only manifests, gitignored like `data/stereo*`) with new per-preset `configOverrides` deep-merged over `default_config_cmd` defaults — rtv3d needs Scheimpflug sensors + EyeToHand, which defaults can't know.
- In-app "save export to file" (to run the two-stage flow without leaving the app) moved to B3e and noted in the roadmap.

### Gates

`cargo fmt --check` ✓ · `clippy --workspace --all-targets --all-features -D warnings` ✓ · `cargo test --workspace --all-features` ✓ (39 suites) · `RUSTDOCFLAGS=-D warnings cargo doc` ✓ · `python3 -m compileall` ✓ · app crate clippy + tests ✓ · `bun run build` ✓ · all three ignored E2E suites ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)