### PR TITLE
B-laser: laserline visualization (laser frames in manifest, Diagnose overlay, 3D planes)

### DIFF
--- a/app/scripts/ui_smoke_rtv3d.py
+++ b/app/scripts/ui_smoke_rtv3d.py
@@ -1,0 +1,139 @@
+"""UI smoke test: drive the frontend against the real rtv3d exports.
+
+Catches viewer-contract crashes (uncaught exceptions / the router's
+error boundary) that Rust-side tests can't see — e.g. an export kind
+missing a field the TS code dereferences, like the
+`data.mean_reproj_error.toFixed` crash on the laser export. Local-only:
+needs the gitignored privatedata/rtv3d exports (produced by the
+`rtv3d_laser_end_to_end` ignored test) and `pip install playwright`.
+
+Run from `app/`:
+
+    bun run dev &           # Vite at :1420
+    python3 scripts/ui_smoke_rtv3d.py
+
+The Vite dev server has no Tauri runtime, so image loading fails with a
+handled error banner — expected and filtered.
+"""
+
+import json
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+ROOT = str(pathlib.Path(__file__).resolve().parents[2])
+LASER_EXPORT = f"{ROOT}/privatedata/rtv3d/rig_laserline_export.json"
+HANDEYE_EXPORT = f"{ROOT}/privatedata/rtv3d/rig_handeye_export.json"
+
+if not pathlib.Path(LASER_EXPORT).exists():
+    print(f"skipping: {LASER_EXPORT} not present (run rtv3d_laser_end_to_end first)")
+    sys.exit(0)
+
+INJECT = """async (payload) => {
+  const mod = await import('/src/store/index.ts');
+  mod.useStore.getState().acceptLiveRunExport(payload.data, payload.dir);
+  return mod.useStore.getState().kind;
+}"""
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    status = "ok" if cond else "FAIL"
+    print(f"[{status}] {name}" + (f" — {detail}" if detail else ""))
+    if not cond:
+        failures.append(f"{name}: {detail}")
+
+
+def crashed(page):
+    """The router's error boundary renders this on any uncaught render error."""
+    return page.locator("text=Unexpected Application Error").count() > 0
+
+
+def run_workspace_suite(page, label, export_path, expect_kind, expect_laser):
+    data = json.load(open(export_path))
+    page.goto("http://localhost:1420/#/diagnose")
+    page.wait_for_load_state("networkidle")
+    kind = page.evaluate(INJECT, {"data": data, "dir": f"{ROOT}/privatedata/rtv3d"})
+    check(f"{label}: store kind", kind == expect_kind, f"got {kind}")
+    page.wait_for_timeout(800)
+
+    # ── Diagnose ──────────────────────────────────────────────────────
+    check(f"{label}: diagnose no crash", not crashed(page))
+    chip = page.locator("text=mean reproj:")
+    check(f"{label}: mean reproj chip", chip.count() > 0)
+    laser_btn = page.get_by_role("button", name="Laser", exact=True)
+    if expect_laser:
+        check(f"{label}: Laser toggle present", laser_btn.count() == 1)
+        laser_btn.click()
+        page.wait_for_timeout(600)
+        check(f"{label}: laser view no crash", not crashed(page))
+        check(
+            f"{label}: laser legend",
+            page.locator("text=laser pts").count() > 0,
+            "mm stats legend visible",
+        )
+        page.screenshot(path=f"/tmp/{label}_diagnose_laser.png")
+        # Toggle back so the next steps see target view.
+        page.get_by_role("button", name="Laser ✓").click()
+    else:
+        check(f"{label}: Laser toggle hidden", laser_btn.count() == 0)
+
+    # ── 3D viewer ─────────────────────────────────────────────────────
+    page.goto("http://localhost:1420/#/viewer3d")
+    page.wait_for_load_state("networkidle")
+    page.wait_for_timeout(2500)  # lazy chunk + R3F first frame
+    check(f"{label}: 3D no crash", not crashed(page))
+    check(
+        f"{label}: 3D scene mounted (not the rig-export fallback)",
+        page.locator("canvas").count() > 0,
+        f"needs cameras+cam_se3_rig+rig_se3_target on {expect_kind}",
+    )
+    planes_btn = page.get_by_role("button", name="Laser planes ✓")
+    if expect_laser:
+        check(f"{label}: 3D laser-planes toggle on", planes_btn.count() == 1)
+        page.screenshot(path=f"/tmp/{label}_viewer3d_planes.png")
+        planes_btn.click()
+        page.wait_for_timeout(400)
+        check(f"{label}: 3D toggle off no crash", not crashed(page))
+    else:
+        check(f"{label}: 3D laser-planes toggle hidden", planes_btn.count() == 0)
+
+    # ── Epipolar (must degrade gracefully, not crash) ────────────────
+    page.goto("http://localhost:1420/#/epipolar")
+    page.wait_for_load_state("networkidle")
+    page.wait_for_timeout(600)
+    check(f"{label}: epipolar no crash", not crashed(page))
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, args=["--enable-unsafe-swiftshader"])
+    page = browser.new_page()
+    page_errors = []
+    page.on("pageerror", lambda e: page_errors.append(str(e)))
+
+    run_workspace_suite(
+        page, "laser", LASER_EXPORT, "rig_laserline_device", expect_laser=True
+    )
+    run_workspace_suite(
+        page, "handeye", HANDEYE_EXPORT, "rig_handeye", expect_laser=False
+    )
+
+    # Tauri invoke failures are expected in a plain browser; anything
+    # else uncaught is a real bug.
+    real_errors = [
+        e
+        for e in page_errors
+        if "invoke" not in e and "__TAURI" not in e and "Tauri" not in e
+    ]
+    check("no uncaught page errors", not real_errors, "; ".join(real_errors[:3]))
+    browser.close()
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("ALL CHECKS PASSED")

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -962,6 +962,16 @@ mod tests {
         .unwrap();
         let planes = laser.export["laser_planes_cam"].as_array().unwrap();
         assert_eq!(planes.len(), 6, "one laser plane per camera");
+        // Viewer contract: the export must be self-contained for the
+        // 3D / diagnose workspaces (frozen upstream echo + headline
+        // reprojection number).
+        assert_eq!(laser.export["cameras"].as_array().unwrap().len(), 6);
+        assert_eq!(laser.export["cam_se3_rig"].as_array().unwrap().len(), 6);
+        assert_eq!(
+            laser.export["rig_se3_target"].as_array().unwrap().len(),
+            laser.usable_views
+        );
+        assert!(laser.export["mean_reproj_error"].is_number());
         let stats = laser.export["per_camera_stats"].as_array().unwrap();
         assert_eq!(stats.len(), 6);
         for (cam, s) in stats.iter().enumerate() {

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -952,6 +952,14 @@ mod tests {
             RunResponse::Ok(s) => s,
             other => panic!("rig laserline stage: expected Ok, got {other:?}"),
         };
+        // Persist the stage-2 export so the app can open it (laser
+        // overlay + 3D planes). Stop-gap until B3e ships in-app
+        // "save export to file".
+        std::fs::write(
+            data_dir.join("rig_laserline_export.json"),
+            serde_json::to_string(&laser.export).unwrap(),
+        )
+        .unwrap();
         let planes = laser.export["laser_planes_cam"].as_array().unwrap();
         assert_eq!(planes.len(), 6, "one laser plane per camera");
         let stats = laser.export["per_camera_stats"].as_array().unwrap();

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -968,10 +968,26 @@ mod tests {
                 "cam {cam}: mean laser residual {laser_err:.6} m"
             );
         }
+        // The manifest must carry both frame kinds (ADR 0021 §5): the
+        // target frames for the reprojection overlay and the laser
+        // frames Diagnose's laser view plots residuals onto.
+        let frames = laser.export["image_manifest"]["frames"].as_array().unwrap();
+        let n_laser = frames.iter().filter(|f| f["kind"] == "laser").count();
+        let n_target = frames.len() - n_laser;
+        assert!(n_target > 0, "manifest carries target frames");
         assert!(
-            laser.export["image_manifest"]["frames"].is_array(),
-            "laser export carries the target-frame manifest"
+            n_laser > 0,
+            "manifest carries laser-kind frames ({} total)",
+            frames.len()
         );
+        let laser_residuals = laser.export["per_feature_residuals"]["laser"]
+            .as_array()
+            .unwrap();
+        assert!(
+            !laser_residuals.is_empty(),
+            "laser export carries per-pixel laser residuals"
+        );
+        eprintln!("manifest: {n_target} target + {n_laser} laser frames");
         eprintln!(
             "rtv3d laser E2E: handeye {mean_px:.3} px over {} views; laser stage {} views in {} ms",
             handeye.usable_views, laser.usable_views, laser.duration_ms

--- a/app/src-tauri/src/run.rs
+++ b/app/src-tauri/src/run.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
-use vision_calibration_core::{FrameRef, ImageManifest, PlanarDataset, RigDataset};
+use vision_calibration_core::{FrameKind, FrameRef, ImageManifest, PlanarDataset, RigDataset};
 use vision_calibration_dataset::{DatasetSpec, Topology};
 use vision_calibration_detect::FsDetectionCache;
 use vision_calibration_pipeline::dataset_runner::{
@@ -398,12 +398,12 @@ fn run_laserline_topology(
             Ok(v) => v,
             Err(boxed) => return *boxed,
         };
-    // Single camera ⇒ the planar manifest shape (pose = kept-view
-    // index, camera = 0) over the *target* frames; laser-frame
-    // manifest entries are deferred to B-laser (ADR 0021 §5).
+    // Single camera ⇒ planar manifest shape (pose = kept-view index,
+    // camera = 0) for the target frames, plus the aligned laser frames
+    // (ADR 0021 §5).
     if let Err(boxed) = splice_image_manifest(
         &mut export,
-        planar_image_manifest(&laser_run.view_paths, base_dir),
+        laserline_image_manifest(&laser_run.view_paths, &laser_run.laser_paths, base_dir),
     ) {
         return *boxed;
     }
@@ -438,6 +438,7 @@ fn run_rig_laserline_topology(
     let usable_views = laser_run.usable_views;
     let total_views = laser_run.total_views;
     let view_paths = laser_run.view_paths.clone();
+    let laser_paths = laser_run.laser_paths.clone();
 
     let mut export = match run_session::<RigLaserlineDeviceProblem>(
         laser_run.input,
@@ -447,9 +448,10 @@ fn run_rig_laserline_topology(
         Ok(v) => v,
         Err(boxed) => return *boxed,
     };
-    if let Err(boxed) =
-        splice_image_manifest(&mut export, rig_image_manifest(&view_paths, base_dir))
-    {
+    if let Err(boxed) = splice_image_manifest(
+        &mut export,
+        rig_laserline_image_manifest(&view_paths, &laser_paths, base_dir),
+    ) {
         return *boxed;
     }
 
@@ -519,6 +521,57 @@ fn planar_image_manifest(view_paths: &[PathBuf], base_dir: &Path) -> Result<Imag
     Ok(manifest_from_frames(frames))
 }
 
+/// Single-camera laser manifest: target frames (kind omitted in JSON)
+/// plus one laser frame per kept view (ADR 0021 §5). `view_paths` and
+/// `laser_paths` are aligned by kept-view index.
+fn laserline_image_manifest(
+    view_paths: &[PathBuf],
+    laser_paths: &[PathBuf],
+    base_dir: &Path,
+) -> Result<ImageManifest, String> {
+    let base_abs = canonical_base(base_dir)?;
+    let mut frames = Vec::with_capacity(view_paths.len() + laser_paths.len());
+    for (pose, path) in view_paths.iter().enumerate() {
+        frames.push(frame_ref(pose, 0, path, &base_abs)?);
+    }
+    for (pose, path) in laser_paths.iter().enumerate() {
+        frames.push(frame_ref_of_kind(pose, 0, path, &base_abs, FrameKind::Laser)?);
+    }
+    Ok(manifest_from_frames(frames))
+}
+
+/// Rig laser manifest: target frames plus laser frames per
+/// `(view, camera)` slot that contributed a usable laser observation.
+fn rig_laserline_image_manifest(
+    view_paths: &[Vec<Option<PathBuf>>],
+    laser_paths: &[Vec<Option<PathBuf>>],
+    base_dir: &Path,
+) -> Result<ImageManifest, String> {
+    let base_abs = canonical_base(base_dir)?;
+    let mut frames = Vec::new();
+    for (pose, cameras) in view_paths.iter().enumerate() {
+        for (camera, maybe_path) in cameras.iter().enumerate() {
+            if let Some(path) = maybe_path {
+                frames.push(frame_ref(pose, camera, path, &base_abs)?);
+            }
+        }
+    }
+    for (pose, cameras) in laser_paths.iter().enumerate() {
+        for (camera, maybe_path) in cameras.iter().enumerate() {
+            if let Some(path) = maybe_path {
+                frames.push(frame_ref_of_kind(
+                    pose,
+                    camera,
+                    path,
+                    &base_abs,
+                    FrameKind::Laser,
+                )?);
+            }
+        }
+    }
+    Ok(manifest_from_frames(frames))
+}
+
 /// Build a rig manifest from `view_paths[view][camera]` — one frame
 /// per `(view, camera)` slot that contributed a usable observation.
 fn rig_image_manifest(
@@ -558,6 +611,18 @@ fn frame_ref(pose: usize, camera: usize, path: &Path, base_abs: &Path) -> Result
     frame.pose = pose;
     frame.camera = camera;
     frame.path = rel.to_path_buf();
+    Ok(frame)
+}
+
+fn frame_ref_of_kind(
+    pose: usize,
+    camera: usize,
+    path: &Path,
+    base_abs: &Path,
+    kind: FrameKind,
+) -> Result<FrameRef, String> {
+    let mut frame = frame_ref(pose, camera, path, base_abs)?;
+    frame.kind = kind;
     Ok(frame)
 }
 
@@ -720,6 +785,43 @@ mod tests {
             !manifest.frames.iter().any(|f| f.pose == 1 && f.camera == 1),
             "None slots must not produce frames"
         );
+    }
+
+    #[test]
+    fn laser_manifests_emit_both_frame_kinds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        std::fs::create_dir_all(base.join("cam0")).unwrap();
+        for name in ["cam0/t0.png", "cam0/t1.png", "cam0/l0.png", "cam0/l1.png"] {
+            std::fs::write(base.join(name), b"x").unwrap();
+        }
+
+        // Single-camera: target + laser frames aligned by kept-view index.
+        let manifest = laserline_image_manifest(
+            &[base.join("cam0/t0.png"), base.join("cam0/t1.png")],
+            &[base.join("cam0/l0.png"), base.join("cam0/l1.png")],
+            base,
+        )
+        .unwrap();
+        assert_eq!(manifest.target_frames().count(), 2);
+        assert_eq!(manifest.laser_frames().count(), 2);
+        let laser = manifest.frame_of_kind(1, 0, FrameKind::Laser).unwrap();
+        assert_eq!(laser.path, PathBuf::from("cam0/l1.png"));
+        // `frame()` stays target-only despite the laser entry for (1, 0).
+        assert_eq!(
+            manifest.frame(1, 0).unwrap().path,
+            PathBuf::from("cam0/t1.png")
+        );
+
+        // Rig: None laser slots produce no frames.
+        let manifest = rig_laserline_image_manifest(
+            &[vec![Some(base.join("cam0/t0.png"))]],
+            &[vec![None]],
+            base,
+        )
+        .unwrap();
+        assert_eq!(manifest.laser_frames().count(), 0);
+        assert_eq!(manifest.target_frames().count(), 1);
     }
 
     #[test]

--- a/app/src/components/FrameCanvas.tsx
+++ b/app/src/components/FrameCanvas.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import type {
   FrameKey,
+  LaserFeatureResidual,
   TargetFeatureResidual,
   ViewportTransform,
 } from "../types";
@@ -19,6 +20,11 @@ interface FrameCanvasProps {
   /** Target residuals for the loaded export; filtered down to
    * `frame.{pose, camera}` before drawing. */
   residuals: TargetFeatureResidual[];
+  /** Laser residuals to plot instead of target arrows — pass them when
+   * `frame` is a laser-kind frame (with `residuals={[]}`). Observed
+   * pixels are colored by point-to-plane distance; the projected laser
+   * line is drawn from the first record that carries endpoints. */
+  laserResiduals?: LaserFeatureResidual[];
   /** Decoded image element. `null` while loading. */
   image: HTMLImageElement | null;
   /** Controlled transform. When provided, the canvas treats it as
@@ -65,6 +71,7 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
     {
       frame,
       residuals,
+      laserResiduals,
       image,
       transform: controlled,
       onTransformChange,
@@ -262,7 +269,10 @@ export const FrameCanvas = forwardRef<FrameCanvasHandle, FrameCanvasProps>(
       const sh = roi?.h ?? image.naturalHeight;
       ctx.drawImage(image, sx, sy, sw, sh, 0, 0, sw, sh);
       drawResidualArrows(ctx, residuals, frame, transform.scale);
-    }, [image, container, transform, roi, residuals, frame]);
+      if (laserResiduals) {
+        drawLaserOverlay(ctx, laserResiduals, frame, transform.scale);
+      }
+    }, [image, container, transform, roi, residuals, laserResiduals, frame]);
 
     return (
       <div
@@ -366,4 +376,49 @@ export function colorForError(err: number): string {
   if (err < 5) return "#f1c40f";
   if (err < 10) return "#e67e22";
   return "#e74c3c";
+}
+
+/** Color scale for laser point-to-plane distance in millimeters.
+ * Thresholds follow the device norm (<0.2 mm plane σ is healthy);
+ * same palette as `colorForError` so the two legends read alike. */
+export function colorForLaserError(mm: number): string {
+  if (mm < 0.2) return "#1abc9c";
+  if (mm < 0.5) return "#2ecc71";
+  if (mm < 1.0) return "#f1c40f";
+  if (mm < 2.0) return "#e67e22";
+  return "#e74c3c";
+}
+
+function drawLaserOverlay(
+  ctx: CanvasRenderingContext2D,
+  all: LaserFeatureResidual[],
+  frame: FrameKey,
+  scale: number,
+) {
+  const records = all.filter(
+    (r) => r.pose === frame.pose && r.camera === frame.camera,
+  );
+  const inv = 1 / scale;
+
+  // Projected laser line: identical endpoints on every record of the
+  // view, so the first carrier suffices.
+  const line = records.find((r) => r.projected_line_px)?.projected_line_px;
+  if (line) {
+    ctx.strokeStyle = "rgba(64, 156, 255, 0.6)";
+    ctx.lineWidth = 1.5 * inv;
+    ctx.beginPath();
+    ctx.moveTo(line[0][0], line[0][1]);
+    ctx.lineTo(line[1][0], line[1][1]);
+    ctx.stroke();
+  }
+
+  for (const r of records) {
+    ctx.fillStyle =
+      r.residual_m != null
+        ? colorForLaserError(Math.abs(r.residual_m) * 1e3)
+        : "rgba(255,255,255,0.4)";
+    ctx.beginPath();
+    ctx.arc(r.observed_px[0], r.observed_px[1], 1.4 * inv, 0, Math.PI * 2);
+    ctx.fill();
+  }
 }

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -21,6 +21,9 @@ function nextInWrap(arr: number[], current: number, delta: number): number {
 
 interface MaterializedExport {
   frames: FrameKey[];
+  /** Laser-kind frames (ADR 0021 §5), kept out of `frames` so pose /
+   * camera navigation stays driven by the target observations. */
+  laserFrames: FrameKey[];
   poseValues: number[];
   cameraValues: number[];
   posesByCamera: Map<number, number[]>;
@@ -41,13 +44,19 @@ function materializeExport(data: AnyExport, exportDir: string):
     };
   }
   const root = joinPath(exportDir, manifest.root);
-  const frames: FrameKey[] = manifest.frames.map((f) => ({
+  const toKey = (f: (typeof manifest.frames)[number]): FrameKey => ({
     pose: f.pose,
     camera: f.camera,
     label: `pose ${f.pose} · cam ${f.camera}`,
     abs_path: joinPath(root, f.path),
     roi: f.roi,
-  }));
+  });
+  const frames: FrameKey[] = manifest.frames
+    .filter((f) => (f.kind ?? "target") === "target")
+    .map(toKey);
+  const laserFrames: FrameKey[] = manifest.frames
+    .filter((f) => f.kind === "laser")
+    .map(toKey);
   if (frames.length === 0) {
     return {
       ok: false,
@@ -91,6 +100,7 @@ function materializeExport(data: AnyExport, exportDir: string):
     ok: true,
     value: {
       frames,
+      laserFrames,
       poseValues,
       cameraValues,
       posesByCamera,
@@ -107,6 +117,8 @@ export interface ExportSlice {
   data: AnyExport | null;
   kind: ExportKind | null;
   frames: FrameKey[];
+  /** Laser-kind manifest frames; empty for non-laser exports. */
+  laserFrames: FrameKey[];
   poseValues: number[];
   cameraValues: number[];
   posesByCamera: Map<number, number[]>;
@@ -152,6 +164,7 @@ export const useStore = create<AppState>()(
     data: null,
     kind: null,
     frames: [],
+    laserFrames: [],
     poseValues: [],
     cameraValues: [],
     posesByCamera: new Map(),
@@ -198,6 +211,7 @@ export const useStore = create<AppState>()(
         data,
         kind: inferExportKind(data),
         frames: materialized.value.frames,
+        laserFrames: materialized.value.laserFrames,
         poseValues: materialized.value.poseValues,
         cameraValues: materialized.value.cameraValues,
         posesByCamera: materialized.value.posesByCamera,
@@ -225,6 +239,7 @@ export const useStore = create<AppState>()(
         data,
         kind: inferExportKind(data),
         frames: materialized.value.frames,
+        laserFrames: materialized.value.laserFrames,
         poseValues: materialized.value.poseValues,
         cameraValues: materialized.value.cameraValues,
         posesByCamera: materialized.value.posesByCamera,
@@ -246,6 +261,7 @@ export const useStore = create<AppState>()(
         data: null,
         kind: null,
         frames: [],
+        laserFrames: [],
         poseValues: [],
         cameraValues: [],
         posesByCamera: new Map(),

--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -51,6 +51,15 @@ export interface PinholeCameraWire {
   dist?: BrownConrady5Wire;
 }
 
+/** Laser plane wire format (`vision_calibration_optim::LaserPlane`):
+ * `{ normal: [nx, ny, nz], distance: d }` with a unit normal and the
+ * plane equation `n · p + d = 0`. Frame depends on the carrying field
+ * (`laser_planes_rig` = rig frame, `laser_planes_cam` = per-camera). */
+export interface LaserPlaneWire {
+  normal: [number, number, number];
+  distance: number;
+}
+
 /** Loose union over the seven calibration export shapes. The viewer
  * (B1.0) only consumes the residuals + manifest + mean reprojection
  * error; rig-only fields (cameras, cam_se3_rig, rig_se3_target) are
@@ -69,8 +78,10 @@ export interface AnyExport {
   camera_se3_target?: Iso3Wire[];
   /** rig_handeye / single_cam_handeye carry mode-tagged hand-eye fields. */
   handeye_mode?: string;
-  /** rig_laserline_device-only. */
-  laser_planes_rig?: unknown[];
+  /** rig_laserline_device-only: per-camera laser planes in rig frame. */
+  laser_planes_rig?: LaserPlaneWire[];
+  /** rig_laserline_device-only: the same planes in each camera's frame. */
+  laser_planes_cam?: LaserPlaneWire[];
 }
 
 /** Tauri command response shape from `load_export`. */

--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -68,7 +68,10 @@ export interface LaserPlaneWire {
 export interface AnyExport {
   per_feature_residuals: PerFeatureResiduals;
   image_manifest?: ImageManifest;
-  mean_reproj_error: number;
+  /** All current exports carry this, but treat it as optional: exports
+   * written before their type gained the field (e.g. pre-B-laser
+   * rig_laserline_device) omit it on the wire. */
+  mean_reproj_error?: number;
   /** Present on rig_extrinsics, rig_handeye, rig_laserline_device. */
   cameras?: PinholeCameraWire[];
   cam_se3_rig?: Iso3Wire[];

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -74,7 +74,8 @@ export interface PerFeatureResiduals {
 export interface PlanarExport {
   per_feature_residuals: PerFeatureResiduals;
   image_manifest?: ImageManifest;
-  mean_reproj_error: number;
+  /** Optional on the wire — older export files may omit it. */
+  mean_reproj_error?: number;
 }
 
 /** Tauri command response from `load_export`. */

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -11,11 +11,16 @@ export interface PixelRect {
   h: number;
 }
 
+/** What a frame depicts (ADR 0021 §5). Absent on the wire means
+ * "target" — exports written before the discriminator omit it. */
+export type FrameKind = "target" | "laser";
+
 export interface FrameRef {
   pose: number;
   camera: number;
   path: string;
   roi?: PixelRect;
+  kind?: FrameKind;
 }
 
 export interface ImageManifest {
@@ -33,10 +38,36 @@ export interface TargetFeatureResidual {
   error_px?: number | null;
 }
 
+/** Per-laser-pixel residual record (laser problem types only). */
+export interface LaserFeatureResidual {
+  pose: number;
+  camera: number;
+  feature: number;
+  observed_px: [number, number];
+  /** Point-to-plane distance in meters; null when the back-projected
+   * ray does not intersect the target plane. */
+  residual_m?: number | null;
+  /** Distance to the projected laser line in undistorted pixel space. */
+  residual_px?: number | null;
+  /** Two endpoints of the projected laser line in image space. */
+  projected_line_px?: [[number, number], [number, number]] | null;
+}
+
+/** Aggregate residual histogram (fixed [<=1, <=2, <=5, <=10, >10] px buckets). */
+export interface FeatureResidualHistogram {
+  bucket_edges_px: [number, number, number, number];
+  counts: [number, number, number, number, number];
+  count: number;
+  mean: number;
+  max: number;
+}
+
 export interface PerFeatureResiduals {
   target: TargetFeatureResidual[];
-  // laser, target_hist_per_camera, laser_hist_per_camera exist on the
-  // wire but the v0 viewer does not consume them.
+  /** Per-laser-pixel records; absent/empty on non-laser problem types. */
+  laser?: LaserFeatureResidual[];
+  target_hist_per_camera?: FeatureResidualHistogram[] | null;
+  laser_hist_per_camera?: FeatureResidualHistogram[] | null;
 }
 
 /** The subset of PlanarIntrinsicsExport the viewer reads. */

--- a/app/src/workspaces/DiagnoseWorkspace/index.tsx
+++ b/app/src/workspaces/DiagnoseWorkspace/index.tsx
@@ -7,6 +7,7 @@ import {
   FrameCanvas,
   type FrameCanvasHandle,
   colorForError,
+  colorForLaserError,
 } from "../../components/FrameCanvas";
 import { Histogram } from "../../components/Histogram";
 import { PoseCameraStepper } from "../../components/PoseCameraStepper";
@@ -17,14 +18,25 @@ import {
 } from "../../hooks/useImageData";
 import { useKeyboardNav } from "../../hooks/useKeyboardNav";
 import { useStore } from "../../store";
-import type { CursorReadout, FrameKey, TargetFeatureResidual } from "../../types";
+import type {
+  CursorReadout,
+  FeatureResidualHistogram,
+  FrameKey,
+  LaserFeatureResidual,
+  TargetFeatureResidual,
+} from "../../types";
 
 const HISTOGRAM_BINS = 64;
+
+/** Stable empty array so laser view doesn't retrigger the canvas draw
+ * effect with a fresh `[]` identity on every render. */
+const NO_TARGET_RESIDUALS: TargetFeatureResidual[] = [];
 
 export function DiagnoseWorkspace() {
   // Cross-workspace state from the store.
   const data = useStore((s) => s.data);
   const frames = useStore((s) => s.frames);
+  const laserFrames = useStore((s) => s.laserFrames);
   const poseValues = useStore((s) => s.poseValues);
   const cameraValues = useStore((s) => s.cameraValues);
   const selectedPose = useStore((s) => s.selectedPose);
@@ -40,6 +52,10 @@ export function DiagnoseWorkspace() {
   // exist in the other workspaces.
   const [compare, setCompare] = useState<boolean>(false);
   const [linked, setLinked] = useState<boolean>(true);
+  // Laser view plots per_feature_residuals.laser onto the laser-kind
+  // frame for the active (pose, camera). Mutually exclusive with
+  // compare mode — both repurpose the single canvas area.
+  const [laserView, setLaserView] = useState<boolean>(false);
   const [activePane, setActivePane] = useState<"left" | "right">("left");
   const [cursor, setCursor] = useState<CursorReadout | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -62,22 +78,47 @@ export function DiagnoseWorkspace() {
     );
   }, [frames, selectedPoseB, cameraB]);
 
-  const imageData = useImageData(frame, setError);
+  const laserResiduals = useMemo<LaserFeatureResidual[]>(
+    () => data?.per_feature_residuals.laser ?? [],
+    [data],
+  );
+  const hasLaser = laserFrames.length > 0 || laserResiduals.length > 0;
+
+  // Loading a non-laser export while laser view is active would strand
+  // the workspace on a mode with no data — drop back to target view.
+  useEffect(() => {
+    if (!hasLaser) setLaserView(false);
+  }, [hasLaser]);
+
+  const laserFrame = useMemo<FrameKey | null>(() => {
+    return (
+      laserFrames.find(
+        (f) => f.pose === selectedPose && f.camera === cameraA,
+      ) ?? null
+    );
+  }, [laserFrames, selectedPose, cameraA]);
+
+  // The frame the canvas actually shows: the laser frame in laser view
+  // (when one exists for the slot), the target frame otherwise.
+  const showLaser = laserView && !compare;
+  const activeFrame = showLaser ? laserFrame : frame;
+
+  const imageData = useImageData(activeFrame, setError);
 
   // Static ROI histogram — recomputed only when the frame's image data
   // changes, which is the cheap path. (A viewport-tracking variant
   // can come later; for diagnostic use the static distribution is
   // more stable to read.)
   const roiHistogram = useMemo<number[] | null>(() => {
-    if (!imageData || !frame) return null;
-    const r = frame.roi ?? {
+    if (!imageData || !activeFrame) return null;
+    const r = activeFrame.roi ?? {
       x: 0,
       y: 0,
       w: imageData.naturalWidth,
       h: imageData.naturalHeight,
     };
     return rectHistogram(imageData, r, HISTOGRAM_BINS);
-  }, [imageData, frame]);
+  }, [imageData, activeFrame]);
 
   const cursorBin = useMemo<number | null>(() => {
     if (!cursor || cursor.intensity == null) return null;
@@ -89,7 +130,7 @@ export function DiagnoseWorkspace() {
   // (x, y) no longer maps to the new image.
   useEffect(() => {
     setCursor(null);
-  }, [frame?.abs_path]);
+  }, [activeFrame?.abs_path]);
 
   const handleCursor = useCallback(
     (c: { x: number; y: number } | null) => {
@@ -97,7 +138,7 @@ export function DiagnoseWorkspace() {
         setCursor(null);
         return;
       }
-      const roi = frame?.roi;
+      const roi = activeFrame?.roi;
       const srcX = (roi?.x ?? 0) + c.x;
       const srcY = (roi?.y ?? 0) + c.y;
       setCursor({
@@ -106,7 +147,7 @@ export function DiagnoseWorkspace() {
         intensity: getPixelLum(imageData, srcX, srcY),
       });
     },
-    [imageData, frame],
+    [imageData, activeFrame],
   );
 
   const onPoseStep = useCallback(
@@ -224,13 +265,35 @@ export function DiagnoseWorkspace() {
         {data && (
           <button
             type="button"
-            onClick={() => setCompare((v) => !v)}
+            onClick={() => {
+              setCompare((v) => {
+                if (!v) setLaserView(false);
+                return !v;
+              });
+            }}
             className={`h-7 px-2 font-mono text-[11px] ${
               compare ? "border-brand text-brand" : ""
             }`}
             title="Toggle compare mode"
           >
             {compare ? "Compare ✓" : "Compare"}
+          </button>
+        )}
+        {data && hasLaser && (
+          <button
+            type="button"
+            onClick={() => {
+              setLaserView((v) => {
+                if (!v) setCompare(false);
+                return !v;
+              });
+            }}
+            className={`h-7 px-2 font-mono text-[11px] ${
+              laserView ? "border-brand text-brand" : ""
+            }`}
+            title="Show the laser frame with point-to-plane residuals"
+          >
+            {laserView ? "Laser ✓" : "Laser"}
           </button>
         )}
         {data && compare && (
@@ -271,15 +334,21 @@ export function DiagnoseWorkspace() {
             onError={setError}
             innerRef={compareHandleRef}
           />
-        ) : data && frame ? (
+        ) : data && activeFrame ? (
           <FrameCanvas
             ref={canvasHandleRef}
-            frame={frame}
-            residuals={data.per_feature_residuals.target}
+            frame={activeFrame}
+            residuals={showLaser ? NO_TARGET_RESIDUALS : data.per_feature_residuals.target}
+            laserResiduals={showLaser ? laserResiduals : undefined}
             image={imageData?.image ?? null}
             onCursor={handleCursor}
             onError={setError}
           />
+        ) : data && showLaser ? (
+          <div className="m-auto text-[13px] text-muted-foreground">
+            No laser frame in the manifest for pose {selectedPose} · cam{" "}
+            {cameraA}.
+          </div>
         ) : (
           <div className="m-auto text-[13px] text-muted-foreground">
             Open an <code>export.json</code> from a calibration run with an
@@ -289,18 +358,33 @@ export function DiagnoseWorkspace() {
         )}
       </div>
 
-      {data && frame && (
+      {data && activeFrame && (
         // Reserve a stable height so the panel doesn't shimmy when the
         // histogram briefly drops out during a frame switch (imageData
         // unloads → roiHistogram becomes null until the next decode).
         // The histogram block always mounts; its bins go empty during
         // the gap and re-fill once decode lands.
         <div className="flex min-h-[3.25rem] flex-wrap items-center gap-x-4 gap-y-2">
-          <ResidualLegend
-            residuals={data.per_feature_residuals.target.filter(
-              (r) => r.pose === frame.pose && r.camera === frame.camera,
-            )}
-          />
+          {showLaser ? (
+            <LaserResidualLegend
+              residuals={laserResiduals.filter(
+                (r) =>
+                  r.pose === activeFrame.pose &&
+                  r.camera === activeFrame.camera,
+              )}
+              hist={
+                data.per_feature_residuals.laser_hist_per_camera?.[cameraA]
+              }
+            />
+          ) : (
+            <ResidualLegend
+              residuals={data.per_feature_residuals.target.filter(
+                (r) =>
+                  r.pose === activeFrame.pose &&
+                  r.camera === activeFrame.camera,
+              )}
+            />
+          )}
           <div className="flex items-center gap-2">
             <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
               histogram
@@ -356,6 +440,50 @@ function ResidualLegend({
         <Swatch err={20} label="≥10" />
       </span>
     </div>
+  );
+}
+
+function LaserResidualLegend({
+  residuals,
+  hist,
+}: {
+  residuals: LaserFeatureResidual[];
+  hist?: FeatureResidualHistogram | null;
+}) {
+  const mm = residuals
+    .map((r) => r.residual_m)
+    .filter((d): d is number => typeof d === "number")
+    .map((d) => Math.abs(d) * 1e3);
+  const mean = mm.length > 0 ? mm.reduce((a, b) => a + b, 0) / mm.length : 0;
+  const max = mm.length > 0 ? Math.max(...mm) : 0;
+  const missed = residuals.length - mm.length;
+  return (
+    <div className="flex flex-wrap items-center gap-x-3.5 gap-y-1 font-mono text-[11px] text-muted-foreground">
+      <span>laser pts {residuals.length}</span>
+      <span>no-intersect {missed}</span>
+      <span>mean {mean.toFixed(3)} mm</span>
+      <span>max {max.toFixed(3)} mm</span>
+      {hist && <span>cam px-mean {hist.mean.toFixed(3)}</span>}
+      <span className="flex items-center gap-2">
+        <LaserSwatch mm={0.1} label="<0.2" />
+        <LaserSwatch mm={0.3} label="<0.5" />
+        <LaserSwatch mm={0.7} label="<1" />
+        <LaserSwatch mm={1.5} label="<2" />
+        <LaserSwatch mm={3} label="≥2" />
+      </span>
+    </div>
+  );
+}
+
+function LaserSwatch({ mm, label }: { mm: number; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="inline-block h-2 w-2 rounded-[2px]"
+        style={{ background: colorForLaserError(mm) }}
+      />
+      {label}
+    </span>
   );
 }
 

--- a/app/src/workspaces/DiagnoseWorkspace/index.tsx
+++ b/app/src/workspaces/DiagnoseWorkspace/index.tsx
@@ -308,7 +308,7 @@ export function DiagnoseWorkspace() {
             {linked ? "Linked" : "Unlinked"}
           </button>
         )}
-        {data && (
+        {data && typeof data.mean_reproj_error === "number" && (
           <span className="ml-auto font-mono text-xs text-muted-foreground">
             mean reproj: {data.mean_reproj_error.toFixed(3)} px
           </span>

--- a/app/src/workspaces/Viewer3DWorkspace/LaserPlane.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/LaserPlane.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from "react";
+import { DoubleSide, Quaternion, Vector3 } from "three";
+import type { LaserPlaneWire } from "../../store/types";
+
+interface LaserPlaneProps {
+  /** Plane in rig frame: unit `normal`, signed `distance`
+   * (`n · p + d = 0`). */
+  plane: LaserPlaneWire;
+  /** Point on (or near) the plane the quad is centred at — typically
+   * the owning camera's position projected onto the plane, so the quad
+   * shows up where the device actually measures, not at the rig
+   * origin's closest point. Projected onto the plane here in case the
+   * caller passes an off-plane anchor. */
+  anchor: [number, number, number];
+  /** Quad half-extent in meters. */
+  halfExtent: number;
+  /** Outline color (matches the owning camera's frustum selection). */
+  color: string;
+  active?: boolean;
+  onSelect?: () => void;
+}
+
+/** Laser line color, independent of the theme: the fill stays
+ * recognizably "laser red" against the brand-tinted target boards. */
+const LASER_FILL = "#e74c3c";
+
+/** Translucent bounded quad for one calibrated laser plane, with a
+ * sharp outline like `TargetBoard` so it reads at any opacity. */
+export function LaserPlane({
+  plane,
+  anchor,
+  halfExtent,
+  color,
+  active = false,
+  onSelect,
+}: LaserPlaneProps) {
+  const { position, quaternion } = useMemo(() => {
+    const n = new Vector3(...plane.normal).normalize();
+    const p = new Vector3(...anchor);
+    // Snap the anchor onto the plane: p ← p − (n·p + d) n.
+    p.addScaledVector(n, -(n.dot(p) + plane.distance));
+    // planeGeometry lies in the local XY plane with +Z normal; rotate
+    // +Z onto the plane normal. setFromUnitVectors handles the
+    // antiparallel case internally.
+    const q = new Quaternion().setFromUnitVectors(new Vector3(0, 0, 1), n);
+    return { position: p, quaternion: q };
+  }, [plane, anchor]);
+
+  const outline = useMemo(() => {
+    const e = halfExtent;
+    return new Float32Array(
+      [
+        [-e, -e, 0],
+        [e, -e, 0],
+        [e, e, 0],
+        [-e, e, 0],
+        [-e, -e, 0],
+      ].flat(),
+    );
+  }, [halfExtent]);
+
+  return (
+    <group position={position} quaternion={quaternion} onClick={onSelect}>
+      <mesh>
+        <planeGeometry args={[halfExtent * 2, halfExtent * 2]} />
+        <meshBasicMaterial
+          color={LASER_FILL}
+          transparent
+          opacity={active ? 0.22 : 0.08}
+          depthWrite={false}
+          side={DoubleSide}
+        />
+      </mesh>
+      <line>
+        <bufferGeometry>
+          <bufferAttribute attach="attributes-position" args={[outline, 3]} />
+        </bufferGeometry>
+        <lineBasicMaterial color={color} transparent opacity={active ? 1 : 0.4} />
+      </line>
+    </group>
+  );
+}

--- a/app/src/workspaces/Viewer3DWorkspace/Scene.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/Scene.tsx
@@ -4,15 +4,18 @@ import { useMemo } from "react";
 import { Vector3 } from "three";
 import { cameraPositionInRig, iso3FromWire } from "../../lib/se3";
 import { useStore } from "../../store";
-import type { AnyExport } from "../../store/types";
+import type { AnyExport, Iso3Wire, LaserPlaneWire } from "../../store/types";
 import type { TargetFeatureResidual } from "../../types";
 import { CameraFrustum } from "./CameraFrustum";
+import { LaserPlane } from "./LaserPlane";
 import { TargetBoard } from "./TargetBoard";
 import { useThemeColors } from "./useThemeColors";
 
 interface SceneProps {
   data: AnyExport;
   showAllPoses: boolean;
+  /** Render `laser_planes_rig` as bounded translucent quads. */
+  showLaserPlanes: boolean;
   /** Per-camera image dimensions (pixels). Built from the manifest's
    * ROI metadata in the workspace; falls back to a sensible default
    * when a camera has no manifest entry. The frustum aspect ratio
@@ -33,6 +36,7 @@ const FAR_DEPTH_M = 0.05; // 5 cm — long enough to read on the puzzle
 export function Scene({
   data,
   showAllPoses,
+  showLaserPlanes,
   cameraDimensions,
   fallbackImage,
 }: SceneProps) {
@@ -40,6 +44,7 @@ export function Scene({
   const cameras = data.cameras ?? [];
   const camSe3Rig = data.cam_se3_rig ?? [];
   const rigSe3Target = data.rig_se3_target ?? [];
+  const laserPlanesRig = data.laser_planes_rig ?? [];
   const cameraA = useStore((s) => s.cameraA);
   const selectedPose = useStore((s) => s.selectedPose);
   const setCamera = useStore((s) => s.setCamera);
@@ -69,6 +74,15 @@ export function Scene({
   const visiblePoses: number[] = showAllPoses
     ? rigSe3Target.map((_, i) => i)
     : [selectedPose].filter((i) => i >= 0 && i < rigSe3Target.length);
+
+  // Anchor + size each laser plane around its owning camera (plane i
+  // belongs to camera i): the quad is centred on the camera position
+  // projected onto the plane, sized from the camera↔plane distance —
+  // the natural scale of the device's measurement volume.
+  const laserQuads = useMemo(
+    () => computeLaserQuads(laserPlanesRig, camSe3Rig),
+    [laserPlanesRig, camSe3Rig],
+  );
 
   return (
     <Canvas
@@ -109,6 +123,19 @@ export function Scene({
         );
       })}
 
+      {showLaserPlanes &&
+        laserQuads.map((quad, i) => (
+          <LaserPlane
+            key={`laser-plane-${i}`}
+            plane={quad.plane}
+            anchor={quad.anchor}
+            halfExtent={quad.halfExtent}
+            color={i === cameraA ? colors.active : colors.inactive}
+            active={i === cameraA}
+            onSelect={() => setCamera(i, "A")}
+          />
+        ))}
+
       {visiblePoses.map((poseIdx) => {
         const pose = rigSe3Target[poseIdx];
         if (!pose) return null;
@@ -136,6 +163,53 @@ export function Scene({
       />
     </Canvas>
   );
+}
+
+interface LaserQuad {
+  plane: LaserPlaneWire;
+  anchor: [number, number, number];
+  halfExtent: number;
+}
+
+const LASER_QUAD_MIN_HALF_EXTENT_M = 0.05;
+const LASER_QUAD_MAX_HALF_EXTENT_M = 0.3;
+const LASER_QUAD_FALLBACK_HALF_EXTENT_M = 0.15;
+
+/** Anchor each plane at its camera's position projected onto the plane
+ * and size it from the camera-to-plane distance (clamped) — keeps the
+ * quad in the device's working volume regardless of where the plane's
+ * closest point to the rig origin lands. */
+function computeLaserQuads(
+  planes: LaserPlaneWire[],
+  camSe3Rig: Iso3Wire[],
+): LaserQuad[] {
+  return planes.map((plane, i) => {
+    const n = new Vector3(...plane.normal).normalize();
+    const camPose = camSe3Rig[i];
+    if (!camPose) {
+      // No owning camera — fall back to the plane's closest point to
+      // the rig origin with a fixed extent.
+      const anchor = n.clone().multiplyScalar(-plane.distance);
+      return {
+        plane,
+        anchor: [anchor.x, anchor.y, anchor.z],
+        halfExtent: LASER_QUAD_FALLBACK_HALF_EXTENT_M,
+      };
+    }
+    const [px, py, pz] = cameraPositionInRig(camPose);
+    const p = new Vector3(px, py, pz);
+    const signed = n.dot(p) + plane.distance;
+    const anchor = p.clone().addScaledVector(n, -signed);
+    const halfExtent = Math.min(
+      LASER_QUAD_MAX_HALF_EXTENT_M,
+      Math.max(LASER_QUAD_MIN_HALF_EXTENT_M, 1.5 * Math.abs(signed)),
+    );
+    return {
+      plane,
+      anchor: [anchor.x, anchor.y, anchor.z],
+      halfExtent,
+    };
+  });
 }
 
 interface FitResult {

--- a/app/src/workspaces/Viewer3DWorkspace/index.tsx
+++ b/app/src/workspaces/Viewer3DWorkspace/index.tsx
@@ -26,6 +26,7 @@ export function Viewer3DWorkspace() {
   const selectedPose = useStore((s) => s.selectedPose);
   const setSelectedPose = useStore((s) => s.setSelectedPose);
   const [showAllPoses, setShowAllPoses] = useState(false);
+  const [showLaserPlanes, setShowLaserPlanes] = useState(true);
   const [referenceCamera, setReferenceCamera] = useState<number>(0);
 
   const cameraDimensions = useMemo(
@@ -60,6 +61,7 @@ export function Viewer3DWorkspace() {
 
   const numCameras = camerasArr.length;
   const numPoses = rigSe3Target.length;
+  const hasLaserPlanes = (data.laser_planes_rig?.length ?? 0) > 0;
   const cameraIndices = Array.from({ length: numCameras }, (_, i) => i);
   const poseIndices = Array.from({ length: numPoses }, (_, i) => i);
 
@@ -102,6 +104,18 @@ export function Viewer3DWorkspace() {
           >
             {showAllPoses ? "All poses ✓" : "All poses"}
           </button>
+          {hasLaserPlanes && (
+            <button
+              type="button"
+              onClick={() => setShowLaserPlanes((v) => !v)}
+              className={`h-7 px-2 font-mono text-[11px] ${
+                showLaserPlanes ? "border-brand text-brand" : ""
+              }`}
+              title="Toggle the calibrated laser planes (rig frame)"
+            >
+              {showLaserPlanes ? "Laser planes ✓" : "Laser planes"}
+            </button>
+          )}
           <span className="font-mono text-[11px] text-muted-foreground">
             {exportKindLabel(kind)}
           </span>
@@ -113,6 +127,7 @@ export function Viewer3DWorkspace() {
           <Scene
             data={data}
             showAllPoses={showAllPoses}
+            showLaserPlanes={hasLaserPlanes && showLaserPlanes}
             cameraDimensions={cameraDimensions}
             fallbackImage={{ width: 1024, height: 768 }}
           />

--- a/crates/vision-calibration-core/src/lib.rs
+++ b/crates/vision-calibration-core/src/lib.rs
@@ -92,9 +92,9 @@ pub use models::{
 };
 pub use ransac::{Estimator, RansacOptions, RansacResult, ransac_fit};
 pub use types::{
-    CameraFixMask, CorrespondenceView, DistortionFixMask, FeatureResidualHistogram, FrameRef,
-    ImageManifest, IntrinsicsFixMask, LaserFeatureResidual, PerFeatureResiduals, PixelRect,
-    REPROJECTION_HISTOGRAM_EDGES_PX, ReprojectionStats, TargetFeatureResidual,
+    CameraFixMask, CorrespondenceView, DistortionFixMask, FeatureResidualHistogram, FrameKind,
+    FrameRef, ImageManifest, IntrinsicsFixMask, LaserFeatureResidual, PerFeatureResiduals,
+    PixelRect, REPROJECTION_HISTOGRAM_EDGES_PX, ReprojectionStats, TargetFeatureResidual,
 };
 pub use view::{NoMeta, PlanarDataset, RigDataset, RigView, RigViewObs, View};
 

--- a/crates/vision-calibration-core/src/types/image_manifest.rs
+++ b/crates/vision-calibration-core/src/types/image_manifest.rs
@@ -63,6 +63,34 @@ pub struct ImageManifest {
     pub frames: Vec<FrameRef>,
 }
 
+/// What a frame depicts, distinguishing target images from laser-on images.
+///
+/// Laser problem types capture two images per `(pose, camera)` slot: one of
+/// the calibration target and one with the laser line on. Both can appear in
+/// the same [`ImageManifest`], discriminated by [`FrameRef::kind`]
+/// (ADR 0021 §5).
+///
+/// Serialized in `snake_case`; absent in JSON means [`FrameKind::Target`],
+/// which keeps pre-existing exports byte-stable and forward-readable.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FrameKind {
+    /// Image of the calibration target (chessboard / ChArUco / …).
+    #[default]
+    Target,
+    /// Image with the laser line on; residuals of flavor
+    /// `PerFeatureResiduals.laser` plot onto frames of this kind.
+    Laser,
+}
+
+impl FrameKind {
+    /// `true` for [`FrameKind::Target`]. Used as `skip_serializing_if` so the
+    /// default kind never appears in JSON.
+    pub fn is_target(&self) -> bool {
+        *self == FrameKind::Target
+    }
+}
+
 /// Reference to a single image (or sub-image) for one `(pose, camera)`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -85,6 +113,10 @@ pub struct FrameRef {
     /// drawing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub roi: Option<PixelRect>,
+    /// What the frame depicts. Absent in JSON means [`FrameKind::Target`],
+    /// so exports written before ADR 0021 §5 deserialize unchanged.
+    #[serde(default, skip_serializing_if = "FrameKind::is_target")]
+    pub kind: FrameKind,
 }
 
 /// Inclusive-exclusive pixel rectangle: `[x, x+w) × [y, y+h)`.
@@ -102,14 +134,33 @@ pub struct PixelRect {
 }
 
 impl ImageManifest {
-    /// Find the frame for a given `(pose, camera)` pair, if any.
+    /// Find the **target** frame for a given `(pose, camera)` pair, if any.
+    ///
+    /// Equivalent to [`frame_of_kind`](Self::frame_of_kind) with
+    /// [`FrameKind::Target`] — the historical behavior, kept target-only so
+    /// manifests that also carry laser frames stay unambiguous.
+    pub fn frame(&self, pose: usize, camera: usize) -> Option<&FrameRef> {
+        self.frame_of_kind(pose, camera, FrameKind::Target)
+    }
+
+    /// Find the frame of a given kind for a `(pose, camera)` pair, if any.
     ///
     /// Linear scan; first match wins. Returns `None` if the manifest has
-    /// no entry for that slot.
-    pub fn frame(&self, pose: usize, camera: usize) -> Option<&FrameRef> {
+    /// no entry of that kind for that slot.
+    pub fn frame_of_kind(&self, pose: usize, camera: usize, kind: FrameKind) -> Option<&FrameRef> {
         self.frames
             .iter()
-            .find(|f| f.pose == pose && f.camera == camera)
+            .find(|f| f.pose == pose && f.camera == camera && f.kind == kind)
+    }
+
+    /// Iterate over frames of kind [`FrameKind::Target`].
+    pub fn target_frames(&self) -> impl Iterator<Item = &FrameRef> {
+        self.frames.iter().filter(|f| f.kind == FrameKind::Target)
+    }
+
+    /// Iterate over frames of kind [`FrameKind::Laser`].
+    pub fn laser_frames(&self) -> impl Iterator<Item = &FrameRef> {
+        self.frames.iter().filter(|f| f.kind == FrameKind::Laser)
     }
 }
 
@@ -126,6 +177,7 @@ mod tests {
                     camera: 0,
                     path: PathBuf::from("pose_0_cam_0.png"),
                     roi: None,
+                    kind: FrameKind::Target,
                 },
                 FrameRef {
                     pose: 1,
@@ -137,6 +189,7 @@ mod tests {
                         w: 720,
                         h: 540,
                     }),
+                    kind: FrameKind::Target,
                 },
                 FrameRef {
                     pose: 1,
@@ -148,6 +201,14 @@ mod tests {
                         w: 720,
                         h: 540,
                     }),
+                    kind: FrameKind::Target,
+                },
+                FrameRef {
+                    pose: 0,
+                    camera: 0,
+                    path: PathBuf::from("laser_pose_0_cam_0.png"),
+                    roi: None,
+                    kind: FrameKind::Laser,
                 },
             ],
         }
@@ -166,6 +227,69 @@ mod tests {
         let m = sample();
         assert!(m.frame(2, 0).is_none());
         assert!(m.frame(0, 5).is_none());
+    }
+
+    #[test]
+    fn frame_lookup_is_target_only() {
+        let m = sample();
+        // (0, 0) has both a target and a laser frame; `frame()` must return
+        // the target one.
+        assert_eq!(
+            m.frame(0, 0).unwrap().path,
+            PathBuf::from("pose_0_cam_0.png")
+        );
+    }
+
+    #[test]
+    fn frame_of_kind_finds_laser_frame() {
+        let m = sample();
+        let f = m.frame_of_kind(0, 0, FrameKind::Laser).unwrap();
+        assert_eq!(f.path, PathBuf::from("laser_pose_0_cam_0.png"));
+        // No laser frame for pose 1.
+        assert!(m.frame_of_kind(1, 0, FrameKind::Laser).is_none());
+    }
+
+    #[test]
+    fn kind_iterators_partition_frames() {
+        let m = sample();
+        assert_eq!(m.target_frames().count(), 3);
+        assert_eq!(m.laser_frames().count(), 1);
+        assert_eq!(
+            m.target_frames().count() + m.laser_frames().count(),
+            m.frames.len()
+        );
+    }
+
+    #[test]
+    fn kind_serde_back_compat() {
+        // Target kind never appears in JSON.
+        let target = FrameRef {
+            pose: 0,
+            camera: 0,
+            path: PathBuf::from("a.png"),
+            roi: None,
+            kind: FrameKind::Target,
+        };
+        let json = serde_json::to_string(&target).unwrap();
+        assert!(
+            !json.contains("kind"),
+            "default kind must be omitted: {json}"
+        );
+
+        // Laser kind serializes in snake_case and round-trips.
+        let laser = FrameRef {
+            kind: FrameKind::Laser,
+            ..target.clone()
+        };
+        let json = serde_json::to_string(&laser).unwrap();
+        assert!(json.contains("\"kind\":\"laser\""), "got: {json}");
+        let restored: FrameRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, laser);
+
+        // Pre-ADR-0021§5 JSON (no `kind` field) deserializes as Target.
+        let legacy: FrameRef =
+            serde_json::from_str(r#"{"pose":3,"camera":1,"path":"b.png"}"#).unwrap();
+        assert_eq!(legacy.kind, FrameKind::Target);
     }
 
     #[test]

--- a/crates/vision-calibration-pipeline/src/dataset_runner/laser.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/laser.rs
@@ -92,6 +92,10 @@ pub struct RigLaserlineRunResult {
     /// and camera; `None` where the camera contributed no usable
     /// target observation.
     pub view_paths: Vec<Vec<Option<PathBuf>>>,
+    /// `laser_paths[view][camera]` — *laser* image path per kept view
+    /// and camera, aligned with `view_paths`; `None` where the camera
+    /// contributed no usable laser observation.
+    pub laser_paths: Vec<Vec<Option<PathBuf>>>,
     /// Number of kept views (≥1 camera with ≥4 target features).
     pub usable_views: usize,
     /// Total number of paired views attempted.
@@ -282,12 +286,15 @@ pub fn build_rig_laserline_device_input(
         .map(|c| laser_key_config(&laser_spec, c.roi_xywh))
         .collect();
     let mut laser_per_view: Vec<Vec<Option<Vec<Pt2>>>> = Vec::with_capacity(core.views.len());
+    let mut laser_paths: Vec<Vec<Option<PathBuf>>> = Vec::with_capacity(core.views.len());
     let mut per_camera_usable = vec![0usize; num_cameras];
     for (_obs, token) in &core.views {
         let mut slots: Vec<Option<Vec<Pt2>>> = Vec::with_capacity(num_cameras);
+        let mut path_slots: Vec<Option<PathBuf>> = Vec::with_capacity(num_cameras);
         for cam_idx in 0..num_cameras {
             let Some(laser_path) = laser_by_token[cam_idx].get(token) else {
                 slots.push(None);
+                path_slots.push(None);
                 continue;
             };
             let pixels = extract_laser_pixels(
@@ -301,12 +308,15 @@ pub fn build_rig_laserline_device_input(
             )?;
             if pixels.len() < laser_spec.min_points as usize {
                 slots.push(None);
+                path_slots.push(None);
                 continue;
             }
             per_camera_usable[cam_idx] += 1;
             slots.push(Some(pixels));
+            path_slots.push(Some(laser_path.clone()));
         }
         laser_per_view.push(slots);
+        laser_paths.push(path_slots);
     }
     for (cam_idx, usable) in per_camera_usable.iter().enumerate() {
         if *usable == 0 {
@@ -389,6 +399,7 @@ pub fn build_rig_laserline_device_input(
             initial_planes_cam: None,
         },
         view_paths: core.view_paths,
+        laser_paths,
         usable_views,
         total_views: core.total_views,
     })
@@ -1061,6 +1072,15 @@ mod tests {
         let result =
             build_rig_laserline_device_input(&spec, tmp.path(), &cache, &fake, false).unwrap();
         assert_eq!((result.usable_views, result.total_views), (3, 3));
+        // Laser image paths are captured per (view, camera), aligned
+        // with view_paths, for the export's image_manifest.
+        assert_eq!(result.laser_paths.len(), 3);
+        assert!(
+            result.laser_paths[2][1]
+                .as_ref()
+                .unwrap()
+                .ends_with("cam1/laser_2.png")
+        );
         let input = &result.input;
         assert_eq!(input.dataset.num_cameras, 2);
         assert_eq!(input.dataset.num_views(), 3);

--- a/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
@@ -201,10 +201,10 @@ pub struct LaserlineDeviceExport {
     #[serde(default)]
     pub per_feature_residuals: PerFeatureResiduals,
 
-    /// Optional image manifest (ADR 0014, viewer-side contract). One
-    /// frame per accepted view (pose = kept-view index, camera = 0),
-    /// pointing at the *target* image; laser-frame entries are
-    /// deferred to B-laser. `None` means "no images shipped"; the
+    /// Optional image manifest (ADR 0014, viewer-side contract). Per
+    /// accepted view (pose = kept-view index, camera = 0): one frame
+    /// for the *target* image plus one of kind `laser` for the laser
+    /// image (ADR 0021 §5). `None` means "no images shipped"; the
     /// calibration pipeline never reads this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_manifest: Option<ImageManifest>,

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
@@ -5,8 +5,8 @@ use crate::rig_handeye::RigHandeyeExport;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
     BrownConrady5, Camera, FeatureResidualHistogram, FxFyCxCySkew, ImageManifest, Iso3, NoMeta,
-    PerFeatureResiduals, Pinhole, Real, RigDataset, RigView, RigViewObs, ScheimpflugParams,
-    build_feature_histogram, compute_rig_target_residuals,
+    PerFeatureResiduals, Pinhole, PinholeCamera, Real, RigDataset, RigView, RigViewObs,
+    ScheimpflugParams, build_feature_histogram, compute_rig_target_residuals, make_pinhole_camera,
 };
 use vision_calibration_optim::{
     LaserPlane, LaserlineResidualType, LaserlineStats, RigLaserlineDataset, RigLaserlineEstimate,
@@ -132,6 +132,28 @@ pub struct RigLaserlineDeviceExport {
     pub laser_planes_cam: Vec<LaserPlane>,
     /// Per-camera stats (reprojection + laser residuals).
     pub per_camera_stats: Vec<LaserlineStats>,
+
+    /// Frozen upstream cameras (pinhole part), echoed so the export is
+    /// self-contained for downstream viewers (3D rig scene, epipolar) —
+    /// same field names as `RigHandeyeExport`. Empty on pre-B-laser
+    /// exports (`serde(default)`).
+    #[serde(default)]
+    pub cameras: Vec<PinholeCamera>,
+    /// Frozen upstream Scheimpflug sensor parameters (zero tilt for
+    /// pinhole rigs), aligned with `cameras`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sensors: Option<Vec<ScheimpflugParams>>,
+    /// Frozen upstream per-camera extrinsics `T_C_R`.
+    #[serde(default)]
+    pub cam_se3_rig: Vec<Iso3>,
+    /// Frozen upstream per-view rig poses `T_R_T`.
+    #[serde(default)]
+    pub rig_se3_target: Vec<Iso3>,
+    /// Mean target reprojection error (pixels) against the frozen
+    /// upstream. Diagnostic echo — this problem type does not optimize
+    /// reprojection.
+    #[serde(default)]
+    pub mean_reproj_error: f64,
     /// Per-feature reprojection + laser residuals (ADR 0012). Multi-camera
     /// rig: `target` covers per-corner reprojection (when present) and
     /// `laser` covers per-pixel laser distances. Both per-camera histograms
@@ -288,6 +310,18 @@ impl ProblemType for RigLaserlineDeviceProblem {
             })
             .collect();
 
+        // Mean over all finite per-feature reprojection errors — the
+        // viewer-facing headline number (against the frozen upstream).
+        let (err_sum, err_count) = target
+            .iter()
+            .filter_map(|r| r.error_px)
+            .fold((0.0, 0usize), |(s, c), e| (s + e, c + 1));
+        let mean_reproj_error = if err_count > 0 {
+            err_sum / err_count as f64
+        } else {
+            0.0
+        };
+
         let mut per_feature_residuals = PerFeatureResiduals::default();
         per_feature_residuals.target = target;
         per_feature_residuals.laser = laser;
@@ -297,6 +331,13 @@ impl ProblemType for RigLaserlineDeviceProblem {
             laser_planes_rig: output.laser_planes_rig.clone(),
             laser_planes_cam: output.laser_planes_cam.clone(),
             per_camera_stats: output.per_camera_stats.clone(),
+            cameras: (0..n)
+                .map(|c| make_pinhole_camera(upstream.intrinsics[c], upstream.distortion[c]))
+                .collect(),
+            sensors: Some(upstream.sensors.clone()),
+            cam_se3_rig: upstream.cam_se3_rig.clone(),
+            rig_se3_target: upstream.rig_se3_target.clone(),
+            mean_reproj_error,
             per_feature_residuals,
             // Manifest is populated by callers that wrote images for the
             // dataset; the pipeline never has image paths to fill in.
@@ -318,6 +359,11 @@ mod tests {
             laser_planes_rig: Vec::new(),
             laser_planes_cam: Vec::new(),
             per_camera_stats: Vec::new(),
+            cameras: Vec::new(),
+            sensors: None,
+            cam_se3_rig: Vec::new(),
+            rig_se3_target: Vec::new(),
+            mean_reproj_error: 0.0,
             per_feature_residuals: PerFeatureResiduals::default(),
             image_manifest: None,
         }

--- a/crates/vision-calibration-pipeline/tests/rig_laserline_device.rs
+++ b/crates/vision-calibration-pipeline/tests/rig_laserline_device.rs
@@ -219,6 +219,20 @@ fn pipeline_converges_rig_laserline() {
             stats.mean_reproj_error
         );
     }
+
+    // Viewer contract: the export echoes the frozen upstream rig
+    // geometry so the diagnose / 3D workspaces can render it without
+    // the hand-eye export (B-laser). Same field names as
+    // RigHandeyeExport.
+    assert_eq!(export.cameras.len(), 2);
+    assert_eq!(export.cam_se3_rig.len(), 2);
+    assert_eq!(export.sensors.as_ref().map(Vec::len), Some(2));
+    assert_eq!(export.rig_se3_target.len(), 4, "one T_R_T per view");
+    assert!(
+        export.mean_reproj_error.is_finite() && export.mean_reproj_error < 1.0,
+        "export-level mean reproj: {}",
+        export.mean_reproj_error
+    );
 }
 
 #[test]

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -459,14 +459,14 @@ pub use crate::rig_laserline_device::pixel_to_gripper_point;
 pub mod core {
     pub use vision_calibration_core::{
         BrownConrady5, Camera, CameraParams, CorrespondenceView, DistortionFixMask,
-        DistortionParams, FeatureResidualHistogram, FrameRef, FxFyCxCySkew, IdentitySensor,
-        ImageManifest, IntrinsicsFixMask, IntrinsicsParams, Iso3, LaserFeatureResidual, NoMeta,
-        PerFeatureResiduals, Pinhole, PinholeCamera, PixelRect, PlanarDataset, ProjectionParams,
-        Pt2, Pt3, REPROJECTION_HISTOGRAM_EDGES_PX, Real, ReprojectionStats, RigDataset, RigView,
-        RigViewObs, ScheimpflugParams, SensorModel, SensorParams, TargetFeatureResidual, Vec2,
-        Vec3, View, build_feature_histogram, compute_planar_target_residuals,
-        compute_planar_target_residuals_views, compute_rig_target_residuals, make_pinhole_camera,
-        pinhole_camera_params,
+        DistortionParams, FeatureResidualHistogram, FrameKind, FrameRef, FxFyCxCySkew,
+        IdentitySensor, ImageManifest, IntrinsicsFixMask, IntrinsicsParams, Iso3,
+        LaserFeatureResidual, NoMeta, PerFeatureResiduals, Pinhole, PinholeCamera, PixelRect,
+        PlanarDataset, ProjectionParams, Pt2, Pt3, REPROJECTION_HISTOGRAM_EDGES_PX, Real,
+        ReprojectionStats, RigDataset, RigView, RigViewObs, ScheimpflugParams, SensorModel,
+        SensorParams, TargetFeatureResidual, Vec2, Vec3, View, build_feature_histogram,
+        compute_planar_target_residuals, compute_planar_target_residuals_views,
+        compute_rig_target_residuals, make_pinhole_camera, pinhole_camera_params,
     };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -135,13 +135,16 @@ puzzleboard / ringgrid) are supported.
     ringgrid detectors, bench/examples-private charuco dedup; in-app
     "save export to file" (needed to run the two-stage laser flow
     without leaving the app) moves to B3e.
-- **B-laser — laserline visualization.** Laser-pixel overlay in
-  Diagnose; laser plane-fit residuals (point-to-plane mm) alongside
-  reprojection residuals; laser planes rendered in the 3D rig viewer.
-  The laser topologies *run* in the app since B3c-3 (and the laser
-  exports carry `per_feature_residuals.laser`), but no laser pixels or
-  planes are rendered anywhere yet; `ImageManifest` also still lacks
-  laser-frame entries (ADR 0021 §5).
+- **B-laser — laserline visualization (SHIPPED 2026-06-12).**
+  `FrameRef.kind` discriminator closes ADR 0021 §5: both laser
+  topologies now splice laser-kind frames into their export manifests.
+  Diagnose gains a Laser view — observed pixels colored by
+  point-to-plane distance (thresholds at the 0.2 mm device norm),
+  projected laser line overlay, mm-domain stats legend. The 3D rig
+  viewer renders `laser_planes_rig` as bounded translucent quads
+  anchored at each owning camera. Follow-ups: laser plane for the
+  single-cam `LaserlineDeviceExport` in 3D (viewer is rig-only),
+  laser-pixel overlay in compare mode.
 - **B-explore — dataset exploration.** Browse a dataset *before*
   calibrating: image grid per camera/pose, detection overlay from the
   cache, board coverage map. Today the app only visualizes exports.

--- a/docs/adrs/0021-laser-frame-manifest.md
+++ b/docs/adrs/0021-laser-frame-manifest.md
@@ -116,10 +116,15 @@ Pinhole rigs work (zero Scheimpflug tilt = identity sensor).
 
 `LaserlineDeviceExport` gains `image_manifest` (the last `*Export`
 without one). Both laser exports get the manifest spliced by the Tauri
-runner from the **target** frames. Laser-frame entries in
-`ImageManifest` are deferred to B-laser (the visualization slice) —
-`FrameRef` has no frame-kind discriminator yet, and nothing renders
-laser pixels today.
+runner from the **target** frames.
+
+**Laser-frame entries (implemented in B-laser).** `FrameRef` carries a
+`kind: FrameKind` discriminator (`target` | `laser`), serialized in
+snake_case and omitted for `target`, so pre-existing exports stay
+byte-stable and deserialize unchanged. The Tauri runner splices laser
+frames (aligned with the kept-view target frames) into both laser
+exports; the Diagnose workspace plots
+`per_feature_residuals.laser` onto frames of kind `laser`.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Ships the **B-laser** roadmap slice — the laser exports have carried `per_feature_residuals.laser` since ADR 0012, but nothing rendered it. This PR closes the ADR 0021 §5 deferral and wires laser data through both viewer workspaces.

### 1. Laser frames in `ImageManifest` (Rust)

- `FrameRef` gains `kind: FrameKind` (`target` | `laser`), `#[serde(default, skip_serializing_if)]` so pre-existing exports stay **byte-stable** and old JSON deserializes as `Target`.
- `ImageManifest::frame()` stays target-only (the historical behavior, now explicit); new `frame_of_kind` / `target_frames()` / `laser_frames()` accessors.
- `RigLaserlineRunResult` reports per-`(view, camera)` laser image paths; the Tauri runner splices laser-kind frames into both laser exports' manifests.

### 2. Diagnose: laser overlay + mm stats (TS)

- Laser-kind frames materialize into a separate `laserFrames` store list — pose/camera navigation stays target-driven.
- A **Laser** toggle (mutually exclusive with compare) swaps the canvas to the laser frame: observed pixels colored by point-to-plane distance (thresholds at the **0.2 mm device norm**), projected laser line overlay, and an mm-domain stats legend (mean/max point-to-plane, no-intersect count).

### 3. 3D rig viewer: laser planes (TS)

- `laser_planes_rig` (now properly typed as `{normal, distance}`, wire shape verified empirically) renders as bounded translucent quads, anchored at each owning camera's position projected onto its plane and sized from the camera-to-plane distance. Header toggle; clicking a plane selects its camera.

## Real-data acceptance

`rtv3d_laser_end_to_end` (two-stage user workflow) now also asserts the manifest carries both frame kinds — **116 target + 120 laser frames** on the real dataset — and non-empty per-pixel laser residuals. Solve numbers unchanged (visualization-only slice): hand-eye 1.561 px, planes 0.85–1.15 mm. Per user feedback, these are ~5× worse than the device norm (0.3 px / <0.2 mm pre-BA) — this slice ships the diagnostic tooling for that investigation, which is tracked separately.

`kuka_handeye_end_to_end` and `local_presets_end_to_end` (stereo, stereo_charuco) still pass.

## Quality gates

fmt ✓ · clippy `-D warnings` (workspace + app crate) ✓ · 39 workspace test suites ✓ · doc gate (`RUSTDOCFLAGS=-D warnings`) ✓ · app crate tests ✓ · `bun run build` ✓

## Follow-ups (noted in ROADMAP)

- Single-cam `LaserlineDeviceExport` plane in the 3D viewer (viewer is rig-only today).
- Laser overlay in compare mode.
- In-app "save export to file" (B3e) — the two-stage laser flow still needs a terminal step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)