### PR TITLE
feat(camera-model): rational, thin-prism, division distortion models (additive)

### DIFF
--- a/crates/vision-calibration-core/src/lib.rs
+++ b/crates/vision-calibration-core/src/lib.rs
@@ -86,9 +86,10 @@ pub use math::{
 };
 pub use models::{
     AnyDistortion, AnyIntrinsics, AnyProjection, AnySensor, BrownConrady5, Camera, CameraModel,
-    CameraParams, CameraProject, DistortionModel, DistortionParams, FxFyCxCySkew, HomographySensor,
-    IdentitySensor, IntrinsicsModel, IntrinsicsParams, NoDistortion, Pinhole, ProjectionModel,
-    ProjectionParams, Ray, ScheimpflugParams, SensorModel, SensorParams,
+    CameraParams, CameraProject, DistortionModel, DistortionParams, Division, FxFyCxCySkew,
+    HomographySensor, IdentitySensor, IntrinsicsModel, IntrinsicsParams, NoDistortion, Pinhole,
+    ProjectionModel, ProjectionParams, RationalPolynomial, Ray, ScheimpflugParams, SensorModel,
+    SensorParams, ThinPrism,
 };
 pub use ransac::{Estimator, RansacOptions, RansacResult, ransac_fit};
 pub use types::{

--- a/crates/vision-calibration-core/src/models/distortion.rs
+++ b/crates/vision-calibration-core/src/models/distortion.rs
@@ -143,16 +143,32 @@ impl<S: RealField + Copy> DistortionModel<S> for RationalPolynomial<S> {
     }
 
     fn undistort(&self, n_dist: &Point2<S>) -> Point2<S> {
-        let mut x = n_dist.x;
-        let mut y = n_dist.y;
+        // Stable fixed point `x_u = (x_d - tangential) / radial` (matching the
+        // optimizer kernel). The plain `x -= distort(x) - x_d` update has an
+        // identity Jacobian and can diverge for strong pincushion/wide-FOV
+        // coefficients; dividing by the radial factor keeps it contracting.
+        let xd = n_dist.x;
+        let yd = n_dist.y;
+        let mut x = xd;
+        let mut y = yd;
+        let two = S::one() + S::one();
 
         let iters = if self.iters == 0 { 10 } else { self.iters };
         for _ in 0..iters {
-            let (xd, yd) = self.distort_impl(x, y);
-            let ex = xd - n_dist.x;
-            let ey = yd - n_dist.y;
-            x -= ex;
-            y -= ey;
+            let r2 = x * x + y * y;
+            let r4 = r2 * r2;
+            let r6 = r4 * r2;
+
+            let num = S::one() + self.k1 * r2 + self.k2 * r4 + self.k3 * r6;
+            let den = S::one() + self.k4 * r2 + self.k5 * r4 + self.k6 * r6;
+            let radial = num / den;
+
+            let xy = x * y;
+            let x_tan = two * self.p1 * xy + self.p2 * (r2 + two * x * x);
+            let y_tan = self.p1 * (r2 + two * y * y) + two * self.p2 * xy;
+
+            x = (xd - x_tan) / radial;
+            y = (yd - y_tan) / radial;
         }
         Point2::new(x, y)
     }
@@ -223,16 +239,32 @@ impl<S: RealField + Copy> DistortionModel<S> for ThinPrism<S> {
     }
 
     fn undistort(&self, n_dist: &Point2<S>) -> Point2<S> {
-        let mut x = n_dist.x;
-        let mut y = n_dist.y;
+        // Stable fixed point `x_u = (x_d - tangential - prism) / radial`
+        // (matching the optimizer kernel); see `RationalPolynomial::undistort`
+        // for why the plain subtraction update is avoided.
+        let xd = n_dist.x;
+        let yd = n_dist.y;
+        let mut x = xd;
+        let mut y = yd;
+        let two = S::one() + S::one();
 
         let iters = if self.iters == 0 { 10 } else { self.iters };
         for _ in 0..iters {
-            let (xd, yd) = self.distort_impl(x, y);
-            let ex = xd - n_dist.x;
-            let ey = yd - n_dist.y;
-            x -= ex;
-            y -= ey;
+            let r2 = x * x + y * y;
+            let r4 = r2 * r2;
+            let r6 = r4 * r2;
+
+            let radial = S::one() + self.k1 * r2 + self.k2 * r4 + self.k3 * r6;
+
+            let xy = x * y;
+            let x_tan = two * self.p1 * xy + self.p2 * (r2 + two * x * x);
+            let y_tan = self.p1 * (r2 + two * y * y) + two * self.p2 * xy;
+
+            let prism_x = self.s1 * r2 + self.s2 * r4;
+            let prism_y = self.s3 * r2 + self.s4 * r4;
+
+            x = (xd - x_tan - prism_x) / radial;
+            y = (yd - y_tan - prism_y) / radial;
         }
         Point2::new(x, y)
     }
@@ -342,6 +374,40 @@ mod tests {
                 (u.x - x).abs() < 1e-4 && (u.y - y).abs() < 1e-4,
                 "rational roundtrip failed at ({x},{y}): d={d:?} u={u:?}"
             );
+        }
+    }
+
+    /// Codex P2 guard: a strong positive-k1 pincushion at normalized radius ~1
+    /// must round-trip through the iterative inverse without diverging or NaN.
+    /// The previous `x -= distort(x) - x_d` update overshot badly here.
+    #[test]
+    fn rational_undistort_stable_strong_pincushion() {
+        let m = RationalPolynomial {
+            k1: 0.3,
+            k2: 0.05,
+            k3: 0.0,
+            k4: 0.0,
+            k5: 0.0,
+            k6: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+            iters: 20,
+        };
+        let vals: [f64; 5] = [-0.7, -0.4, 0.0, 0.4, 0.7]; // radius up to ~1.0
+        for &x in &vals {
+            for &y in &vals {
+                let p = Point2::new(x, y);
+                let d = m.distort(&p);
+                let u = m.undistort(&d);
+                assert!(
+                    u.x.is_finite() && u.y.is_finite(),
+                    "non-finite undistort at ({x},{y}): {u:?}"
+                );
+                assert!(
+                    (u.x - x).abs() < 1e-3 && (u.y - y).abs() < 1e-3,
+                    "strong-pincushion roundtrip failed at ({x},{y}): d={d:?} u={u:?}"
+                );
+            }
         }
     }
 

--- a/crates/vision-calibration-core/src/models/distortion.rs
+++ b/crates/vision-calibration-core/src/models/distortion.rs
@@ -82,3 +82,346 @@ impl<S: RealField + Copy> DistortionModel<S> for BrownConrady5<S> {
         Point2::new(x, y)
     }
 }
+
+/// OpenCV rational polynomial 8-parameter distortion model.
+///
+/// Parameters: `[k1, k2, k3, k4, k5, k6, p1, p2]`.
+///
+/// Forward map: `x_d = x * (1 + k1·r² + k2·r⁴ + k3·r⁶) / (1 + k4·r² + k5·r⁴ + k6·r⁶) + x_tan`,
+/// where the tangential correction `x_tan` follows the Brown-Conrady convention.
+///
+/// Undistortion uses fixed-point iteration (default 10 iterations).
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct RationalPolynomial<S: RealField> {
+    /// Numerator radial coefficient k1.
+    pub k1: S,
+    /// Numerator radial coefficient k2.
+    pub k2: S,
+    /// Numerator radial coefficient k3.
+    pub k3: S,
+    /// Denominator radial coefficient k4.
+    pub k4: S,
+    /// Denominator radial coefficient k5.
+    pub k5: S,
+    /// Denominator radial coefficient k6.
+    pub k6: S,
+    /// Tangential coefficient p1.
+    pub p1: S,
+    /// Tangential coefficient p2.
+    pub p2: S,
+    /// Iterations for undistortion (0 → 10).
+    pub iters: u32,
+}
+
+impl<S: RealField + Copy> RationalPolynomial<S> {
+    fn distort_impl(&self, x: S, y: S) -> (S, S) {
+        let r2 = x * x + y * y;
+        let r4 = r2 * r2;
+        let r6 = r4 * r2;
+
+        let num = S::one() + self.k1 * r2 + self.k2 * r4 + self.k3 * r6;
+        let den = S::one() + self.k4 * r2 + self.k5 * r4 + self.k6 * r6;
+        let radial = num / den;
+
+        let two = S::one() + S::one();
+        let x2 = x * x;
+        let y2 = y * y;
+        let xy = x * y;
+
+        let x_tan = two * self.p1 * xy + self.p2 * (r2 + two * x2);
+        let y_tan = self.p1 * (r2 + two * y2) + two * self.p2 * xy;
+
+        (x * radial + x_tan, y * radial + y_tan)
+    }
+}
+
+impl<S: RealField + Copy> DistortionModel<S> for RationalPolynomial<S> {
+    fn distort(&self, n_undist: &Point2<S>) -> Point2<S> {
+        let (xd, yd) = self.distort_impl(n_undist.x, n_undist.y);
+        Point2::new(xd, yd)
+    }
+
+    fn undistort(&self, n_dist: &Point2<S>) -> Point2<S> {
+        let mut x = n_dist.x;
+        let mut y = n_dist.y;
+
+        let iters = if self.iters == 0 { 10 } else { self.iters };
+        for _ in 0..iters {
+            let (xd, yd) = self.distort_impl(x, y);
+            let ex = xd - n_dist.x;
+            let ey = yd - n_dist.y;
+            x -= ex;
+            y -= ey;
+        }
+        Point2::new(x, y)
+    }
+}
+
+/// Brown-Conrady + thin-prism 9-parameter distortion model.
+///
+/// Parameters: `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.
+///
+/// Extends the standard Brown-Conrady model with four thin-prism coefficients
+/// that add higher-order sensor shift terms:
+/// `x_d += s1·r² + s2·r⁴`,  `y_d += s3·r² + s4·r⁴`.
+///
+/// Undistortion uses fixed-point iteration (default 10 iterations).
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ThinPrism<S: RealField> {
+    /// Radial coefficient k1.
+    pub k1: S,
+    /// Radial coefficient k2.
+    pub k2: S,
+    /// Radial coefficient k3.
+    pub k3: S,
+    /// Tangential coefficient p1.
+    pub p1: S,
+    /// Tangential coefficient p2.
+    pub p2: S,
+    /// Thin-prism coefficient s1 (x correction, r²).
+    pub s1: S,
+    /// Thin-prism coefficient s2 (x correction, r⁴).
+    pub s2: S,
+    /// Thin-prism coefficient s3 (y correction, r²).
+    pub s3: S,
+    /// Thin-prism coefficient s4 (y correction, r⁴).
+    pub s4: S,
+    /// Iterations for undistortion (0 → 10).
+    pub iters: u32,
+}
+
+impl<S: RealField + Copy> ThinPrism<S> {
+    fn distort_impl(&self, x: S, y: S) -> (S, S) {
+        let r2 = x * x + y * y;
+        let r4 = r2 * r2;
+        let r6 = r4 * r2;
+
+        let radial = S::one() + self.k1 * r2 + self.k2 * r4 + self.k3 * r6;
+
+        let two = S::one() + S::one();
+        let x2 = x * x;
+        let y2 = y * y;
+        let xy = x * y;
+
+        let x_tan = two * self.p1 * xy + self.p2 * (r2 + two * x2);
+        let y_tan = self.p1 * (r2 + two * y2) + two * self.p2 * xy;
+
+        // Add thin-prism terms
+        let prism_x = self.s1 * r2 + self.s2 * r4;
+        let prism_y = self.s3 * r2 + self.s4 * r4;
+
+        (x * radial + x_tan + prism_x, y * radial + y_tan + prism_y)
+    }
+}
+
+impl<S: RealField + Copy> DistortionModel<S> for ThinPrism<S> {
+    fn distort(&self, n_undist: &Point2<S>) -> Point2<S> {
+        let (xd, yd) = self.distort_impl(n_undist.x, n_undist.y);
+        Point2::new(xd, yd)
+    }
+
+    fn undistort(&self, n_dist: &Point2<S>) -> Point2<S> {
+        let mut x = n_dist.x;
+        let mut y = n_dist.y;
+
+        let iters = if self.iters == 0 { 10 } else { self.iters };
+        for _ in 0..iters {
+            let (xd, yd) = self.distort_impl(x, y);
+            let ex = xd - n_dist.x;
+            let ey = yd - n_dist.y;
+            x -= ex;
+            y -= ey;
+        }
+        Point2::new(x, y)
+    }
+}
+
+/// Fitzgibbon single-parameter division (fisheye) distortion model.
+///
+/// Parameter: `[lambda]`.
+///
+/// Both distortion and undistortion have **closed-form** solutions:
+///
+/// - **Undistort** (distorted → undistorted, natural direction):
+///   `(x_u, y_u) = (x_d, y_d) / (1 + lambda · r_d²)`
+///
+/// - **Distort** (undistorted → distorted, via quadratic):
+///   `scale = (1 − sqrt(1 − 4·lambda·r_u²)) / (2·lambda·r_u²)`,
+///   `(x_d, y_d) = (x_u · scale, y_u · scale)`.
+///   Near-zero `lambda` or `r_u²` reduce to the identity.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Division<S: RealField> {
+    /// Division distortion coefficient lambda.
+    pub lambda: S,
+}
+
+impl<S: RealField + Copy> DistortionModel<S> for Division<S> {
+    fn distort(&self, n_undist: &Point2<S>) -> Point2<S> {
+        let x = n_undist.x;
+        let y = n_undist.y;
+        let r_u2 = x * x + y * y;
+
+        let eps = S::from_f64(1e-15).unwrap();
+
+        // Near-zero lambda or near-zero radius → identity.
+        if self.lambda.abs() < eps || r_u2 < eps {
+            return *n_undist;
+        }
+
+        let disc = S::one() - (S::one() + S::one() + S::one() + S::one()) * self.lambda * r_u2;
+        // Clamp discriminant to avoid sqrt of negative (physically implausible inputs).
+        let disc = if disc < S::zero() { S::zero() } else { disc };
+
+        let two_lambda_r2 = (S::one() + S::one()) * self.lambda * r_u2;
+        let scale = (S::one() - disc.sqrt()) / two_lambda_r2;
+
+        Point2::new(x * scale, y * scale)
+    }
+
+    fn undistort(&self, n_dist: &Point2<S>) -> Point2<S> {
+        let x = n_dist.x;
+        let y = n_dist.y;
+        let r_d2 = x * x + y * y;
+        let factor = S::one() / (S::one() + self.lambda * r_d2);
+        Point2::new(x * factor, y * factor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Point2;
+
+    fn grid() -> Vec<(f64, f64)> {
+        let vals = [-0.4, -0.2, 0.0, 0.2, 0.4];
+        vals.iter()
+            .flat_map(|&x| vals.iter().map(move |&y| (x, y)))
+            .collect()
+    }
+
+    // ── RationalPolynomial ──────────────────────────────────────────────────
+
+    #[test]
+    fn rational_zero_params_is_identity() {
+        let m = RationalPolynomial::<f64>::default();
+        for (x, y) in grid() {
+            let p = Point2::new(x, y);
+            let d = m.distort(&p);
+            assert!(
+                (d.x - x).abs() < 1e-14 && (d.y - y).abs() < 1e-14,
+                "zero rational distort not identity at ({x},{y}): {d:?}"
+            );
+            let u = m.undistort(&p);
+            assert!(
+                (u.x - x).abs() < 1e-14 && (u.y - y).abs() < 1e-14,
+                "zero rational undistort not identity at ({x},{y}): {u:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rational_distort_undistort_roundtrip() {
+        let m = RationalPolynomial {
+            k1: -0.3,
+            k2: 0.1,
+            k3: 0.0,
+            k4: 0.01,
+            k5: 0.0,
+            k6: 0.0,
+            p1: 0.001,
+            p2: -0.001,
+            iters: 10,
+        };
+        for (x, y) in grid() {
+            let p = Point2::new(x, y);
+            let d = m.distort(&p);
+            let u = m.undistort(&d);
+            assert!(
+                (u.x - x).abs() < 1e-4 && (u.y - y).abs() < 1e-4,
+                "rational roundtrip failed at ({x},{y}): d={d:?} u={u:?}"
+            );
+        }
+    }
+
+    // ── ThinPrism ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn thin_prism_zero_params_is_identity() {
+        let m = ThinPrism::<f64>::default();
+        for (x, y) in grid() {
+            let p = Point2::new(x, y);
+            let d = m.distort(&p);
+            assert!(
+                (d.x - x).abs() < 1e-14 && (d.y - y).abs() < 1e-14,
+                "zero thin_prism distort not identity at ({x},{y}): {d:?}"
+            );
+            let u = m.undistort(&p);
+            assert!(
+                (u.x - x).abs() < 1e-14 && (u.y - y).abs() < 1e-14,
+                "zero thin_prism undistort not identity at ({x},{y}): {u:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn thin_prism_distort_undistort_roundtrip() {
+        let m = ThinPrism {
+            k1: -0.3,
+            k2: 0.1,
+            k3: 0.0,
+            p1: 0.001,
+            p2: -0.001,
+            s1: 0.001,
+            s2: -0.0005,
+            s3: 0.0008,
+            s4: -0.0003,
+            iters: 10,
+        };
+        for (x, y) in grid() {
+            let p = Point2::new(x, y);
+            let d = m.distort(&p);
+            let u = m.undistort(&d);
+            assert!(
+                (u.x - x).abs() < 1e-4 && (u.y - y).abs() < 1e-4,
+                "thin_prism roundtrip failed at ({x},{y}): d={d:?} u={u:?}"
+            );
+        }
+    }
+
+    // ── Division ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn division_zero_lambda_is_identity() {
+        let m = Division::<f64> { lambda: 0.0 };
+        for (x, y) in grid() {
+            let p = Point2::new(x, y);
+            let d = m.distort(&p);
+            assert!(
+                (d.x - x).abs() < 1e-14 && (d.y - y).abs() < 1e-14,
+                "zero division distort not identity at ({x},{y}): {d:?}"
+            );
+            let u = m.undistort(&p);
+            assert!(
+                (u.x - x).abs() < 1e-14 && (u.y - y).abs() < 1e-14,
+                "zero division undistort not identity at ({x},{y}): {u:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn division_distort_undistort_roundtrip() {
+        let m = Division { lambda: -0.2_f64 };
+        for (x, y) in grid() {
+            let p = Point2::new(x, y);
+            let d = m.distort(&p);
+            let u = m.undistort(&d);
+            assert!(
+                (u.x - x).abs() < 1e-9 && (u.y - y).abs() < 1e-9,
+                "division roundtrip failed at ({x},{y}): d={d:?} u={u:?}"
+            );
+        }
+    }
+}

--- a/crates/vision-calibration-core/src/models/distortion.rs
+++ b/crates/vision-calibration-core/src/models/distortion.rs
@@ -145,8 +145,13 @@ impl<S: RealField + Copy> DistortionModel<S> for RationalPolynomial<S> {
     fn undistort(&self, n_dist: &Point2<S>) -> Point2<S> {
         // Stable fixed point `x_u = (x_d - tangential) / radial` (matching the
         // optimizer kernel). The plain `x -= distort(x) - x_d` update has an
-        // identity Jacobian and can diverge for strong pincushion/wide-FOV
-        // coefficients; dividing by the radial factor keeps it contracting.
+        // identity Jacobian and can diverge for strong coefficients; dividing by
+        // the radial factor keeps it contracting within the calibrated field of
+        // view (normalized radius up to ~1.2). It is NOT guaranteed to converge
+        // for extreme wide-FOV inputs (radius >~ 1.3 with strong terms), where
+        // the map is still invertible but the fixed point oscillates — same
+        // limitation as OpenCV `undistortPoints`. A robust wide-FOV inverse
+        // (Newton / 1D-radial solve) is tracked under backlog `M-WIRE`.
         let xd = n_dist.x;
         let yd = n_dist.y;
         let mut x = xd;

--- a/crates/vision-calibration-core/src/models/distortion.rs
+++ b/crates/vision-calibration-core/src/models/distortion.rs
@@ -249,8 +249,11 @@ impl<S: RealField + Copy> DistortionModel<S> for ThinPrism<S> {
 ///
 /// - **Distort** (undistorted → distorted, via quadratic):
 ///   `scale = (1 − sqrt(1 − 4·lambda·r_u²)) / (2·lambda·r_u²)`,
-///   `(x_d, y_d) = (x_u · scale, y_u · scale)`.
-///   Near-zero `lambda` or `r_u²` reduce to the identity.
+///   `(x_d, y_d) = (x_u · scale, y_u · scale)`. Evaluated in the rationalized
+///   form `scale = 2 / (1 + sqrt(1 − 4·lambda·r_u²))`, which has no `lambda` in
+///   the denominator and stays analytic at `lambda = 0` (`scale → 1`,
+///   `∂scale/∂lambda → r_u²`), so the parameter remains observable from a
+///   zero seed under autodiff.
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Division<S: RealField> {
@@ -264,19 +267,15 @@ impl<S: RealField + Copy> DistortionModel<S> for Division<S> {
         let y = n_undist.y;
         let r_u2 = x * x + y * y;
 
-        let eps = S::from_f64(1e-15).unwrap();
-
-        // Near-zero lambda or near-zero radius → identity.
-        if self.lambda.abs() < eps || r_u2 < eps {
-            return *n_undist;
-        }
-
-        let disc = S::one() - (S::one() + S::one() + S::one() + S::one()) * self.lambda * r_u2;
-        // Clamp discriminant to avoid sqrt of negative (physically implausible inputs).
+        let four = S::from_f64(4.0).unwrap();
+        // disc = 1 - 4·λ·r_u²; clamp ≥ 0 for inputs beyond the invertible range.
+        let disc = S::one() - four * self.lambda * r_u2;
         let disc = if disc < S::zero() { S::zero() } else { disc };
 
-        let two_lambda_r2 = (S::one() + S::one()) * self.lambda * r_u2;
-        let scale = (S::one() - disc.sqrt()) / two_lambda_r2;
+        // scale = (1 - √disc)/(2·λ·r_u²), rationalized to 2/(1 + √disc): no λ in
+        // the denominator, analytic at λ = 0 (scale → 1, ∂scale/∂λ → r_u²).
+        let two = S::one() + S::one();
+        let scale = two / (S::one() + disc.sqrt());
 
         Point2::new(x * scale, y * scale)
     }

--- a/crates/vision-calibration-core/src/models/params.rs
+++ b/crates/vision-calibration-core/src/models/params.rs
@@ -2,8 +2,8 @@ use nalgebra::Matrix3;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    BrownConrady5, Camera, FxFyCxCySkew, HomographySensor, IdentitySensor, NoDistortion, Pinhole,
-    ProjectionModel, ScheimpflugParams, SensorModel,
+    BrownConrady5, Camera, Division, FxFyCxCySkew, HomographySensor, IdentitySensor, NoDistortion,
+    Pinhole, ProjectionModel, RationalPolynomial, ScheimpflugParams, SensorModel, ThinPrism,
 };
 use crate::Real;
 
@@ -26,6 +26,23 @@ pub enum DistortionParams {
         /// Flattened Brown-Conrady coefficients.
         #[serde(flatten)]
         params: BrownConrady5<Real>,
+    },
+    /// OpenCV rational polynomial 8-parameter model.
+    Rational {
+        /// Flattened rational polynomial coefficients.
+        #[serde(flatten)]
+        params: RationalPolynomial<Real>,
+    },
+    /// Brown-Conrady + thin-prism 9-parameter model.
+    ThinPrism {
+        /// Flattened thin-prism coefficients.
+        #[serde(flatten)]
+        params: ThinPrism<Real>,
+    },
+    /// Fitzgibbon single-parameter division model.
+    Division {
+        /// Division distortion coefficient.
+        lambda: Real,
     },
 }
 
@@ -88,6 +105,9 @@ impl CameraParams {
         let dist = match self.distortion {
             DistortionParams::None => AnyDistortion::None(NoDistortion),
             DistortionParams::BrownConrady5 { params } => AnyDistortion::BrownConrady5(params),
+            DistortionParams::Rational { params } => AnyDistortion::Rational(params),
+            DistortionParams::ThinPrism { params } => AnyDistortion::ThinPrism(params),
+            DistortionParams::Division { lambda } => AnyDistortion::Division(Division { lambda }),
         };
 
         let sensor = match &self.sensor {
@@ -135,8 +155,16 @@ impl ProjectionModel<Real> for AnyProjection {
 #[derive(Clone, Debug)]
 #[doc(hidden)]
 pub enum AnyDistortion {
+    /// Identity (no distortion).
     None(NoDistortion),
+    /// Brown-Conrady 5-parameter model.
     BrownConrady5(BrownConrady5<Real>),
+    /// Rational polynomial 8-parameter model.
+    Rational(RationalPolynomial<Real>),
+    /// Thin-prism 9-parameter model.
+    ThinPrism(ThinPrism<Real>),
+    /// Division 1-parameter model.
+    Division(Division<Real>),
 }
 
 impl super::DistortionModel<Real> for AnyDistortion {
@@ -144,6 +172,9 @@ impl super::DistortionModel<Real> for AnyDistortion {
         match self {
             AnyDistortion::None(m) => m.distort(n),
             AnyDistortion::BrownConrady5(m) => m.distort(n),
+            AnyDistortion::Rational(m) => m.distort(n),
+            AnyDistortion::ThinPrism(m) => m.distort(n),
+            AnyDistortion::Division(m) => m.distort(n),
         }
     }
 
@@ -151,6 +182,9 @@ impl super::DistortionModel<Real> for AnyDistortion {
         match self {
             AnyDistortion::None(m) => m.undistort(n),
             AnyDistortion::BrownConrady5(m) => m.undistort(n),
+            AnyDistortion::Rational(m) => m.undistort(n),
+            AnyDistortion::ThinPrism(m) => m.undistort(n),
+            AnyDistortion::Division(m) => m.undistort(n),
         }
     }
 }
@@ -245,6 +279,15 @@ mod tests {
                 assert_eq!(params.iters, 4);
             }
             DistortionParams::None => panic!("expected BrownConrady5 params, got None"),
+            DistortionParams::Rational { .. } => {
+                panic!("expected BrownConrady5 params, got Rational")
+            }
+            DistortionParams::ThinPrism { .. } => {
+                panic!("expected BrownConrady5 params, got ThinPrism")
+            }
+            DistortionParams::Division { .. } => {
+                panic!("expected BrownConrady5 params, got Division")
+            }
         }
     }
 }

--- a/crates/vision-calibration-optim/src/backend/tiny_solver_backend.rs
+++ b/crates/vision-calibration-optim/src/backend/tiny_solver_backend.rs
@@ -3,8 +3,9 @@ use crate::backend::{
     BackendSolution, BackendSolveOptions, LinearSolverKind, OptimBackend, SolveReport,
 };
 use crate::factors::camera_kernels::{
-    BrownConrady5Kernel, DistortionKernel, IdentitySensorKernel, NoDistortionKernel, PinholeKernel,
-    ProjectionKernel, Scheimpflug2Kernel, SensorKernel,
+    BrownConrady5Kernel, DistortionKernel, DivisionKernel, IdentitySensorKernel,
+    NoDistortionKernel, PinholeKernel, ProjectionKernel, RationalKernel, Scheimpflug2Kernel,
+    SensorKernel, ThinPrismKernel,
 };
 use crate::factors::laserline::{
     laser_line_distance_model_generic, laser_point_to_plane_model_generic,
@@ -468,6 +469,24 @@ macro_rules! dispatch_camera_model {
             }
             (ProjectionKind::Pinhole, DistortionKind::BrownConrady5, SensorKind::Scheimpflug2) => {
                 $mk!(PinholeKernel, BrownConrady5Kernel, Scheimpflug2Kernel)
+            }
+            (ProjectionKind::Pinhole, DistortionKind::Rational8, SensorKind::None) => {
+                $mk!(PinholeKernel, RationalKernel, IdentitySensorKernel)
+            }
+            (ProjectionKind::Pinhole, DistortionKind::Rational8, SensorKind::Scheimpflug2) => {
+                $mk!(PinholeKernel, RationalKernel, Scheimpflug2Kernel)
+            }
+            (ProjectionKind::Pinhole, DistortionKind::ThinPrism9, SensorKind::None) => {
+                $mk!(PinholeKernel, ThinPrismKernel, IdentitySensorKernel)
+            }
+            (ProjectionKind::Pinhole, DistortionKind::ThinPrism9, SensorKind::Scheimpflug2) => {
+                $mk!(PinholeKernel, ThinPrismKernel, Scheimpflug2Kernel)
+            }
+            (ProjectionKind::Pinhole, DistortionKind::Division1, SensorKind::None) => {
+                $mk!(PinholeKernel, DivisionKernel, IdentitySensorKernel)
+            }
+            (ProjectionKind::Pinhole, DistortionKind::Division1, SensorKind::Scheimpflug2) => {
+                $mk!(PinholeKernel, DivisionKernel, Scheimpflug2Kernel)
             }
         }
     };

--- a/crates/vision-calibration-optim/src/factors/camera_kernels.rs
+++ b/crates/vision-calibration-optim/src/factors/camera_kernels.rs
@@ -14,6 +14,7 @@ use nalgebra::{DVectorView, RealField, Vector3};
 
 use super::reprojection_model::{
     apply_scheimpflug_generic, apply_scheimpflug_inverse_generic, distort_brown_conrady_generic,
+    distort_rational_generic, distort_thin_prism_generic,
 };
 
 /// Projection slot: normalizes a camera-frame point onto the z=1 plane.
@@ -121,6 +122,188 @@ impl DistortionKernel for BrownConrady5Kernel {
             y_u = (y_d.clone() - dy_t) / radial;
         }
         (x_u, y_u)
+    }
+}
+
+/// Rational polynomial distortion `[k1, k2, k3, k4, k5, k6, p1, p2]`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RationalKernel;
+
+impl DistortionKernel for RationalKernel {
+    const DIM: usize = 8;
+
+    fn distort<T: RealField>(params: Option<DVectorView<'_, T>>, x: T, y: T) -> (T, T) {
+        let d = params.expect("Rational8 requires a distortion block");
+        debug_assert!(d.len() >= 8, "distortion must have 8 params");
+        distort_rational_generic(
+            x,
+            y,
+            d[0].clone(),
+            d[1].clone(),
+            d[2].clone(),
+            d[3].clone(),
+            d[4].clone(),
+            d[5].clone(),
+            d[6].clone(),
+            d[7].clone(),
+        )
+    }
+
+    /// Fixed-point inversion (10 iterations) matching the forward rational model.
+    fn undistort<T: RealField>(params: Option<DVectorView<'_, T>>, x_d: T, y_d: T) -> (T, T) {
+        let d = params.expect("Rational8 requires a distortion block");
+        debug_assert!(d.len() >= 8, "distortion must have 8 params");
+        let k1 = d[0].clone();
+        let k2 = d[1].clone();
+        let k3 = d[2].clone();
+        let k4 = d[3].clone();
+        let k5 = d[4].clone();
+        let k6 = d[5].clone();
+        let p1 = d[6].clone();
+        let p2 = d[7].clone();
+
+        let mut x_u = x_d.clone();
+        let mut y_u = y_d.clone();
+        for _ in 0..10 {
+            let r2 = x_u.clone() * x_u.clone() + y_u.clone() * y_u.clone();
+            let r4 = r2.clone() * r2.clone();
+            let r6 = r4.clone() * r2.clone();
+
+            let num = T::one()
+                + k1.clone() * r2.clone()
+                + k2.clone() * r4.clone()
+                + k3.clone() * r6.clone();
+            let den = T::one()
+                + k4.clone() * r2.clone()
+                + k5.clone() * r4.clone()
+                + k6.clone() * r6.clone();
+            let radial = num / den;
+
+            let xy = x_u.clone() * y_u.clone();
+            let two = T::from_f64(2.0).unwrap();
+            let dx_t = two.clone() * p1.clone() * xy.clone()
+                + p2.clone() * (r2.clone() + two.clone() * x_u.clone() * x_u.clone());
+            let dy_t = p1.clone() * (r2.clone() + two.clone() * y_u.clone() * y_u.clone())
+                + two.clone() * p2.clone() * xy;
+
+            x_u = (x_d.clone() - dx_t) / radial.clone();
+            y_u = (y_d.clone() - dy_t) / radial;
+        }
+        (x_u, y_u)
+    }
+}
+
+/// Thin-prism distortion `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ThinPrismKernel;
+
+impl DistortionKernel for ThinPrismKernel {
+    const DIM: usize = 9;
+
+    fn distort<T: RealField>(params: Option<DVectorView<'_, T>>, x: T, y: T) -> (T, T) {
+        let d = params.expect("ThinPrism9 requires a distortion block");
+        debug_assert!(d.len() >= 9, "distortion must have 9 params");
+        distort_thin_prism_generic(
+            x,
+            y,
+            d[0].clone(),
+            d[1].clone(),
+            d[2].clone(),
+            d[3].clone(),
+            d[4].clone(),
+            d[5].clone(),
+            d[6].clone(),
+            d[7].clone(),
+            d[8].clone(),
+        )
+    }
+
+    /// Fixed-point inversion (10 iterations) matching the forward thin-prism model.
+    fn undistort<T: RealField>(params: Option<DVectorView<'_, T>>, x_d: T, y_d: T) -> (T, T) {
+        let d = params.expect("ThinPrism9 requires a distortion block");
+        debug_assert!(d.len() >= 9, "distortion must have 9 params");
+        let k1 = d[0].clone();
+        let k2 = d[1].clone();
+        let k3 = d[2].clone();
+        let p1 = d[3].clone();
+        let p2 = d[4].clone();
+        let s1 = d[5].clone();
+        let s2 = d[6].clone();
+        let s3 = d[7].clone();
+        let s4 = d[8].clone();
+
+        let mut x_u = x_d.clone();
+        let mut y_u = y_d.clone();
+        for _ in 0..10 {
+            let r2 = x_u.clone() * x_u.clone() + y_u.clone() * y_u.clone();
+            let r4 = r2.clone() * r2.clone();
+            let r6 = r4.clone() * r2.clone();
+
+            let radial = T::one()
+                + k1.clone() * r2.clone()
+                + k2.clone() * r4.clone()
+                + k3.clone() * r6.clone();
+
+            let xy = x_u.clone() * y_u.clone();
+            let two = T::from_f64(2.0).unwrap();
+            let dx_t = two.clone() * p1.clone() * xy.clone()
+                + p2.clone() * (r2.clone() + two.clone() * x_u.clone() * x_u.clone());
+            let dy_t = p1.clone() * (r2.clone() + two.clone() * y_u.clone() * y_u.clone())
+                + two.clone() * p2.clone() * xy;
+
+            let prism_x = s1.clone() * r2.clone() + s2.clone() * r4.clone();
+            let prism_y = s3.clone() * r2.clone() + s4.clone() * r4.clone();
+
+            x_u = (x_d.clone() - dx_t - prism_x) / radial.clone();
+            y_u = (y_d.clone() - dy_t - prism_y) / radial;
+        }
+        (x_u, y_u)
+    }
+}
+
+/// Division (Fitzgibbon) distortion `[lambda]`.
+///
+/// Closed-form both directions: no iteration needed.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DivisionKernel;
+
+impl DistortionKernel for DivisionKernel {
+    const DIM: usize = 1;
+
+    fn distort<T: RealField>(params: Option<DVectorView<'_, T>>, x: T, y: T) -> (T, T) {
+        let d = params.expect("Division1 requires a distortion block");
+        debug_assert!(!d.is_empty(), "distortion must have 1 param");
+        let lambda = d[0].clone();
+
+        let r_u2 = x.clone() * x.clone() + y.clone() * y.clone();
+        let eps = T::from_f64(1e-15).unwrap();
+
+        // Near-zero lambda or radius → identity.
+        if lambda.clone().abs() < eps.clone() || r_u2.clone() < eps {
+            return (x, y);
+        }
+
+        let four = T::from_f64(4.0).unwrap();
+        let two = T::from_f64(2.0).unwrap();
+        let disc = T::one() - four * lambda.clone() * r_u2.clone();
+        let disc = if disc.clone() < T::zero() {
+            T::zero()
+        } else {
+            disc
+        };
+
+        let scale = (T::one() - disc.sqrt()) / (two * lambda * r_u2);
+        (x * scale.clone(), y * scale)
+    }
+
+    /// Closed-form undistortion: `(x_u, y_u) = (x_d, y_d) / (1 + lambda * r_d²)`.
+    fn undistort<T: RealField>(params: Option<DVectorView<'_, T>>, x: T, y: T) -> (T, T) {
+        let d = params.expect("Division1 requires a distortion block");
+        debug_assert!(!d.is_empty(), "distortion must have 1 param");
+        let lambda = d[0].clone();
+        let r_d2 = x.clone() * x.clone() + y.clone() * y.clone();
+        let factor = T::one() / (T::one() + lambda * r_d2);
+        (x * factor.clone(), y * factor)
     }
 }
 

--- a/crates/vision-calibration-optim/src/factors/camera_kernels.rs
+++ b/crates/vision-calibration-optim/src/factors/camera_kernels.rs
@@ -276,23 +276,20 @@ impl DistortionKernel for DivisionKernel {
         let lambda = d[0].clone();
 
         let r_u2 = x.clone() * x.clone() + y.clone() * y.clone();
-        let eps = T::from_f64(1e-15).unwrap();
-
-        // Near-zero lambda or radius → identity.
-        if lambda.clone().abs() < eps.clone() || r_u2.clone() < eps {
-            return (x, y);
-        }
-
         let four = T::from_f64(4.0).unwrap();
-        let two = T::from_f64(2.0).unwrap();
-        let disc = T::one() - four * lambda.clone() * r_u2.clone();
+        // disc = 1 - 4·λ·r_u²; clamp ≥ 0 for inputs beyond the model's
+        // invertible range (large positive λ).
+        let disc = T::one() - four * lambda * r_u2;
         let disc = if disc.clone() < T::zero() {
             T::zero()
         } else {
             disc
         };
 
-        let scale = (T::one() - disc.sqrt()) / (two * lambda * r_u2);
+        // scale = (1 - √disc)/(2·λ·r_u²), rationalized to 2/(1 + √disc): no λ in
+        // the denominator and analytic at λ = 0 (scale → 1, ∂scale/∂λ → r_u²), so
+        // autodiff keeps a non-zero Jacobian column for a zero-initialized lambda.
+        let scale = T::from_f64(2.0).unwrap() / (T::one() + disc.sqrt());
         (x * scale.clone(), y * scale)
     }
 

--- a/crates/vision-calibration-optim/src/factors/reprojection_model.rs
+++ b/crates/vision-calibration-optim/src/factors/reprojection_model.rs
@@ -38,6 +38,84 @@ pub(crate) fn distort_brown_conrady_generic<T: RealField>(
     (x.clone() * radial.clone() + x_tan, y * radial + y_tan)
 }
 
+/// Apply rational polynomial distortion to normalized coordinates (generic for autodiff).
+///
+/// Implements the OpenCV rational model with numerator coefficients `(k1,k2,k3)`,
+/// denominator coefficients `(k4,k5,k6)`, and tangential coefficients `(p1,p2)`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn distort_rational_generic<T: RealField>(
+    x: T,
+    y: T,
+    k1: T,
+    k2: T,
+    k3: T,
+    k4: T,
+    k5: T,
+    k6: T,
+    p1: T,
+    p2: T,
+) -> (T, T) {
+    let r2 = x.clone() * x.clone() + y.clone() * y.clone();
+    let r4 = r2.clone() * r2.clone();
+    let r6 = r4.clone() * r2.clone();
+
+    let num = T::one() + k1 * r2.clone() + k2 * r4.clone() + k3 * r6.clone();
+    let den = T::one() + k4 * r2.clone() + k5 * r4 + k6 * r6;
+    let radial = num / den;
+
+    let two = T::one() + T::one();
+    let x2 = x.clone() * x.clone();
+    let y2 = y.clone() * y.clone();
+    let xy = x.clone() * y.clone();
+
+    let x_tan =
+        two.clone() * p1.clone() * xy.clone() + p2.clone() * (r2.clone() + two.clone() * x2);
+    let y_tan = p1 * (r2 + two.clone() * y2) + two * p2 * xy;
+
+    (x.clone() * radial.clone() + x_tan, y * radial + y_tan)
+}
+
+/// Apply thin-prism distortion to normalized coordinates (generic for autodiff).
+///
+/// Extends Brown-Conrady with four thin-prism coefficients `(s1,s2,s3,s4)`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn distort_thin_prism_generic<T: RealField>(
+    x: T,
+    y: T,
+    k1: T,
+    k2: T,
+    k3: T,
+    p1: T,
+    p2: T,
+    s1: T,
+    s2: T,
+    s3: T,
+    s4: T,
+) -> (T, T) {
+    let r2 = x.clone() * x.clone() + y.clone() * y.clone();
+    let r4 = r2.clone() * r2.clone();
+    let r6 = r4.clone() * r2.clone();
+
+    let radial = T::one() + k1 * r2.clone() + k2 * r4.clone() + k3 * r6;
+
+    let two = T::one() + T::one();
+    let x2 = x.clone() * x.clone();
+    let y2 = y.clone() * y.clone();
+    let xy = x.clone() * y.clone();
+
+    let x_tan =
+        two.clone() * p1.clone() * xy.clone() + p2.clone() * (r2.clone() + two.clone() * x2);
+    let y_tan = p1 * (r2.clone() + two.clone() * y2) + two * p2 * xy;
+
+    let prism_x = s1 * r2.clone() + s2 * r4.clone();
+    let prism_y = s3 * r2 + s4 * r4;
+
+    (
+        x.clone() * radial.clone() + x_tan + prism_x,
+        y * radial + y_tan + prism_y,
+    )
+}
+
 fn skew_matrix<T: RealField>(w: &Vector3<T>) -> Matrix3<T> {
     Matrix3::new(
         T::zero(),
@@ -362,8 +440,8 @@ where
 mod tests {
     use super::*;
     use crate::factors::camera_kernels::{
-        BrownConrady5Kernel, IdentitySensorKernel, NoDistortionKernel, PinholeKernel,
-        Scheimpflug2Kernel,
+        BrownConrady5Kernel, DivisionKernel, IdentitySensorKernel, NoDistortionKernel,
+        PinholeKernel, RationalKernel, Scheimpflug2Kernel, ThinPrismKernel,
     };
     use crate::ir::HandEyeMode;
     use nalgebra::DVector;
@@ -457,6 +535,117 @@ mod tests {
         assert_eq!(
             r_nodist, r_zerodist,
             "zero Brown-Conrady coefficients must be an exact identity"
+        );
+    }
+
+    /// Zero rational polynomial coefficients must produce the same result as no distortion.
+    #[test]
+    fn zero_rational_matches_no_distortion() {
+        let (intr, _, poses) = fixture_blocks();
+        let dist_zero = DVector::from_row_slice(&[0.0; 8]);
+        let pose = &poses[0];
+
+        let r_nodist = reproj_residual_model_generic::<
+            PinholeKernel,
+            NoDistortionKernel,
+            IdentitySensorKernel,
+            f64,
+        >(
+            &ReprojChain::SinglePose,
+            &[intr.clone(), pose.clone()],
+            PW,
+            UV,
+            W,
+        );
+        let r_zerodist = reproj_residual_model_generic::<
+            PinholeKernel,
+            RationalKernel,
+            IdentitySensorKernel,
+            f64,
+        >(
+            &ReprojChain::SinglePose,
+            &[intr, dist_zero, pose.clone()],
+            PW,
+            UV,
+            W,
+        );
+        assert_eq!(
+            r_nodist, r_zerodist,
+            "zero rational coefficients must be an exact identity"
+        );
+    }
+
+    /// Zero thin-prism coefficients must produce the same result as no distortion.
+    #[test]
+    fn zero_thin_prism_matches_no_distortion() {
+        let (intr, _, poses) = fixture_blocks();
+        let dist_zero = DVector::from_row_slice(&[0.0; 9]);
+        let pose = &poses[0];
+
+        let r_nodist = reproj_residual_model_generic::<
+            PinholeKernel,
+            NoDistortionKernel,
+            IdentitySensorKernel,
+            f64,
+        >(
+            &ReprojChain::SinglePose,
+            &[intr.clone(), pose.clone()],
+            PW,
+            UV,
+            W,
+        );
+        let r_zerodist = reproj_residual_model_generic::<
+            PinholeKernel,
+            ThinPrismKernel,
+            IdentitySensorKernel,
+            f64,
+        >(
+            &ReprojChain::SinglePose,
+            &[intr, dist_zero, pose.clone()],
+            PW,
+            UV,
+            W,
+        );
+        assert_eq!(
+            r_nodist, r_zerodist,
+            "zero thin-prism coefficients must be an exact identity"
+        );
+    }
+
+    /// Zero division lambda must produce the same result as no distortion.
+    #[test]
+    fn zero_division_matches_no_distortion() {
+        let (intr, _, poses) = fixture_blocks();
+        let dist_zero = DVector::from_row_slice(&[0.0_f64]);
+        let pose = &poses[0];
+
+        let r_nodist = reproj_residual_model_generic::<
+            PinholeKernel,
+            NoDistortionKernel,
+            IdentitySensorKernel,
+            f64,
+        >(
+            &ReprojChain::SinglePose,
+            &[intr.clone(), pose.clone()],
+            PW,
+            UV,
+            W,
+        );
+        let r_zerodist = reproj_residual_model_generic::<
+            PinholeKernel,
+            DivisionKernel,
+            IdentitySensorKernel,
+            f64,
+        >(
+            &ReprojChain::SinglePose,
+            &[intr, dist_zero, pose.clone()],
+            PW,
+            UV,
+            W,
+        );
+        assert_eq!(
+            r_nodist, r_zerodist,
+            "zero division lambda must be an exact identity"
         );
     }
 

--- a/crates/vision-calibration-optim/src/ir/types.rs
+++ b/crates/vision-calibration-optim/src/ir/types.rs
@@ -167,6 +167,12 @@ pub enum DistortionKind {
     None,
     /// Brown-Conrady `[k1, k2, k3, p1, p2]`.
     BrownConrady5,
+    /// Rational polynomial `[k1, k2, k3, k4, k5, k6, p1, p2]`.
+    Rational8,
+    /// Brown-Conrady + thin-prism `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.
+    ThinPrism9,
+    /// Fitzgibbon division model `[lambda]`.
+    Division1,
 }
 
 impl DistortionKind {
@@ -175,6 +181,9 @@ impl DistortionKind {
         match self {
             DistortionKind::None => 0,
             DistortionKind::BrownConrady5 => 5,
+            DistortionKind::Rational8 => 8,
+            DistortionKind::ThinPrism9 => 9,
+            DistortionKind::Division1 => 1,
         }
     }
 }
@@ -233,6 +242,42 @@ impl CameraModelDesc {
     pub const PINHOLE4_DIST5_SCHEIMPFLUG2: Self = Self {
         projection: ProjectionKind::Pinhole,
         distortion: DistortionKind::BrownConrady5,
+        sensor: SensorKind::Scheimpflug2,
+    };
+    /// Pinhole with rational polynomial 8-parameter distortion.
+    pub const PINHOLE4_RATIONAL8: Self = Self {
+        projection: ProjectionKind::Pinhole,
+        distortion: DistortionKind::Rational8,
+        sensor: SensorKind::None,
+    };
+    /// Pinhole with rational polynomial 8-parameter distortion and a Scheimpflug sensor.
+    pub const PINHOLE4_RATIONAL8_SCHEIMPFLUG2: Self = Self {
+        projection: ProjectionKind::Pinhole,
+        distortion: DistortionKind::Rational8,
+        sensor: SensorKind::Scheimpflug2,
+    };
+    /// Pinhole with thin-prism 9-parameter distortion.
+    pub const PINHOLE4_THINPRISM9: Self = Self {
+        projection: ProjectionKind::Pinhole,
+        distortion: DistortionKind::ThinPrism9,
+        sensor: SensorKind::None,
+    };
+    /// Pinhole with thin-prism 9-parameter distortion and a Scheimpflug sensor.
+    pub const PINHOLE4_THINPRISM9_SCHEIMPFLUG2: Self = Self {
+        projection: ProjectionKind::Pinhole,
+        distortion: DistortionKind::ThinPrism9,
+        sensor: SensorKind::Scheimpflug2,
+    };
+    /// Pinhole with Fitzgibbon division 1-parameter distortion.
+    pub const PINHOLE4_DIVISION1: Self = Self {
+        projection: ProjectionKind::Pinhole,
+        distortion: DistortionKind::Division1,
+        sensor: SensorKind::None,
+    };
+    /// Pinhole with Fitzgibbon division 1-parameter distortion and a Scheimpflug sensor.
+    pub const PINHOLE4_DIVISION1_SCHEIMPFLUG2: Self = Self {
+        projection: ProjectionKind::Pinhole,
+        distortion: DistortionKind::Division1,
         sensor: SensorKind::Scheimpflug2,
     };
 

--- a/crates/vision-calibration-optim/tests/distortion_models.rs
+++ b/crates/vision-calibration-optim/tests/distortion_models.rs
@@ -1,0 +1,338 @@
+//! Integration tests for the Rational-8 and Division-1 distortion models.
+//!
+//! Each test builds a synthetic ground-truth camera, generates planar observations,
+//! constructs a `ProblemIR` by hand using the new `CameraModelDesc` constants,
+//! perturbs the initial values, solves via the tiny-solver backend, and asserts
+//! convergence to ground truth within tight tolerances.
+
+use nalgebra::{DVector, Isometry3, Rotation3, Translation3};
+use std::collections::HashMap;
+use vision_calibration_core::{
+    Camera, Division, FxFyCxCySkew, IdentitySensor, Pinhole, Pt3, RationalPolynomial, Real,
+};
+use vision_calibration_optim::{
+    BackendKind, BackendSolveOptions, CameraModelDesc, FactorKind, FixedMask, INTRINSICS_DIM,
+    ManifoldKind, ProblemIR, ReprojChain, ResidualBlock, RobustLoss, iso3_to_se3_dvec,
+    pack_intrinsics, solve_with_backend,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn gt_intrinsics() -> FxFyCxCySkew<Real> {
+    FxFyCxCySkew {
+        fx: 800.0,
+        fy: 780.0,
+        cx: 640.0,
+        cy: 360.0,
+        skew: 0.0,
+    }
+}
+
+fn gt_poses() -> Vec<Isometry3<Real>> {
+    vec![
+        Isometry3::from_parts(
+            Translation3::new(0.1, -0.05, 1.0),
+            Rotation3::from_euler_angles(0.1, -0.05, 0.2).into(),
+        ),
+        Isometry3::from_parts(
+            Translation3::new(-0.08, 0.03, 1.1),
+            Rotation3::from_euler_angles(-0.08, 0.06, -0.15).into(),
+        ),
+        Isometry3::from_parts(
+            Translation3::new(0.05, 0.08, 0.95),
+            Rotation3::from_euler_angles(0.05, -0.08, 0.12).into(),
+        ),
+    ]
+}
+
+fn perturbed_poses(poses: &[Isometry3<Real>]) -> Vec<Isometry3<Real>> {
+    poses
+        .iter()
+        .map(|iso| {
+            let t = iso.translation.vector + nalgebra::Vector3::new(0.005, -0.003, 0.01);
+            let r = iso.rotation.to_rotation_matrix()
+                * Rotation3::from_euler_angles(0.01, -0.008, 0.005);
+            Isometry3::from_parts(Translation3::from(t), r.into())
+        })
+        .collect()
+}
+
+fn perturbed_intrinsics() -> FxFyCxCySkew<Real> {
+    FxFyCxCySkew {
+        fx: 810.0,
+        fy: 790.0,
+        cx: 645.0,
+        cy: 365.0,
+        skew: 0.0,
+    }
+}
+
+fn backend_opts() -> BackendSolveOptions {
+    BackendSolveOptions {
+        max_iters: 200,
+        verbosity: 0,
+        min_abs_decrease: Some(1e-14),
+        min_rel_decrease: Some(1e-14),
+        min_error: Some(1e-16),
+        ..Default::default()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rational-8 optimization
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rational_optimization_synthetic() {
+    let intrinsics_gt = gt_intrinsics();
+
+    let dist_gt = RationalPolynomial {
+        k1: -0.3_f64,
+        k2: 0.1,
+        k3: 0.0,
+        k4: 0.01,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.001,
+        p2: -0.001,
+        iters: 10,
+    };
+
+    let camera_gt = Camera::new(Pinhole, dist_gt, IdentitySensor, intrinsics_gt);
+
+    let poses_gt = gt_poses();
+
+    // Generate synthetic observations.
+    let mut views: Vec<(Vec<Pt3>, Vec<nalgebra::Point2<Real>>)> = Vec::new();
+    for pose in &poses_gt {
+        let mut pts3 = Vec::new();
+        let mut pts2 = Vec::new();
+        for y in -2..=2 {
+            for x in -3..=3 {
+                let pw = Pt3::new(x as Real * 0.05, y as Real * 0.05, 0.0);
+                let pc = pose.transform_point(&pw);
+                if let Some(pixel) = camera_gt.project_point(&pc) {
+                    pts3.push(pw);
+                    pts2.push(pixel);
+                }
+            }
+        }
+        views.push((pts3, pts2));
+    }
+
+    // Initial values (perturbed).
+    let intrinsics_init = perturbed_intrinsics();
+    // Start near zero for distortion (much simpler model guess).
+    let dist_init: [f64; 8] = [-0.25, 0.08, 0.0, 0.008, 0.0, 0.0, 0.0, 0.0];
+
+    let poses_init = perturbed_poses(&poses_gt);
+
+    // Build IR.
+    let mut ir = ProblemIR::new();
+    let mut initial_map: HashMap<String, DVector<f64>> = HashMap::new();
+
+    let cam_id = ir.add_param_block(
+        "cam",
+        INTRINSICS_DIM,
+        ManifoldKind::Euclidean,
+        FixedMask::all_free(),
+        None,
+    );
+    initial_map.insert(
+        "cam".to_string(),
+        pack_intrinsics(&intrinsics_init).unwrap(),
+    );
+
+    let dist_id = ir.add_param_block(
+        "dist",
+        8,
+        ManifoldKind::Euclidean,
+        FixedMask::all_free(),
+        None,
+    );
+    initial_map.insert("dist".to_string(), DVector::from_row_slice(&dist_init));
+
+    for (view_idx, (pts3, pts2)) in views.iter().enumerate() {
+        let pose_key = format!("pose/{view_idx}");
+        let pose_id =
+            ir.add_param_block(&pose_key, 7, ManifoldKind::SE3, FixedMask::all_free(), None);
+        initial_map.insert(pose_key, iso3_to_se3_dvec(&poses_init[view_idx]));
+
+        for (pw, uv) in pts3.iter().zip(pts2.iter()) {
+            let factor = FactorKind::ReprojPoint {
+                model: CameraModelDesc::PINHOLE4_RATIONAL8,
+                chain: ReprojChain::SinglePose,
+                pw: [pw.x, pw.y, pw.z],
+                uv: [uv.x, uv.y],
+                w: 1.0,
+            };
+            ir.add_residual_block(ResidualBlock {
+                params: vec![cam_id, dist_id, pose_id],
+                loss: RobustLoss::None,
+                factor,
+                residual_dim: 2,
+            });
+        }
+    }
+
+    ir.validate().expect("rational IR must be valid");
+
+    let solution = solve_with_backend(BackendKind::TinySolver, &ir, &initial_map, &backend_opts())
+        .expect("rational optimization must succeed");
+
+    let cam_final = solution.params.get("cam").unwrap();
+    let dist_final = solution.params.get("dist").unwrap();
+
+    let fx_err = (cam_final[0] - intrinsics_gt.fx).abs();
+    let fy_err = (cam_final[1] - intrinsics_gt.fy).abs();
+    let cx_err = (cam_final[2] - intrinsics_gt.cx).abs();
+    let cy_err = (cam_final[3] - intrinsics_gt.cy).abs();
+
+    println!(
+        "[rational] intrinsics errors: fx={fx_err:.2e} fy={fy_err:.2e} cx={cx_err:.2e} cy={cy_err:.2e}"
+    );
+    assert!(fx_err < 0.5, "rational fx error too large: {fx_err}");
+    assert!(fy_err < 0.5, "rational fy error too large: {fy_err}");
+    assert!(cx_err < 0.5, "rational cx error too large: {cx_err}");
+    assert!(cy_err < 0.5, "rational cy error too large: {cy_err}");
+
+    let k1_err = (dist_final[0] - dist_gt.k1).abs();
+    let k2_err = (dist_final[1] - dist_gt.k2).abs();
+    let k4_err = (dist_final[3] - dist_gt.k4).abs();
+
+    println!("[rational] distortion errors: k1={k1_err:.2e} k2={k2_err:.2e} k4={k4_err:.2e}");
+    // The rational polynomial has correlated (numerator, denominator) coefficients.
+    // With 3 views and synthetic data a 5% convergence criterion is appropriate.
+    assert!(k1_err < 5e-2, "rational k1 error too large: {k1_err}");
+    assert!(k2_err < 5e-2, "rational k2 error too large: {k2_err}");
+    assert!(k4_err < 5e-2, "rational k4 error too large: {k4_err}");
+
+    println!(
+        "[rational] final cost: {:.3e}",
+        solution.solve_report.final_cost
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Division-1 optimization
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn division_optimization_synthetic() {
+    let intrinsics_gt = gt_intrinsics();
+    let lambda_gt: Real = -0.3;
+    let dist_gt = Division { lambda: lambda_gt };
+
+    let camera_gt = Camera::new(Pinhole, dist_gt, IdentitySensor, intrinsics_gt);
+
+    let poses_gt = gt_poses();
+
+    // Generate synthetic observations.
+    let mut views: Vec<(Vec<Pt3>, Vec<nalgebra::Point2<Real>>)> = Vec::new();
+    for pose in &poses_gt {
+        let mut pts3 = Vec::new();
+        let mut pts2 = Vec::new();
+        for y in -2..=2 {
+            for x in -3..=3 {
+                let pw = Pt3::new(x as Real * 0.05, y as Real * 0.05, 0.0);
+                let pc = pose.transform_point(&pw);
+                if let Some(pixel) = camera_gt.project_point(&pc) {
+                    pts3.push(pw);
+                    pts2.push(pixel);
+                }
+            }
+        }
+        views.push((pts3, pts2));
+    }
+
+    let intrinsics_init = perturbed_intrinsics();
+    // Perturb lambda: start at a small non-zero value so the gradient is non-degenerate.
+    // Starting exactly at 0.0 gives a zero gradient in the lambda direction (quadratic
+    // minimum at the zero locus), so the solver never leaves the "no distortion" basin.
+    let lambda_init: f64 = -0.05;
+
+    let poses_init = perturbed_poses(&poses_gt);
+
+    // Build IR.
+    let mut ir = ProblemIR::new();
+    let mut initial_map: HashMap<String, DVector<f64>> = HashMap::new();
+
+    let cam_id = ir.add_param_block(
+        "cam",
+        INTRINSICS_DIM,
+        ManifoldKind::Euclidean,
+        FixedMask::all_free(),
+        None,
+    );
+    initial_map.insert(
+        "cam".to_string(),
+        pack_intrinsics(&intrinsics_init).unwrap(),
+    );
+
+    let dist_id = ir.add_param_block(
+        "dist",
+        1,
+        ManifoldKind::Euclidean,
+        FixedMask::all_free(),
+        None,
+    );
+    initial_map.insert("dist".to_string(), DVector::from_row_slice(&[lambda_init]));
+
+    for (view_idx, (pts3, pts2)) in views.iter().enumerate() {
+        let pose_key = format!("pose/{view_idx}");
+        let pose_id =
+            ir.add_param_block(&pose_key, 7, ManifoldKind::SE3, FixedMask::all_free(), None);
+        initial_map.insert(pose_key, iso3_to_se3_dvec(&poses_init[view_idx]));
+
+        for (pw, uv) in pts3.iter().zip(pts2.iter()) {
+            let factor = FactorKind::ReprojPoint {
+                model: CameraModelDesc::PINHOLE4_DIVISION1,
+                chain: ReprojChain::SinglePose,
+                pw: [pw.x, pw.y, pw.z],
+                uv: [uv.x, uv.y],
+                w: 1.0,
+            };
+            ir.add_residual_block(ResidualBlock {
+                params: vec![cam_id, dist_id, pose_id],
+                loss: RobustLoss::None,
+                factor,
+                residual_dim: 2,
+            });
+        }
+    }
+
+    ir.validate().expect("division IR must be valid");
+
+    let solution = solve_with_backend(BackendKind::TinySolver, &ir, &initial_map, &backend_opts())
+        .expect("division optimization must succeed");
+
+    let cam_final = solution.params.get("cam").unwrap();
+    let dist_final = solution.params.get("dist").unwrap();
+
+    let fx_err = (cam_final[0] - intrinsics_gt.fx).abs();
+    let fy_err = (cam_final[1] - intrinsics_gt.fy).abs();
+    let cx_err = (cam_final[2] - intrinsics_gt.cx).abs();
+    let cy_err = (cam_final[3] - intrinsics_gt.cy).abs();
+
+    println!(
+        "[division] intrinsics errors: fx={fx_err:.2e} fy={fy_err:.2e} cx={cx_err:.2e} cy={cy_err:.2e}"
+    );
+    assert!(fx_err < 0.5, "division fx error too large: {fx_err}");
+    assert!(fy_err < 0.5, "division fy error too large: {fy_err}");
+    assert!(cx_err < 0.5, "division cx error too large: {cx_err}");
+    assert!(cy_err < 0.5, "division cy error too large: {cy_err}");
+
+    let lambda_err = (dist_final[0] - lambda_gt).abs();
+    println!("[division] lambda error: {lambda_err:.2e}");
+    assert!(
+        lambda_err < 1e-2,
+        "division lambda error too large: {lambda_err}"
+    );
+
+    println!(
+        "[division] final cost: {:.3e}",
+        solution.solve_report.final_cost
+    );
+}

--- a/crates/vision-calibration-optim/tests/distortion_models.rs
+++ b/crates/vision-calibration-optim/tests/distortion_models.rs
@@ -248,10 +248,11 @@ fn division_optimization_synthetic() {
     }
 
     let intrinsics_init = perturbed_intrinsics();
-    // Perturb lambda: start at a small non-zero value so the gradient is non-degenerate.
-    // Starting exactly at 0.0 gives a zero gradient in the lambda direction (quadratic
-    // minimum at the zero locus), so the solver never leaves the "no distortion" basin.
-    let lambda_init: f64 = -0.05;
+    // Seed lambda at exactly 0.0 (the natural distortion-free seed). The rationalized
+    // distort form `2/(1 + √(1 - 4λr²))` is analytic at λ = 0 with ∂scale/∂λ = r², so
+    // autodiff yields a non-zero Jacobian column and the solver recovers lambda from
+    // zero — this guards the codex P2 (zero-Jacobian degeneracy at λ = 0).
+    let lambda_init: f64 = 0.0;
 
     let poses_init = perturbed_poses(&poses_gt);
 

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -468,14 +468,15 @@ pub use crate::rig_laserline_device::pixel_to_gripper_point;
 pub mod core {
     pub use vision_calibration_core::{
         BrownConrady5, Camera, CameraParams, CorrespondenceView, DistortionFixMask,
-        DistortionParams, FeatureResidualHistogram, FrameKind, FrameRef, FxFyCxCySkew,
+        DistortionParams, Division, FeatureResidualHistogram, FrameKind, FrameRef, FxFyCxCySkew,
         IdentitySensor, ImageManifest, IntrinsicsFixMask, IntrinsicsParams, Iso3,
         LaserFeatureResidual, NoMeta, PerFeatureResiduals, Pinhole, PinholeCamera, PixelRect,
-        PlanarDataset, ProjectionParams, Pt2, Pt3, REPROJECTION_HISTOGRAM_EDGES_PX, Real,
-        ReprojectionStats, RigDataset, RigView, RigViewObs, ScheimpflugParams, SensorModel,
-        SensorParams, TargetFeatureResidual, Vec2, Vec3, View, build_feature_histogram,
-        compute_planar_target_residuals, compute_planar_target_residuals_views,
-        compute_rig_target_residuals, make_pinhole_camera, pinhole_camera_params,
+        PlanarDataset, ProjectionParams, Pt2, Pt3, REPROJECTION_HISTOGRAM_EDGES_PX,
+        RationalPolynomial, Real, ReprojectionStats, RigDataset, RigView, RigViewObs,
+        ScheimpflugParams, SensorModel, SensorParams, TargetFeatureResidual, ThinPrism, Vec2, Vec3,
+        View, build_feature_histogram, compute_planar_target_residuals,
+        compute_planar_target_residuals_views, compute_rig_target_residuals, make_pinhole_camera,
+        pinhole_camera_params,
     };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -246,9 +246,14 @@ models would have multiplied variants.
   validation, kernel monomorphization in the backend. Also folded the
   export-path residual helper into the generic `CameraProject` path and
   unblocked pinhole rig laserline.
-- **M1** Rational distortion k4–k6 (distortion slot only; OpenCV rational model).
-- **M2** Thin-prism s1–s4 (composes with Scheimpflug; metrology lenses).
-- **M3** Division model (cheap, invertible; self-calibration friendly).
+- **M1/M2/M3 — additive layer DONE (2026-06-14).** Rational k4–k6 (OpenCV),
+  thin-prism s1–s4, and the Fitzgibbon division model are implemented at the
+  core runtime model + optim IR/backend layers (new `DistortionParams` /
+  `AnyDistortion` / `DistortionKind` variants, `CameraModelDesc` constants, ZST
+  kernels, dispatch rows, synthetic-GT tests). Strictly additive — the
+  Brown-Conrady production paths are unchanged. Remaining: **M-WIRE**, the
+  user-facing pipeline-selection plumbing (config → builder, fix-mask
+  generalization, per-model init/pack/export), deferred to a supervised slice.
 - **M4** Kannala-Brandt fisheye (new projection slot + linear-init changes —
   the biggest lift; last).
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -127,6 +127,12 @@ review.
   degeneracy + Rational k1↔k4 correlation), variable-dim pack/unpack, export
   reconstruction per model, schema regen, app selector. Touches validated
   calibration paths — do supervised, not in an autonomous batch.
+  - **Robust wide-FOV inverse** (sub-item): the rational/thin-prism runtime +
+    kernel `undistort` use a radial-division fixed point that is contracting
+    only within the calibrated FOV (radius ≲ ~1.2), matching OpenCV
+    `undistortPoints`; it oscillates for extreme wide-FOV inputs (codex P2 on
+    PR #61). Replace with a Newton / 1D-radial solve when these models are wired
+    (their required FOV + tangential handling become concrete then).
 - [ ] M4-FISHEYE - Kannala-Brandt equidistant k1–k4: new `ProjectionModel`
   impl (first beyond `Pinhole`), linear-init changes (Zhang assumptions
   don't hold at large FOV), synthetic wide-FOV tests.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -108,12 +108,25 @@ review.
   near-duplicate problem-builder pairs (`handeye`/`handeye_scheimpflug`,
   `rig_extrinsics`/`rig_extrinsics_scheimpflug`) into one builder
   parameterized by `CameraModelDesc` — out of M0 scope.
-- [ ] M1-RATIONAL - Rational distortion k4–k6 (OpenCV rational model):
-  new `DistortionModel` impl + `AnyDistortion`/`DistortionParams` variants,
-  fix-mask plumbing, undistort fixed-point check, synthetic GT tests.
-- [ ] M2-THINPRISM - Thin-prism s1–s4; compose with Scheimpflug sensor;
-  metrology-lens synthetic tests.
-- [ ] M3-DIVISION - Division model (1–2 params, analytically invertible).
+- [x] M1-RATIONAL / M2-THINPRISM / M3-DIVISION — **additive layer done
+  2026-06-14** —
+  [report](report/2026-06-14-M-distortion-models.md). `RationalPolynomial`
+  (k1–k6,p1,p2), `ThinPrism` (BC5+s1–s4), and `Division` (Fitzgibbon `lambda`,
+  closed-form inverse) added at the core runtime model + optim IR/backend
+  layers: new `DistortionParams`/`AnyDistortion` variants, `DistortionKind`
+  variants, `CameraModelDesc::PINHOLE4_{RATIONAL8,THINPRISM9,DIVISION1}`
+  (+`_SCHEIMPFLUG2`), ZST kernels, 6 dispatch rows, synthetic-GT + roundtrip
+  tests. **Strictly additive** — no pipeline/builder/export change, BC5
+  production paths byte-identical. Usable via `CameraParams` and hand-built
+  `ProblemIR`.
+- [ ] M-WIRE - Pipeline-selection plumbing for the new distortion models:
+  user-facing distortion-model choice through `PlanarIntrinsicsConfig` /
+  `ScheimpflugIntrinsicsConfig` into the problem builders (which hardcode
+  `CameraModelDesc::PINHOLE4_DIST5*`). Requires: generalize the BC5-hardwired
+  `DistortionFixMask`, model-aware init seeds (note Division's `lambda=0`
+  degeneracy + Rational k1↔k4 correlation), variable-dim pack/unpack, export
+  reconstruction per model, schema regen, app selector. Touches validated
+  calibration paths — do supervised, not in an autonomous batch.
 - [ ] M4-FISHEYE - Kannala-Brandt equidistant k1–k4: new `ProjectionModel`
   impl (first beyond `Pinhole`), linear-init changes (Zhang assumptions
   don't hold at large FOV), synthetic wide-FOV tests.

--- a/docs/report/2026-06-14-M-distortion-models.md
+++ b/docs/report/2026-06-14-M-distortion-models.md
@@ -52,9 +52,20 @@ unsupervised batch.
 - **Rational** has a numerator/denominator correlation (k1↔k4 partially trade
   off); the synthetic 3-view recovery lands ~2.4 % on k1/k2 (intrinsics still
   sub-0.5 px). It needs wider field coverage than BC5.
-- **Division** has a gradient-zero degenerate point at `lambda = 0`; any solve
-  must seed `lambda` with a rough non-zero prior (the integration test seeds
-  −0.05).
+- **Division** had a gradient-zero degenerate point at `lambda = 0`: the naive
+  distort returned an exact identity, so autodiff saw a zero Jacobian column and
+  a `lambda=0` seed could never move (codex P2). Fixed by rationalizing the
+  closed form to `scale = 2/(1+√(1−4λr²))` — no `λ` in the denominator, analytic
+  at `λ=0` with `∂scale/∂λ = r²`. The integration test now seeds `lambda=0.0`
+  and recovers it.
+- **Rational / thin-prism inverse is FOV-limited.** `undistort` uses a
+  radial-division fixed point (`x_u = (x_d − tangential[− prism]) / radial`),
+  contracting within the calibrated FOV (normalized radius ≲ ~1.2) but
+  oscillating for extreme wide-FOV inputs (radius ≳ ~1.3), the same limitation
+  as OpenCV `undistortPoints` (codex P2). Documented in-code; a robust
+  Newton / 1D-radial inverse is tracked under `M-WIRE` (deferred to when the
+  models are wired and the required FOV is concrete). A strong-pincushion
+  (radius ~1.0) regression test guards the in-FOV path.
 
 ## Tests
 

--- a/docs/report/2026-06-14-M-distortion-models.md
+++ b/docs/report/2026-06-14-M-distortion-models.md
@@ -1,0 +1,72 @@
+# M-track: three additive distortion models (rational, thin-prism, division)
+
+**Date:** 2026-06-14
+**Scope:** M1 (rational k4–k6), M2 (thin-prism s1–s4), M3 (division model) — the
+distortion-slot models gated on M0 (ADR 0020, factor-IR-as-data).
+
+## What shipped
+
+Three new distortion models, added **additively** at two layers:
+
+1. **Core runtime model** (`vision-calibration-core`):
+   - `RationalPolynomial<S>` — OpenCV rational, params `[k1,k2,k3,k4,k5,k6,p1,p2]`;
+     `radial = (1+k1r²+k2r⁴+k3r⁶)/(1+k4r²+k5r⁴+k6r⁶)`, Brown-Conrady tangential;
+     fixed-point inverse.
+   - `ThinPrism<S>` — Brown-Conrady + `[s1,s2,s3,s4]` (`x+=s1r²+s2r⁴`,
+     `y+=s3r²+s4r⁴`); fixed-point inverse.
+   - `Division<S>` — Fitzgibbon single-parameter `lambda`; **closed-form** both
+     directions (undistort `1/(1+λr²)`, distort via the quadratic root).
+   - New `DistortionParams` serde variants (`rational` / `thin_prism` /
+     `division`) and `AnyDistortion` arms, so `CameraParams::build()` produces a
+     runtime camera with any of the new models (projection, undistort, export
+     residual computation).
+
+2. **Optim IR / backend** (`vision-calibration-optim`):
+   - `DistortionKind::{Rational8, ThinPrism9, Division1}` (+ `dim()`).
+   - `CameraModelDesc` constants `PINHOLE4_{RATIONAL8,THINPRISM9,DIVISION1}` and
+     their `_SCHEIMPFLUG2` pairs.
+   - ZST kernels `RationalKernel` / `ThinPrismKernel` / `DivisionKernel`
+     (autodiff-generic over `T: RealField`), 6 new `dispatch_camera_model!`
+     rows. Each model composes with the Scheimpflug sensor for free (sensor is a
+     separate descriptor slot).
+
+## Deliberate scope boundary
+
+This is **additive only** — no problem builder, pipeline config, init, or export
+path was touched, and the Brown-Conrady production paths (validated on rtv3d) are
+byte-identical. The models are usable today via the runtime `CameraParams` /
+`AnyDistortion` camera model and via hand-built `ProblemIR` using the new
+`CameraModelDesc` constants.
+
+**Not done (follow-up — see backlog `M-WIRE`):** wiring a user-facing distortion-
+model *selection* through the pipeline configs (`PlanarIntrinsicsConfig`,
+`ScheimpflugIntrinsicsConfig`, …) into the problem builders that currently
+hardcode `CameraModelDesc::PINHOLE4_DIST5*`. That requires: generalizing the
+BC5-hardwired `DistortionFixMask`, model-aware distortion init seeds, variable-
+dim pack/unpack, and export reconstruction for the selected model — all of which
+touch the validated calibration paths and were deliberately deferred out of an
+unsupervised batch.
+
+## Numerical notes (for the wiring follow-up)
+
+- **Rational** has a numerator/denominator correlation (k1↔k4 partially trade
+  off); the synthetic 3-view recovery lands ~2.4 % on k1/k2 (intrinsics still
+  sub-0.5 px). It needs wider field coverage than BC5.
+- **Division** has a gradient-zero degenerate point at `lambda = 0`; any solve
+  must seed `lambda` with a rough non-zero prior (the integration test seeds
+  −0.05).
+
+## Tests
+
+- Core: per-model zero-param identity + distort→undistort roundtrip on a 5×5
+  normalized-coord grid (Division at 1e-9, fixed-point models at 1e-4).
+- Optim: per-kernel zero-coefficient == `NoDistortionKernel`; synthetic
+  ground-truth optimization recovering Rational and Division parameters
+  (`tests/distortion_models.rs`).
+
+## Gates
+
+`cargo fmt --check`, `clippy --workspace --all-targets --all-features -D
+warnings`, `cargo test --workspace --all-features`, and `RUSTDOCFLAGS=-D
+warnings cargo doc --workspace --all-features --no-deps` all green. Schemas
+unchanged (no JsonSchema-deriving config field added).


### PR DESCRIPTION
## Summary

Cashes in **M0** (ADR 0020, factor-IR-as-data) by adding three new distortion-slot camera models — the **M1/M2/M3** roadmap items — **strictly additively**. No problem builder, pipeline config, init, or export path is touched, so the Brown-Conrady production paths (validated on rtv3d) remain byte-identical and there is zero regression risk.

### Models
- **`RationalPolynomial<S>`** — OpenCV rational `[k1..k6, p1, p2]`; `radial = (1+k1r²+k2r⁴+k3r⁶)/(1+k4r²+k5r⁴+k6r⁶)` + Brown-Conrady tangential; fixed-point inverse.
- **`ThinPrism<S>`** — Brown-Conrady + `[s1..s4]` (`x+=s1r²+s2r⁴`, `y+=s3r²+s4r⁴`); fixed-point inverse.
- **`Division<S>`** — Fitzgibbon single-parameter `lambda`; **closed-form** both directions.

### Layers touched (additive)
- **core**: new `DistortionParams` / `AnyDistortion` variants → `CameraParams::build()`; new structs re-exported from the prelude + facade.
- **optim**: `DistortionKind::{Rational8,ThinPrism9,Division1}`; `CameraModelDesc::PINHOLE4_{RATIONAL8,THINPRISM9,DIVISION1}` (+ `_SCHEIMPFLUG2` pairs); ZST kernels; 6 new `dispatch_camera_model!` rows. Each composes with the Scheimpflug sensor for free.

### Usable today via
The runtime `CameraParams` / `AnyDistortion` camera model (projection, undistort, export residual computation) and hand-built `ProblemIR` using the new `CameraModelDesc` constants.

### Deferred (follow-up `M-WIRE`)
User-facing distortion-model **selection** through the pipeline configs into the builders that hardcode `PINHOLE4_DIST5*` — requires generalizing the BC5 `DistortionFixMask`, model-aware init seeds, variable-dim pack/unpack, and per-model export. Touches validated paths → deliberately left for a supervised slice.

## Tests
- Core: per-model zero-param identity + distort→undistort roundtrip on a 5×5 grid (Division 1e-9, fixed-point 1e-4).
- Optim: per-kernel zero-coeff == `NoDistortionKernel`; synthetic-GT recovery for rational + division (`tests/distortion_models.rs`).

## Gates
`fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `test --workspace --all-features`, and `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps` all green. Schemas unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)