### PR TITLE
feat(mvg): land vision-geometry + vision-mvg crates (additive port, C1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,6 +3699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vision-geometry"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "nalgebra",
+ "vision-calibration-core",
+]
+
+[[package]]
 name = "vision-metrology"
 version = "0.1.0"
 source = "git+https://github.com/VitalyVorobyev/vision-metrology.git?tag=v0.1.0#c1547f8212d2811cad186f7588f6f5f25af3e6be"
@@ -3709,6 +3718,17 @@ dependencies = [
  "vm-laser",
  "vm-morph",
  "vm-pyr",
+]
+
+[[package]]
+name = "vision-mvg"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "nalgebra",
+ "tiny-solver",
+ "vision-calibration-core",
+ "vision-geometry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
     "crates/vision-calibration-dataset",
     "crates/vision-calibration-detect",
     "crates/vision-calibration-bench",
+    "crates/vision-geometry",
+    "crates/vision-mvg",
     "xtask",
 ]
 # `app/src-tauri/` is its own crate — it pulls in the Tauri build-time
@@ -39,6 +41,8 @@ vision-calibration-pipeline = { path = "./crates/vision-calibration-pipeline", v
 vision-calibration-dataset = { path = "./crates/vision-calibration-dataset", version = "0.5.1" }
 vision-calibration-detect = { path = "./crates/vision-calibration-detect", version = "0.5.1" }
 vision-calibration-bench = { path = "./crates/vision-calibration-bench", version = "0.5.1" }
+vision-geometry = { path = "./crates/vision-geometry", version = "0.5.1" }
+vision-mvg = { path = "./crates/vision-mvg", version = "0.5.1" }
 
 anyhow = "1"
 thiserror = "2"

--- a/crates/vision-geometry/Cargo.toml
+++ b/crates/vision-geometry/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vision-geometry"
+# Not yet published to crates.io — landed internally first (API not stable).
+# Promote to the publish set + release version-lockstep deliberately (see CLAUDE.md).
+publish = false
+readme = "README.md"
+description = "Shared geometric solvers: epipolar geometry, homography, triangulation, camera matrix"
+keywords = ["computer-vision", "geometry", "epipolar", "homography", "triangulation"]
+categories = ["computer-vision"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+vision-calibration-core = { workspace = true }
+nalgebra = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/vision-geometry/README.md
+++ b/crates/vision-geometry/README.md
@@ -1,0 +1,54 @@
+# vision-geometry
+
+Deterministic, allocation-light geometric solvers shared across the
+`calibration-rs` workspace.
+
+This crate provides the low-level building blocks behind calibration and
+multiple-view geometry workflows: epipolar estimation, homography estimation,
+linear triangulation, and camera matrix decomposition.
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `math` | Hartley normalization and small linear-algebra helpers |
+| `epipolar` | Fundamental and essential matrix estimation and decomposition |
+| `homography` | Normalized DLT homography estimation with optional RANSAC |
+| `triangulation` | Linear DLT triangulation from multiple views |
+| `camera_matrix` | Camera matrix estimation and RQ decomposition |
+
+## Coordinate Conventions
+
+- Fundamental matrix solvers accept pixel coordinates.
+- Essential matrix solvers expect calibrated coordinates after applying `K^-1`.
+- Pose outputs follow the `T_C_W` convention: world to camera.
+
+## Usage
+
+```rust
+use vision_calibration_core::Pt2;
+use vision_geometry::dlt_homography;
+
+let world = vec![
+    Pt2::new(0.0, 0.0),
+    Pt2::new(1.0, 0.0),
+    Pt2::new(1.0, 1.0),
+    Pt2::new(0.0, 1.0),
+];
+let image = vec![
+    Pt2::new(120.0, 200.0),
+    Pt2::new(220.0, 198.0),
+    Pt2::new(225.0, 300.0),
+    Pt2::new(118.0, 302.0),
+];
+
+let h = dlt_homography(&world, &image)?;
+println!("H = {h}");
+# Ok::<(), anyhow::Error>(())
+```
+
+## See Also
+
+- `vision-calibration-linear` for calibration-specific initialization solvers
+- `vision-mvg` for higher-level multiple-view geometry workflows
+- `vision-calibration-core` for shared math aliases, camera models, and RANSAC

--- a/crates/vision-geometry/src/camera_matrix.rs
+++ b/crates/vision-geometry/src/camera_matrix.rs
@@ -1,0 +1,250 @@
+//! Camera matrix estimation and decomposition utilities.
+//!
+//! Provides a normalized DLT solver for the 3×4 projection matrix `P` and an
+//! RQ decomposition to recover intrinsics and rotation.
+
+use crate::math::{mat34_from_svd_row, normalize_points_2d, normalize_points_3d};
+use anyhow::Result;
+use nalgebra::{DMatrix, Matrix3x4};
+use vision_calibration_core::{Mat3, Pt2, Pt3, Real, Vec3};
+
+/// 3×4 camera projection matrix `P = K [R | t]`.
+pub type Mat34 = Matrix3x4<Real>;
+
+/// Camera matrix decomposition into `K`, `R`, `t` with `K` upper-triangular.
+#[derive(Debug, Clone)]
+pub struct CameraMatrixDecomposition {
+    /// Intrinsics matrix (upper-triangular, positive diagonal).
+    pub k: Mat3,
+    /// Rotation matrix (orthonormal, det=+1).
+    pub r: Mat3,
+    /// Translation vector in camera coordinates.
+    pub t: Vec3,
+}
+
+/// Estimate a camera projection matrix `P` using normalized DLT.
+///
+/// `world` are 3D points and `image` are their pixel projections. The output is
+/// defined up to a global scale.
+pub fn dlt_camera_matrix(world: &[Pt3], image: &[Pt2]) -> Result<Mat34> {
+    let n = world.len();
+    if n < 6 {
+        anyhow::bail!("need at least 6 point correspondences, got {}", n);
+    }
+    if n != image.len() {
+        anyhow::bail!(
+            "mismatched number of world points ({}) and image points ({})",
+            n,
+            image.len()
+        );
+    }
+
+    let (world_n, t_w) = normalize_points_3d(world).ok_or(anyhow::anyhow!(
+        "degenerate point configuration for normalization"
+    ))?;
+    let (image_n, t_i) = normalize_points_2d(image).ok_or(anyhow::anyhow!(
+        "degenerate point configuration for normalization"
+    ))?;
+
+    let mut a = DMatrix::<Real>::zeros(2 * n, 12);
+
+    for (i, (pw, pi)) in world_n.iter().zip(image_n.iter()).enumerate() {
+        let x = pw.x;
+        let y = pw.y;
+        let z = pw.z;
+        let u = pi.x;
+        let v = pi.y;
+
+        let r0 = 2 * i;
+        let r1 = 2 * i + 1;
+
+        a[(r0, 0)] = x;
+        a[(r0, 1)] = y;
+        a[(r0, 2)] = z;
+        a[(r0, 3)] = 1.0;
+        a[(r0, 8)] = -u * x;
+        a[(r0, 9)] = -u * y;
+        a[(r0, 10)] = -u * z;
+        a[(r0, 11)] = -u;
+
+        a[(r1, 4)] = x;
+        a[(r1, 5)] = y;
+        a[(r1, 6)] = z;
+        a[(r1, 7)] = 1.0;
+        a[(r1, 8)] = -v * x;
+        a[(r1, 9)] = -v * y;
+        a[(r1, 10)] = -v * z;
+        a[(r1, 11)] = -v;
+    }
+
+    let svd = a.svd(true, true);
+    let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+    let p_norm = mat34_from_svd_row(&v_t, v_t.nrows() - 1);
+
+    let t_i_inv = t_i.try_inverse().ok_or(anyhow::anyhow!("SVD failed"))?;
+    let p = t_i_inv * p_norm * t_w;
+
+    Ok(p)
+}
+
+/// RQ decomposition of a 3×3 matrix.
+///
+/// Returns `(K, R)` with `K` upper-triangular and `R` orthonormal.
+pub fn rq_decompose(m: &Mat3) -> (Mat3, Mat3) {
+    let j = Mat3::new(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0);
+
+    let m1 = j * m.transpose() * j;
+    let qr = m1.qr();
+
+    let mut k = j * qr.r().transpose() * j;
+    let mut r = j * qr.q().transpose() * j;
+
+    let mut d = Mat3::identity();
+    for i in 0..3 {
+        if k[(i, i)] < 0.0 {
+            d[(i, i)] = -1.0;
+        }
+    }
+    k *= d;
+    r = d * r;
+
+    (k, r)
+}
+
+/// Decompose a camera projection matrix into intrinsics, rotation, and translation.
+///
+/// Returns `K`, `R`, and `t` such that `P ~ K [R | t]`. The diagonal of `K` is
+/// forced positive and `R` is projected onto SO(3).
+pub fn decompose_camera_matrix(p: &Mat34) -> Result<CameraMatrixDecomposition> {
+    let m = p.fixed_view::<3, 3>(0, 0).into_owned();
+    let (mut k, mut r) = rq_decompose(&m);
+
+    if k[(2, 2)] < 0.0 {
+        k = -k;
+        r = -r;
+    }
+
+    let k_inv = k
+        .try_inverse()
+        .ok_or_else(|| anyhow::anyhow!("intrinsics matrix is not invertible"))?;
+    let mut t = k_inv * p.column(3);
+
+    if r.determinant() < 0.0 {
+        r = -r;
+        t = -t;
+    }
+
+    Ok(CameraMatrixDecomposition {
+        k,
+        r,
+        t: t.into_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Rotation3, Translation3, Vector4};
+
+    fn project(p: &Mat34, point: &Pt3) -> Pt2 {
+        let x = p * Vector4::new(point.x, point.y, point.z, 1.0);
+        Pt2::new(x.x / x.z, x.y / x.z)
+    }
+
+    #[test]
+    fn dlt_camera_matrix_recovers_projection() {
+        let k = Mat3::new(900.0, 0.0, 640.0, 0.0, 880.0, 360.0, 0.0, 0.0, 1.0);
+        let rot = Rotation3::from_euler_angles(0.15, -0.05, 0.1);
+        let t = Translation3::new(0.1, -0.05, 1.2);
+        let r = rot.matrix();
+
+        let mut p_gt = Mat34::zeros();
+        p_gt.fixed_view_mut::<3, 3>(0, 0).copy_from(&(k * r));
+        p_gt.set_column(3, &(k * t.vector));
+
+        let mut world = Vec::new();
+        let mut image = Vec::new();
+        for z in 0..2 {
+            for y in 0..3 {
+                for x in 0..4 {
+                    let pw = Pt3::new(x as Real * 0.2, y as Real * 0.15, 2.0 + z as Real * 0.1);
+                    let uv = project(&p_gt, &pw);
+                    world.push(pw);
+                    image.push(uv);
+                }
+            }
+        }
+
+        let p_est = dlt_camera_matrix(&world, &image).unwrap();
+        let dot: Real = p_gt
+            .as_slice()
+            .iter()
+            .zip(p_est.as_slice().iter())
+            .map(|(a, b)| a * b)
+            .sum();
+        let denom: Real = p_est.as_slice().iter().map(|v| v * v).sum();
+        let scale = if denom.abs() > Real::EPSILON {
+            dot / denom
+        } else {
+            1.0
+        };
+        let p_scaled = p_est * scale;
+
+        let diff = (p_scaled - p_gt).norm();
+        assert!(diff < 1e-6, "camera matrix diff too large: {}", diff);
+    }
+
+    #[test]
+    fn rq_decompose_recovers_k_r() {
+        let k = Mat3::new(800.0, 1.5, 640.0, 0.0, 780.0, 360.0, 0.0, 0.0, 1.0);
+        let rot = Rotation3::from_euler_angles(0.1, 0.2, -0.05);
+        let r = rot.matrix();
+        let m = k * r;
+
+        let (k_est, r_est) = rq_decompose(&m);
+
+        let scale = k[(2, 2)] / k_est[(2, 2)];
+        let diff = (k_est * scale - k).norm();
+        assert!(diff < 1e-6, "K mismatch: {}", diff);
+
+        let r_diff = r_est.transpose() * r;
+        let trace = r_diff.trace();
+        let cos_theta = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang = cos_theta.acos();
+        assert!(ang < 1e-6, "R mismatch: {}", ang);
+    }
+
+    #[test]
+    fn camera_matrix_decomposition_roundtrip() {
+        let k = Mat3::new(900.0, -2.0, 640.0, 0.0, 870.0, 360.0, 0.0, 0.0, 1.0);
+        let rot = Rotation3::from_euler_angles(-0.1, 0.05, 0.2);
+        let t = Translation3::new(-0.2, 0.1, 1.5);
+        let mut p_gt = Mat34::zeros();
+        p_gt.fixed_view_mut::<3, 3>(0, 0)
+            .copy_from(&(k * rot.matrix()));
+        p_gt.set_column(3, &(k * t.vector));
+
+        let decomp = decompose_camera_matrix(&p_gt).unwrap();
+
+        let mut p_recon = Mat34::zeros();
+        p_recon
+            .fixed_view_mut::<3, 3>(0, 0)
+            .copy_from(&(decomp.k * decomp.r));
+        p_recon.set_column(3, &(decomp.k * decomp.t));
+
+        let dot: Real = p_gt
+            .as_slice()
+            .iter()
+            .zip(p_recon.as_slice().iter())
+            .map(|(a, b)| a * b)
+            .sum();
+        let denom: Real = p_recon.as_slice().iter().map(|v| v * v).sum();
+        let scale = if denom.abs() > Real::EPSILON {
+            dot / denom
+        } else {
+            1.0
+        };
+        let diff = (p_recon * scale - p_gt).norm();
+        assert!(diff < 1e-6, "P reconstruction error too large: {}", diff);
+    }
+}

--- a/crates/vision-geometry/src/camera_matrix.rs
+++ b/crates/vision-geometry/src/camera_matrix.rs
@@ -5,7 +5,7 @@
 
 use crate::math::{mat34_from_svd_row, normalize_points_2d, normalize_points_3d};
 use anyhow::Result;
-use nalgebra::{DMatrix, Matrix3x4};
+use nalgebra::{DMatrix, Matrix3, Matrix3x4};
 use vision_calibration_core::{Mat3, Pt2, Pt3, Real, Vec3};
 
 /// 3×4 camera projection matrix `P = K [R | t]`.
@@ -42,6 +42,33 @@ pub fn dlt_camera_matrix(world: &[Pt3], image: &[Pt2]) -> Result<Mat34> {
     let (world_n, t_w) = normalize_points_3d(world).ok_or(anyhow::anyhow!(
         "degenerate point configuration for normalization"
     ))?;
+
+    // Coplanarity guard: if the normalized 3D points lie on (or very near) a
+    // plane, the 2n×12 DLT is underdetermined — a homography is the right
+    // estimator for that case.  We detect this by examining the singular values
+    // of the 3×3 scatter (sum of outer products of centred points): when
+    // σ_min / σ_max < 1e-6 the points are essentially coplanar.
+    {
+        // world_n is already centred by normalize_points_3d (centroid → origin).
+        let mut scatter = Matrix3::<Real>::zeros();
+        for p in &world_n {
+            let v = nalgebra::Vector3::new(p.x, p.y, p.z);
+            scatter += v * v.transpose();
+        }
+        let sv = scatter.svd(false, false).singular_values;
+        let s_max = sv[0]; // singular values are sorted descending
+        let s_min = sv[2];
+        if s_max <= Real::EPSILON {
+            anyhow::bail!("all 3D points coincide — cannot estimate a camera matrix");
+        }
+        if s_min / s_max < 1e-6 {
+            anyhow::bail!(
+                "coplanar or near-degenerate 3D point configuration: the 3×4 camera \
+                 DLT is underdetermined for planar points (estimate a homography instead)"
+            );
+        }
+    }
+
     let (image_n, t_i) = normalize_points_2d(image).ok_or(anyhow::anyhow!(
         "degenerate point configuration for normalization"
     ))?;
@@ -192,6 +219,25 @@ mod tests {
 
         let diff = (p_scaled - p_gt).norm();
         assert!(diff < 1e-6, "camera matrix diff too large: {}", diff);
+    }
+
+    #[test]
+    fn dlt_camera_matrix_rejects_coplanar_points() {
+        // All 3D points have z = 0 (the XY plane).  The DLT is underdetermined
+        // for planar configurations — the function must return Err.
+        let image: Vec<Pt2> = (0..8)
+            .map(|i| Pt2::new(i as Real * 10.0 + 100.0, i as Real * 5.0 + 200.0))
+            .collect();
+        let world: Vec<Pt3> = (0..8)
+            .map(|i| {
+                let fi = i as Real;
+                Pt3::new(fi * 0.1, fi * 0.07, 0.0) // all on z=0 plane
+            })
+            .collect();
+        assert!(
+            dlt_camera_matrix(&world, &image).is_err(),
+            "dlt_camera_matrix must reject coplanar 3D points"
+        );
     }
 
     #[test]

--- a/crates/vision-geometry/src/camera_matrix.rs
+++ b/crates/vision-geometry/src/camera_matrix.rs
@@ -3,7 +3,7 @@
 //! Provides a normalized DLT solver for the 3×4 projection matrix `P` and an
 //! RQ decomposition to recover intrinsics and rotation.
 
-use crate::math::{mat34_from_svd_row, normalize_points_2d, normalize_points_3d};
+use crate::math::{dlt_rank_ok, mat34_from_svd_row, normalize_points_2d, normalize_points_3d};
 use anyhow::Result;
 use nalgebra::{DMatrix, Matrix3, Matrix3x4};
 use vision_calibration_core::{Mat3, Pt2, Pt3, Real, Vec3};
@@ -105,6 +105,17 @@ pub fn dlt_camera_matrix(world: &[Pt3], image: &[Pt2]) -> Result<Mat34> {
     }
 
     let svd = a.svd(true, true);
+    // Rank guard: the 12-column DLT must have a 1-D null space. Inputs that pass
+    // the length and coplanarity checks can still be underdetermined — e.g. six
+    // correspondences with only five unique 3D↔2D pairs — leaving a >1-D null
+    // space whose smallest singular vector is arbitrary.
+    let sv: Vec<Real> = svd.singular_values.iter().cloned().collect();
+    if !dlt_rank_ok(&sv, 12, 1, 1e-7) {
+        anyhow::bail!(
+            "rank-deficient camera DLT system: fewer than 6 independent \
+             3D-2D correspondences (e.g. duplicate or collinear points)"
+        );
+    }
     let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
     let p_norm = mat34_from_svd_row(&v_t, v_t.nrows() - 1);
 
@@ -237,6 +248,37 @@ mod tests {
         assert!(
             dlt_camera_matrix(&world, &image).is_err(),
             "dlt_camera_matrix must reject coplanar 3D points"
+        );
+    }
+
+    #[test]
+    fn dlt_camera_matrix_rejects_underdetermined_duplicate_points() {
+        // Six correspondences but only FIVE unique 3D↔2D pairs (one duplicated).
+        // The points are non-coplanar (varying z) so they pass the coplanarity
+        // guard, but the 12-column design matrix has a >1-D null space → the
+        // rank guard must reject them instead of returning an arbitrary P.
+        let k = Mat3::new(900.0, 0.0, 640.0, 0.0, 880.0, 360.0, 0.0, 0.0, 1.0);
+        let rot = Rotation3::from_euler_angles(0.15, -0.05, 0.1);
+        let t = Translation3::new(0.1, -0.05, 1.2);
+        let r = rot.matrix();
+        let mut p_gt = Mat34::zeros();
+        p_gt.fixed_view_mut::<3, 3>(0, 0).copy_from(&(k * r));
+        p_gt.set_column(3, &(k * t.vector));
+
+        let unique = [
+            Pt3::new(0.0, 0.0, 2.0),
+            Pt3::new(0.4, 0.1, 2.3),
+            Pt3::new(0.1, 0.5, 1.8),
+            Pt3::new(-0.3, -0.2, 2.5),
+            Pt3::new(0.2, -0.4, 2.1),
+        ];
+        let mut world: Vec<Pt3> = unique.to_vec();
+        world.push(unique[0]); // duplicate → 6 points, only 5 unique
+        let image: Vec<Pt2> = world.iter().map(|pw| project(&p_gt, pw)).collect();
+
+        assert!(
+            dlt_camera_matrix(&world, &image).is_err(),
+            "underdetermined (duplicate-point) camera DLT must return Err"
         );
     }
 

--- a/crates/vision-geometry/src/epipolar/decomposition.rs
+++ b/crates/vision-geometry/src/epipolar/decomposition.rs
@@ -1,0 +1,106 @@
+//! Essential matrix decomposition into rotation and translation.
+//!
+//! Recovers candidate camera poses from an essential matrix using SVD
+//! decomposition. Returns four possible (R, t) pairs that must be
+//! disambiguated via cheirality checks.
+
+use anyhow::Result;
+use nalgebra::SMatrix;
+use vision_calibration_core::{Mat3, Real, Vec3};
+
+/// Enforce essential matrix constraints via SVD projection.
+///
+/// Projects a 3×3 matrix onto the essential matrix manifold by forcing
+/// the singular values to be (σ, σ, 0) where σ is the mean of the first
+/// two singular values.
+pub(crate) fn enforce_essential_constraints(e: &Mat3) -> Result<Mat3> {
+    let svd = e.svd(true, true);
+    let u = svd.u.ok_or(anyhow::anyhow!("SVD failed"))?;
+    let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+
+    let s1 = svd.singular_values[0];
+    let s2 = svd.singular_values[1];
+    let s = 0.5 * (s1 + s2);
+
+    let s_mat = SMatrix::<Real, 3, 3>::from_diagonal(&nalgebra::Vector3::new(s, s, 0.0));
+    Ok(u * s_mat * v_t)
+}
+
+/// Decompose an essential matrix into candidate rotation and translation pairs.
+///
+/// Returns four possible `(R, t)` pairs; the correct one can be selected by
+/// cheirality checks on triangulated points. The translation is unit-length
+/// (direction only).
+pub fn decompose_essential(e: &Mat3) -> Result<Vec<(Mat3, Vec3)>> {
+    let e = enforce_essential_constraints(e)?;
+    let svd = e.svd(true, true);
+    let mut u = svd.u.ok_or(anyhow::anyhow!("SVD failed"))?;
+    let mut v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+
+    if u.determinant() < 0.0 {
+        u.column_mut(2).neg_mut();
+    }
+    if v_t.determinant() < 0.0 {
+        v_t.row_mut(2).neg_mut();
+    }
+
+    let w = Mat3::new(0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+
+    let r1 = u * w * v_t;
+    let r2 = u * w.transpose() * v_t;
+
+    let t = u.column(2).normalize();
+
+    let mut solutions = vec![
+        (r1, t.into_owned()),
+        (r1, (-t).into_owned()),
+        (r2, t.into_owned()),
+        (r2, (-t).into_owned()),
+    ];
+
+    for (r, t) in solutions.iter_mut() {
+        if r.determinant() < 0.0 {
+            *r = -*r;
+            *t = -*t;
+        }
+    }
+
+    Ok(solutions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+
+    fn skew(v: &Vec3) -> Mat3 {
+        Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
+    }
+
+    #[test]
+    fn essential_decomposition_recovers_pose() {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        let t = Vec3::new(0.1, 0.02, -0.03);
+
+        let e = skew(&t) * rot.matrix();
+        let solutions = decompose_essential(&e).unwrap();
+
+        let mut found = false;
+        for (r_est, t_est) in solutions {
+            let r_diff = r_est.transpose() * rot.matrix();
+            let trace = r_diff.trace();
+            let cos_theta = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0);
+            let ang = cos_theta.acos();
+
+            let t_dir = t_est.normalize();
+            let cos_t = t_dir.dot(&t.normalize()).abs();
+
+            if ang < 1e-6 && (1.0 - cos_t) < 1e-6 {
+                found = true;
+                break;
+            }
+        }
+
+        assert!(found, "essential decomposition did not recover pose");
+    }
+}

--- a/crates/vision-geometry/src/epipolar/decomposition.rs
+++ b/crates/vision-geometry/src/epipolar/decomposition.rs
@@ -32,41 +32,40 @@ pub(crate) fn enforce_essential_constraints(e: &Mat3) -> Result<Mat3> {
 /// cheirality checks on triangulated points. The translation is unit-length
 /// (direction only).
 ///
-/// Returns `Err` if `E` is zero, rank-deficient beyond the expected rank-2
-/// structure, or otherwise degenerate (e.g. a pure-rotation-derived E has
-/// both valid singular values identical but the ratio `σ₂ / σ₁` departs from
-/// the expected `~1`; a zero E has `σ₁ ≈ 0`).
+/// Returns `Err` if `E` is degenerate before the essential-constraint projection.
+/// The check is performed on the **raw** input matrix to catch rank-1 inputs such
+/// as `diag(1, 0, 0)` that would otherwise slip through to `(σ/2, σ/2, 0)` after
+/// projection and produce an arbitrary translation direction:
 ///
-/// A valid E has singular values ≈ (σ, σ, 0) after the essential-constraint
-/// projection. The check is: after projection,
-/// `σ₁ > ε` (non-zero) and `σ₂ / σ₁ > 0.1` (both leading values are
-/// meaningfully positive — not a rank-1 or rank-0 matrix).
+/// - `σ₀ < 1e-10` — near-zero matrix (pure rotation with `t = 0`, or all-zeros).
+/// - `σ₁ / σ₀ < 0.1` — rank-1 input; the second singular value has collapsed and
+///   the translation direction is unobservable.
+///
+/// A valid estimated `E` (even from a noisy 8-point solve) has raw `σ₀ ≈ σ₁ > 0`,
+/// so the threshold of 0.1 is conservative.
 pub fn decompose_essential(e: &Mat3) -> Result<Vec<(Mat3, Vec3)>> {
-    let e = enforce_essential_constraints(e)?;
-
-    // Rank / degeneracy check on the projected E.
-    // A valid essential matrix after projection has σ₀ ≈ σ₁ > 0, σ₂ = 0.
-    // Detect two failure modes:
-    //   (a) Zero or near-zero E: σ₀ ≈ 0  → translation is unobservable.
-    //   (b) Rank-1 E: σ₁ / σ₀ ≪ 1       → fabricated translation direction.
+    // Degeneracy check on the RAW input — before projection.
+    // This catches rank-1 inputs like diag(1,0,0) that survive projection
+    // to (σ/2, σ/2, 0) and would yield an arbitrary translation direction.
     {
         let sv = e.svd(false, false).singular_values;
         let s0 = sv[0];
         let s1 = sv[1];
         if s0 < 1e-10 {
             anyhow::bail!(
-                "degenerate essential matrix: near-zero norm after projection \
-                 (translation is unobservable — pure rotation or rank-deficient E)"
+                "degenerate essential matrix: translation is unobservable \
+                 (rank-deficient or zero E)"
             );
         }
         if s1 / s0 < 0.1 {
             anyhow::bail!(
-                "degenerate essential matrix: rank-deficient after projection \
-                 (σ₁/σ₀ = {:.4} < 0.1; translation direction is unobservable)",
-                s1 / s0
+                "degenerate essential matrix: translation is unobservable \
+                 (rank-deficient or zero E)"
             );
         }
     }
+
+    let e = enforce_essential_constraints(e)?;
 
     let svd = e.svd(true, true);
     let mut u = svd.u.ok_or(anyhow::anyhow!("SVD failed"))?;
@@ -134,6 +133,23 @@ mod tests {
         assert!(
             decompose_essential(&e).is_err(),
             "pure-rotation E (t=0 ⟹ E=0) must return Err"
+        );
+    }
+
+    /// Regression: a rank-1 raw E such as `diag(1,0,0)` must return Err.
+    ///
+    /// The OLD guard checked singular values AFTER `enforce_essential_constraints`.
+    /// `diag(1,0,0)` has σ = (1,0,0); after projection it becomes `(0.5, 0.5, 0)`,
+    /// which passes the post-projection ratio check — a fabricated translation
+    /// direction is returned.  The new pre-projection check catches it.
+    #[test]
+    fn decompose_essential_rejects_rank1_diag_input() {
+        use nalgebra::Matrix3;
+        // diag(1,0,0) — rank 1, σ = (1, 0, 0).
+        let e = Matrix3::from_diagonal(&nalgebra::Vector3::new(1.0, 0.0, 0.0));
+        assert!(
+            decompose_essential(&e).is_err(),
+            "rank-1 diag(1,0,0) essential matrix must return Err"
         );
     }
 

--- a/crates/vision-geometry/src/epipolar/decomposition.rs
+++ b/crates/vision-geometry/src/epipolar/decomposition.rs
@@ -31,8 +31,43 @@ pub(crate) fn enforce_essential_constraints(e: &Mat3) -> Result<Mat3> {
 /// Returns four possible `(R, t)` pairs; the correct one can be selected by
 /// cheirality checks on triangulated points. The translation is unit-length
 /// (direction only).
+///
+/// Returns `Err` if `E` is zero, rank-deficient beyond the expected rank-2
+/// structure, or otherwise degenerate (e.g. a pure-rotation-derived E has
+/// both valid singular values identical but the ratio `σ₂ / σ₁` departs from
+/// the expected `~1`; a zero E has `σ₁ ≈ 0`).
+///
+/// A valid E has singular values ≈ (σ, σ, 0) after the essential-constraint
+/// projection. The check is: after projection,
+/// `σ₁ > ε` (non-zero) and `σ₂ / σ₁ > 0.1` (both leading values are
+/// meaningfully positive — not a rank-1 or rank-0 matrix).
 pub fn decompose_essential(e: &Mat3) -> Result<Vec<(Mat3, Vec3)>> {
     let e = enforce_essential_constraints(e)?;
+
+    // Rank / degeneracy check on the projected E.
+    // A valid essential matrix after projection has σ₀ ≈ σ₁ > 0, σ₂ = 0.
+    // Detect two failure modes:
+    //   (a) Zero or near-zero E: σ₀ ≈ 0  → translation is unobservable.
+    //   (b) Rank-1 E: σ₁ / σ₀ ≪ 1       → fabricated translation direction.
+    {
+        let sv = e.svd(false, false).singular_values;
+        let s0 = sv[0];
+        let s1 = sv[1];
+        if s0 < 1e-10 {
+            anyhow::bail!(
+                "degenerate essential matrix: near-zero norm after projection \
+                 (translation is unobservable — pure rotation or rank-deficient E)"
+            );
+        }
+        if s1 / s0 < 0.1 {
+            anyhow::bail!(
+                "degenerate essential matrix: rank-deficient after projection \
+                 (σ₁/σ₀ = {:.4} < 0.1; translation direction is unobservable)",
+                s1 / s0
+            );
+        }
+    }
+
     let svd = e.svd(true, true);
     let mut u = svd.u.ok_or(anyhow::anyhow!("SVD failed"))?;
     let mut v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
@@ -77,6 +112,32 @@ mod tests {
         Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
     }
 
+    /// Regression: zero E must return Err, not fabricate four poses.
+    #[test]
+    fn decompose_essential_rejects_zero_matrix() {
+        let e = Mat3::zeros();
+        assert!(
+            decompose_essential(&e).is_err(),
+            "zero essential matrix must return Err"
+        );
+    }
+
+    /// Regression: a pure-rotation-derived E = [t]×R with t=0 is all zeros
+    /// and must also be rejected.
+    #[test]
+    fn decompose_essential_rejects_pure_rotation_e() {
+        use nalgebra::Rotation3;
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        // t = 0 → E = [0]× R = 0
+        let t_zero = Vec3::zeros();
+        let e = skew(&t_zero) * rot.matrix();
+        assert!(
+            decompose_essential(&e).is_err(),
+            "pure-rotation E (t=0 ⟹ E=0) must return Err"
+        );
+    }
+
+    /// Sanity: an existing valid-E decomposition test must still pass after the guard.
     #[test]
     fn essential_decomposition_recovers_pose() {
         let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);

--- a/crates/vision-geometry/src/epipolar/essential.rs
+++ b/crates/vision-geometry/src/epipolar/essential.rs
@@ -5,7 +5,7 @@
 //! overdetermined solver for use in RANSAC refit on large inlier sets.
 
 use super::polynomial::build_polynomial_system;
-use crate::math::mat3_from_svd_row;
+use crate::math::{dlt_rank_ok, mat3_from_svd_row};
 use anyhow::Result;
 use nalgebra::{DMatrix, SMatrix, linalg::Schur};
 use vision_calibration_core::{Mat3, Pt2, Real};
@@ -215,7 +215,19 @@ pub fn essential_linear(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
     }
 
     let svd = a_work.svd(true, true);
+    let sv: Vec<Real> = svd.singular_values.iter().cloned().collect();
     let v_t = svd.v_t.ok_or_else(|| anyhow::anyhow!("SVD failed"))?;
+
+    // The 9-column epipolar design matrix must have rank exactly 8 (1-D null
+    // space).  Degenerate calibrated ray pairs (coincident or collinear rays)
+    // collapse sv[7] toward zero.
+    if !dlt_rank_ok(&sv, 9, 1, 1e-7) {
+        anyhow::bail!(
+            "rank-deficient essential system: correspondences are degenerate \
+             (e.g. coincident or collinear rays)"
+        );
+    }
+
     let e_vec = v_t.row(v_t.nrows() - 1);
 
     let mut e = Mat3::zeros();
@@ -388,6 +400,39 @@ mod tests {
             sv[2] / s_avg < 1e-6,
             "sv[2]/avg = {} (expected ~0.0)",
             sv[2] / s_avg
+        );
+    }
+
+    /// Regression: 8 identical (coincident) calibrated ray pairs must return Err.
+    ///
+    /// Coincident points collapse all but the first singular value of the 9-column
+    /// design matrix, making the null space ≥8-D.  The rank check must catch this
+    /// before the arbitrary last singular vector is used.
+    #[test]
+    fn essential_linear_rejects_coincident_rays() {
+        // All 8 ray pairs identical → the 9-column design matrix is rank 1.
+        let p = Pt2::new(0.1, 0.2);
+        let pts = vec![p; 8];
+        assert!(
+            essential_linear(&pts, &pts).is_err(),
+            "coincident ray pairs must return Err"
+        );
+    }
+
+    /// Regression: 8 collinear calibrated ray pairs must return Err.
+    ///
+    /// All rays lying on a common plane leave the epipolar design matrix rank-
+    /// deficient (null space ≥2-D), so the last singular vector is arbitrary.
+    #[test]
+    fn essential_linear_rejects_collinear_rays() {
+        // All 8 calibrated points on the line y = 0 (horizontal image line).
+        let pts1: Vec<Pt2> = (0..8)
+            .map(|i| Pt2::new(i as Real * 0.05 - 0.175, 0.0))
+            .collect();
+        let pts2: Vec<Pt2> = pts1.iter().map(|p| Pt2::new(p.x + 0.01, 0.0)).collect();
+        assert!(
+            essential_linear(&pts1, &pts2).is_err(),
+            "collinear ray pairs must return Err"
         );
     }
 

--- a/crates/vision-geometry/src/epipolar/essential.rs
+++ b/crates/vision-geometry/src/epipolar/essential.rs
@@ -1,12 +1,13 @@
-//! Essential matrix estimation using the 5-point algorithm.
+//! Essential matrix estimation using the 5-point algorithm and a linear solver.
 //!
 //! Implements Nistér's minimal solver for essential matrices from five
-//! point correspondences in normalized coordinates.
+//! point correspondences in normalized coordinates, and a linear (≥5-point)
+//! overdetermined solver for use in RANSAC refit on large inlier sets.
 
 use super::polynomial::build_polynomial_system;
 use crate::math::mat3_from_svd_row;
 use anyhow::Result;
-use nalgebra::{DMatrix, linalg::Schur};
+use nalgebra::{DMatrix, SMatrix, linalg::Schur};
 use vision_calibration_core::{Mat3, Pt2, Real};
 
 /// 5-point algorithm for the essential matrix in normalized coordinates.
@@ -140,6 +141,89 @@ pub fn essential_5point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
     Ok(solutions.into_iter().map(|(_, e)| e).collect())
 }
 
+/// Linear (≥5-point) essential matrix estimator for overdetermined systems.
+///
+/// Inputs are **calibrated / normalized camera coordinates** (i.e. apply `K⁻¹`
+/// first). Requires `pts1.len() == pts2.len() >= 5`.
+///
+/// The algorithm:
+/// 1. Build the 9-column epipolar design matrix `A` (same as the 8-point
+///    fundamental method, but operating on calibrated coords that are already
+///    well-conditioned, so Hartley normalization is omitted).
+/// 2. Solve for the null-space vector (right singular vector of smallest
+///    singular value) → reshape to 3×3 matrix `E_raw`.
+/// 3. Project `E_raw` onto the essential manifold: SVD `E_raw = U Σ Vᵀ`;
+///    replace singular values with `diag(1, 1, 0)` (up to an overall scale)
+///    → `E = U diag(1,1,0) Vᵀ`.
+///
+/// Returns the projected essential matrix, or `Err` if the SVD fails.
+pub fn essential_linear(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
+    if pts1.len() != pts2.len() {
+        anyhow::bail!(
+            "Point count mismatch: pts1 has {}, pts2 has {}",
+            pts1.len(),
+            pts2.len()
+        );
+    }
+    if pts1.len() < 5 {
+        anyhow::bail!("Need at least 5 correspondences, got {}", pts1.len());
+    }
+
+    let n = pts1.len();
+    let mut a = DMatrix::<Real>::zeros(n, 9);
+    for (i, (p1, p2)) in pts1.iter().zip(pts2.iter()).enumerate() {
+        let x = p1.x;
+        let y = p1.y;
+        let xp = p2.x;
+        let yp = p2.y;
+
+        a[(i, 0)] = xp * x;
+        a[(i, 1)] = xp * y;
+        a[(i, 2)] = xp;
+        a[(i, 3)] = yp * x;
+        a[(i, 4)] = yp * y;
+        a[(i, 5)] = yp;
+        a[(i, 6)] = x;
+        a[(i, 7)] = y;
+        a[(i, 8)] = 1.0;
+    }
+
+    // Pad to square if we have fewer rows than columns (n < 9).
+    let mut a_work = a.clone();
+    if a_work.nrows() < a_work.ncols() {
+        let rows = a_work.nrows();
+        let cols = a_work.ncols();
+        let mut a_pad = DMatrix::<Real>::zeros(cols, cols);
+        a_pad.view_mut((0, 0), (rows, cols)).copy_from(&a_work);
+        a_work = a_pad;
+    }
+
+    let svd = a_work.svd(true, true);
+    let v_t = svd.v_t.ok_or_else(|| anyhow::anyhow!("SVD failed"))?;
+    let e_vec = v_t.row(v_t.nrows() - 1);
+
+    let mut e = Mat3::zeros();
+    for r in 0..3 {
+        for c in 0..3 {
+            e[(r, c)] = e_vec[3 * r + c];
+        }
+    }
+
+    // Project onto the essential manifold: singular values → (1, 1, 0).
+    let svd_e = e.svd(true, true);
+    let u = svd_e.u.ok_or_else(|| anyhow::anyhow!("SVD failed on E"))?;
+    let v_t_e = svd_e
+        .v_t
+        .ok_or_else(|| anyhow::anyhow!("SVD failed on E"))?;
+    // Average the two largest singular values to enforce the (σ, σ, 0) constraint.
+    let sv = svd_e.singular_values;
+    let sigma = (sv[0] + sv[1]) * 0.5;
+    let s_ess = SMatrix::<Real, 3, 3>::from_diagonal(&nalgebra::Vector3::new(sigma, sigma, 0.0));
+    let e_proj = u * s_ess * v_t_e;
+
+    Ok(e_proj)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -204,5 +288,103 @@ mod tests {
             found_good_decomp,
             "5-point solver did not produce an E that decomposes to the correct pose"
         );
+    }
+
+    /// Helper: build synthetic calibrated correspondences from a known rotation + translation.
+    fn make_calibrated_corrs(
+        rot: &Rotation3<Real>,
+        t: &Vec3,
+        n_pts: usize,
+    ) -> (Vec<Pt2>, Vec<Pt2>) {
+        use vision_calibration_core::Pt3;
+
+        // Use a reproducible set of world points.
+        let world: Vec<Pt3> = (0..n_pts)
+            .map(|i| {
+                let fi = i as Real;
+                Pt3::new(
+                    0.15 * (fi * 0.7).sin(),
+                    0.12 * (fi * 0.5).cos(),
+                    2.0 + fi * 0.1,
+                )
+            })
+            .collect();
+
+        let pts1: Vec<Pt2> = world
+            .iter()
+            .map(|pw| Pt2::new(pw.x / pw.z, pw.y / pw.z))
+            .collect();
+        let pts2: Vec<Pt2> = world
+            .iter()
+            .map(|pw| {
+                let pc2 = rot * pw + t;
+                Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z)
+            })
+            .collect();
+
+        (pts1, pts2)
+    }
+
+    #[test]
+    fn essential_linear_recovers_known_essential_from_8pts() {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        let t = Vec3::new(0.1, 0.02, 0.03);
+
+        let (pts1, pts2) = make_calibrated_corrs(&rot, &t, 8);
+
+        let e = essential_linear(&pts1, &pts2).unwrap();
+
+        // Epipolar constraint: |x2^T E x1| must be near-zero for all points.
+        let e_norm = e.norm();
+        assert!(e_norm > 0.0, "essential_linear returned zero matrix");
+
+        let mut max_residual: Real = 0.0;
+        for (p1, p2) in pts1.iter().zip(pts2.iter()) {
+            let x1 = nalgebra::Vector3::new(p1.x, p1.y, 1.0);
+            let x2 = nalgebra::Vector3::new(p2.x, p2.y, 1.0);
+            let val = (x2.transpose() * e * x1)[0].abs() / e_norm;
+            if val > max_residual {
+                max_residual = val;
+            }
+        }
+        assert!(
+            max_residual < 1e-6,
+            "Epipolar residual {:.3e} too large (expected < 1e-6)",
+            max_residual
+        );
+
+        // Essential manifold: singular values must satisfy (σ, σ, 0).
+        let svd = e.svd(false, false);
+        let sv = svd.singular_values;
+        // Normalized singular values: divide by the average of the two larger.
+        let s_avg = (sv[0] + sv[1]) * 0.5;
+        assert!(
+            (sv[0] / s_avg - 1.0).abs() < 1e-6,
+            "sv[0]/avg = {} (expected ~1.0)",
+            sv[0] / s_avg
+        );
+        assert!(
+            (sv[1] / s_avg - 1.0).abs() < 1e-6,
+            "sv[1]/avg = {} (expected ~1.0)",
+            sv[1] / s_avg
+        );
+        assert!(
+            sv[2] / s_avg < 1e-6,
+            "sv[2]/avg = {} (expected ~0.0)",
+            sv[2] / s_avg
+        );
+    }
+
+    #[test]
+    fn essential_linear_rejects_too_few_points() {
+        let pts = vec![Pt2::new(0.0, 0.0); 4];
+        assert!(essential_linear(&pts, &pts).is_err());
+    }
+
+    #[test]
+    fn essential_linear_rejects_mismatched_lengths() {
+        let p1 = vec![Pt2::new(0.0, 0.0); 6];
+        let p2 = vec![Pt2::new(0.0, 0.0); 5];
+        assert!(essential_linear(&p1, &p2).is_err());
     }
 }

--- a/crates/vision-geometry/src/epipolar/essential.rs
+++ b/crates/vision-geometry/src/epipolar/essential.rs
@@ -141,10 +141,17 @@ pub fn essential_5point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
     Ok(solutions.into_iter().map(|(_, e)| e).collect())
 }
 
-/// Linear (≥5-point) essential matrix estimator for overdetermined systems.
+/// Linear (≥8-point) essential matrix estimator for overdetermined systems.
 ///
 /// Inputs are **calibrated / normalized camera coordinates** (i.e. apply `K⁻¹`
-/// first). Requires `pts1.len() == pts2.len() >= 5`.
+/// first). Requires `pts1.len() == pts2.len() >= 8`.
+///
+/// **Why ≥8?** The 9-column epipolar design matrix has 9 unknowns. Its null
+/// space is 1-dimensional only when `rank(A) == 8`, which requires at least 8
+/// linearly independent rows. With 6 or 7 correspondences the null space has
+/// dimension ≥ 2 and the smallest-singular-value vector is an arbitrary element
+/// of that null space — the result would be a garbage essential matrix. Use
+/// [`essential_5point`] for the minimal (5-point) case.
 ///
 /// The algorithm:
 /// 1. Build the 9-column epipolar design matrix `A` (same as the 8-point
@@ -152,6 +159,9 @@ pub fn essential_5point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
 ///    well-conditioned, so Hartley normalization is omitted).
 /// 2. Solve for the null-space vector (right singular vector of smallest
 ///    singular value) → reshape to 3×3 matrix `E_raw`.
+///    When `n == 8` the 8×9 matrix is padded to 9×9 with a zero row so that
+///    nalgebra's full SVD returns a 9×9 `Vᵀ`; the zero row leaves the null
+///    space unchanged (still 1-dimensional).
 /// 3. Project `E_raw` onto the essential manifold: SVD `E_raw = U Σ Vᵀ`;
 ///    replace singular values with `diag(1, 1, 0)` (up to an overall scale)
 ///    → `E = U diag(1,1,0) Vᵀ`.
@@ -165,8 +175,11 @@ pub fn essential_linear(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
             pts2.len()
         );
     }
-    if pts1.len() < 5 {
-        anyhow::bail!("Need at least 5 correspondences, got {}", pts1.len());
+    if pts1.len() < 8 {
+        anyhow::bail!(
+            "Need at least 8 correspondences for the linear essential solver, got {}",
+            pts1.len()
+        );
     }
 
     let n = pts1.len();
@@ -188,7 +201,10 @@ pub fn essential_linear(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
         a[(i, 8)] = 1.0;
     }
 
-    // Pad to square if we have fewer rows than columns (n < 9).
+    // Pad to 9×9 when n == 8 (the only case where nrows < ncols after the ≥8
+    // guard above). Adding one zero row leaves the null space unchanged: A has
+    // rank 8 → a 1-dimensional null space → the smallest right singular vector
+    // is uniquely defined.
     let mut a_work = a.clone();
     if a_work.nrows() < a_work.ncols() {
         let rows = a_work.nrows();
@@ -377,7 +393,9 @@ mod tests {
 
     #[test]
     fn essential_linear_rejects_too_few_points() {
-        let pts = vec![Pt2::new(0.0, 0.0); 4];
+        // The linear solver requires ≥8 correspondences (1-D null space).
+        // 7 points leave a ≥2-D null space → must be rejected.
+        let pts = vec![Pt2::new(0.0, 0.0); 7];
         assert!(essential_linear(&pts, &pts).is_err());
     }
 

--- a/crates/vision-geometry/src/epipolar/essential.rs
+++ b/crates/vision-geometry/src/epipolar/essential.rs
@@ -1,0 +1,208 @@
+//! Essential matrix estimation using the 5-point algorithm.
+//!
+//! Implements Nistér's minimal solver for essential matrices from five
+//! point correspondences in normalized coordinates.
+
+use super::polynomial::build_polynomial_system;
+use crate::math::mat3_from_svd_row;
+use anyhow::Result;
+use nalgebra::{DMatrix, linalg::Schur};
+use vision_calibration_core::{Mat3, Pt2, Real};
+
+/// 5-point algorithm for the essential matrix in normalized coordinates.
+///
+/// The inputs must be **calibrated** (e.g. apply `K⁻¹` to pixel points).
+/// Returns up to ten candidate essential matrices that satisfy the cubic
+/// constraints; choose the physically valid one by cheirality or by
+/// reprojection error against additional correspondences.
+///
+/// Unlike fundamental matrix solvers, this does **not** apply Hartley
+/// normalization — calibrated coordinates are already well-conditioned.
+pub fn essential_5point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
+    if pts1.len() != pts2.len() {
+        anyhow::bail!(
+            "Point count mismatch: expected {}, got {}",
+            pts1.len(),
+            pts2.len()
+        );
+    }
+    if pts1.len() != 5 {
+        anyhow::bail!("Point count mismatch: expected 5, got {}", pts1.len());
+    }
+
+    let mut a = DMatrix::<Real>::zeros(5, 9);
+    for (i, (p1, p2)) in pts1.iter().zip(pts2.iter()).enumerate() {
+        let x = p1.x;
+        let y = p1.y;
+        let xp = p2.x;
+        let yp = p2.y;
+
+        a[(i, 0)] = xp * x;
+        a[(i, 1)] = xp * y;
+        a[(i, 2)] = xp;
+        a[(i, 3)] = yp * x;
+        a[(i, 4)] = yp * y;
+        a[(i, 5)] = yp;
+        a[(i, 6)] = x;
+        a[(i, 7)] = y;
+        a[(i, 8)] = 1.0;
+    }
+
+    let mut a_work = a.clone();
+    if a_work.nrows() < a_work.ncols() {
+        let rows = a_work.nrows();
+        let cols = a_work.ncols();
+        let mut a_pad = DMatrix::<Real>::zeros(cols, cols);
+        a_pad.view_mut((0, 0), (rows, cols)).copy_from(&a_work);
+        a_work = a_pad;
+    }
+
+    let svd = a_work.svd(true, true);
+    let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+    if v_t.nrows() < 4 {
+        anyhow::bail!("SVD failed");
+    }
+
+    let e1 = mat3_from_svd_row(&v_t, v_t.nrows() - 4);
+    let e2 = mat3_from_svd_row(&v_t, v_t.nrows() - 3);
+    let e3 = mat3_from_svd_row(&v_t, v_t.nrows() - 2);
+    let e4 = mat3_from_svd_row(&v_t, v_t.nrows() - 1);
+
+    let eqs = build_polynomial_system(&e1, &e2, &e3, &e4);
+
+    let mut m = DMatrix::<Real>::zeros(10, 20);
+    for (r, row) in eqs.iter().enumerate() {
+        for (c, &val) in row.iter().enumerate() {
+            m[(r, c)] = val;
+        }
+    }
+
+    let m1 = m.view((0, 0), (10, 10)).into_owned();
+    let m2 = m.view((0, 10), (10, 10)).into_owned();
+
+    let m1_lu = m1.lu();
+    let c = m1_lu
+        .solve(&(-m2))
+        .ok_or(anyhow::anyhow!("Polynomial solve failed"))?;
+
+    let mut action = DMatrix::<Real>::zeros(10, 10);
+    let deg3_rows = [2, 4, 5, 7, 8, 9];
+    for (col, &row) in deg3_rows.iter().enumerate() {
+        for r in 0..10 {
+            action[(r, col)] = c[(row, r)];
+        }
+    }
+
+    action[(2, 6)] = 1.0;
+    action[(4, 7)] = 1.0;
+    action[(5, 8)] = 1.0;
+    action[(8, 9)] = 1.0;
+
+    let action = action.transpose();
+
+    let schur = Schur::new(action.clone());
+    let eigvals = schur.complex_eigenvalues();
+
+    let mut solutions = Vec::new();
+    for val in eigvals.iter() {
+        if val.im.abs() > 1e-8 {
+            continue;
+        }
+        let z = val.re;
+
+        let mut a_eval = action.clone();
+        for i in 0..10 {
+            a_eval[(i, i)] -= z;
+        }
+        let svd = a_eval.svd(true, true);
+        let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+        let vec = v_t.row(v_t.nrows() - 1);
+
+        let v9 = vec[9];
+        if v9.abs() < 1e-12 {
+            continue;
+        }
+
+        let x = vec[6] / v9;
+        let y = vec[7] / v9;
+        let z_vec = vec[8] / v9;
+
+        let e = e1 * x + e2 * y + e3 * z_vec + e4;
+
+        solutions.push((z_vec, e));
+    }
+
+    if solutions.is_empty() {
+        anyhow::bail!("Polynomial solve failed");
+    }
+
+    solutions.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(solutions.into_iter().map(|(_, e)| e).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::{Pt3, Vec3};
+
+    #[test]
+    fn essential_5point_fits_minimal_set() {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        let t = Vec3::new(0.1, 0.02, 0.03);
+
+        let world = vec![
+            Pt3::new(0.1, 0.2, 2.0),
+            Pt3::new(-0.2, 0.1, 2.5),
+            Pt3::new(0.3, -0.1, 3.0),
+            Pt3::new(-0.15, -0.2, 2.2),
+            Pt3::new(0.05, 0.3, 2.8),
+        ];
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+        for pw in world {
+            let pc1 = pw.coords;
+            let pc2 = rot * pw + t;
+
+            pts1.push(Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z));
+            pts2.push(Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z));
+        }
+
+        let sols = essential_5point(&pts1, &pts2).unwrap();
+        assert!(!sols.is_empty());
+
+        let mut best = f64::INFINITY;
+        for e in &sols {
+            let mut err = 0.0;
+            for (p1, p2) in pts1.iter().zip(pts2.iter()) {
+                let x = nalgebra::Vector3::new(p1.x, p1.y, 1.0);
+                let xp = nalgebra::Vector3::new(p2.x, p2.y, 1.0);
+                let val = xp.transpose() * e * x;
+                err += val[0].abs();
+            }
+            best = best.min(err);
+        }
+
+        assert!(best < 1e-6, "5-point residual too large: {}", best);
+
+        // Also verify decomposition recovers the ground truth pose.
+        let mut found_good_decomp = false;
+        for e in &sols {
+            let decomps = crate::epipolar::decompose_essential(e).unwrap();
+            for (r_est, t_est) in &decomps {
+                let r_diff: Mat3 = r_est.transpose() * rot.matrix();
+                let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+                let ang_deg = cos_theta.acos().to_degrees();
+                let cos_t: Real = t_est.normalize().dot(&t.normalize()).abs();
+                if ang_deg < 1.0 && cos_t > 0.99 {
+                    found_good_decomp = true;
+                }
+            }
+        }
+        assert!(
+            found_good_decomp,
+            "5-point solver did not produce an E that decomposes to the correct pose"
+        );
+    }
+}

--- a/crates/vision-geometry/src/epipolar/fundamental.rs
+++ b/crates/vision-geometry/src/epipolar/fundamental.rs
@@ -3,7 +3,7 @@
 //! Implements the normalized 8-point algorithm, the minimal 7-point solver,
 //! and RANSAC-based robust estimation for fundamental matrices.
 
-use crate::math::{mat3_from_svd_row, normalize_points_2d, solve_cubic_real};
+use crate::math::{dlt_rank_ok, mat3_from_svd_row, normalize_points_2d, solve_cubic_real};
 use anyhow::Result;
 use nalgebra::{DMatrix, SMatrix};
 use vision_calibration_core::{Estimator, Mat3, Pt2, RansacOptions, Real, ransac_fit};
@@ -53,7 +53,18 @@ pub fn fundamental_8point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
     }
 
     let svd = a_work.svd(true, true);
+    let sv: Vec<Real> = svd.singular_values.iter().cloned().collect();
     let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+
+    // The 9-column epipolar design matrix must have rank exactly 8 (1-D null
+    // space).  Collinear or coincident points collapse sv[7] toward zero.
+    if !dlt_rank_ok(&sv, 9, 1, 1e-7) {
+        anyhow::bail!(
+            "rank-deficient 8-point system: points are collinear or degenerate \
+             (need 8 points in general position)"
+        );
+    }
+
     let f_vec = v_t.row(v_t.nrows() - 1);
 
     let mut f = Mat3::zeros();
@@ -126,9 +137,21 @@ pub fn fundamental_7point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
     }
 
     let svd = a_work.svd(true, true);
+    let sv: Vec<Real> = svd.singular_values.iter().cloned().collect();
     let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
     if v_t.nrows() < 2 {
         anyhow::bail!("SVD failed: not enough nullspace vectors");
+    }
+
+    // The 7-point method intentionally uses a 2-D null space (it solves a
+    // cubic over two null vectors).  The 7th singular value (index 6) must
+    // be meaningfully positive — if it collapses the input is degenerate
+    // (e.g. all 7 points collinear) and both null vectors are arbitrary.
+    if !dlt_rank_ok(&sv, 9, 2, 1e-7) {
+        anyhow::bail!(
+            "rank-deficient 7-point system: points are collinear or degenerate \
+             (need 7 points in general position)"
+        );
     }
 
     let f1 = mat3_from_svd_row(&v_t, v_t.nrows() - 2);
@@ -435,47 +458,67 @@ mod tests {
         assert!(f.norm() > 0.0);
     }
 
+    /// Regression: 8 points all on a single image line in both views must return Err.
+    ///
+    /// Collinear configurations collapse the 8th singular value of the 9-column
+    /// design matrix toward zero (the null space becomes ≥2-D), so the last
+    /// singular vector is arbitrary.  The rank check must catch this.
+    #[test]
+    fn fundamental_8point_rejects_collinear_points() {
+        // Both image point sets on a single line: y = x.
+        let pts: Vec<Pt2> = (0..8)
+            .map(|i| {
+                let x = i as Real * 50.0 + 100.0;
+                Pt2::new(x, x)
+            })
+            .collect();
+        // Shift the second image set slightly along the same line direction.
+        let pts2: Vec<Pt2> = pts
+            .iter()
+            .map(|p| Pt2::new(p.x + 10.0, p.y + 10.0))
+            .collect();
+        assert!(
+            fundamental_8point(&pts, &pts2).is_err(),
+            "collinear 8-point input must return Err"
+        );
+    }
+
     #[test]
     fn fundamental_7point_returns_valid_solution() {
         let (_k, kmtx) = make_k();
 
-        let rot_l = Rotation3::identity();
-        let t_l = Translation3::new(0.0, 0.0, 0.0);
-        let rot_r = Rotation3::identity();
-        let t_r = Translation3::new(0.1, 0.0, 0.0);
+        // Use a non-coplanar set of 7 world points (varying x, y, AND z) so
+        // that the epipolar design matrix has rank 7 (2-D null space).
+        // A pure-z grid (all points at the same depth) is coplanar and yields a
+        // degenerate system for which dlt_rank_ok correctly returns false.
+        let rot_r = Rotation3::from_euler_angles(0.0, 0.05, 0.0);
+        let t_r = Translation3::new(0.15, 0.0, 0.0);
 
         let p_l = kmtx * Mat3::identity();
-        let p_r = kmtx * Mat3::identity();
+
+        let world: Vec<nalgebra::Point3<Real>> = vec![
+            nalgebra::Point3::new(0.0, 0.0, 2.0),
+            nalgebra::Point3::new(0.2, 0.0, 2.3),
+            nalgebra::Point3::new(-0.1, 0.15, 2.5),
+            nalgebra::Point3::new(0.3, -0.1, 1.8),
+            nalgebra::Point3::new(-0.2, 0.2, 3.0),
+            nalgebra::Point3::new(0.1, -0.2, 2.7),
+            nalgebra::Point3::new(-0.3, -0.1, 1.5),
+        ];
 
         let mut pts1 = Vec::new();
         let mut pts2 = Vec::new();
 
-        for z in 1..2 {
-            for y in 0..2 {
-                for x in 0..4 {
-                    let pw =
-                        nalgebra::Point3::new(x as Real * 0.1, y as Real * 0.1, z as Real * 0.5);
-                    let pc_l = rot_l * pw + t_l.vector;
-                    let pc_r = rot_r * pw + t_r.vector;
+        for pw in &world {
+            let xl = p_l * pw.coords;
+            let pc_r = rot_r * pw + t_r.vector;
+            let xr = kmtx * pc_r.coords;
 
-                    let xl = p_l * pc_l.coords;
-                    let xr = p_r * pc_r.coords;
-
-                    let u_l = xl.x / xl.z;
-                    let v_l = xl.y / xl.z;
-                    let u_r = xr.x / xr.z;
-                    let v_r = xr.y / xr.z;
-
-                    pts1.push(Pt2::new(u_l, v_l));
-                    pts2.push(Pt2::new(u_r, v_r));
-                }
-            }
+            pts1.push(Pt2::new(xl.x / xl.z, xl.y / xl.z));
+            pts2.push(Pt2::new(xr.x / xr.z, xr.y / xr.z));
         }
 
-        let pts1 = &pts1[..7];
-        let pts2 = &pts2[..7];
-
-        let sols = fundamental_7point(pts1, pts2).unwrap();
+        let sols = fundamental_7point(&pts1, &pts2).unwrap();
         assert!(!sols.is_empty());
 
         let mut best = f64::INFINITY;
@@ -491,5 +534,30 @@ mod tests {
         }
 
         assert!(best < 1e-6, "7-point residual too large: {}", best);
+    }
+
+    /// Regression: 7 points all on a single image line must return Err.
+    ///
+    /// Collinear 7-point input produces a rank-≤6 design matrix (vs the
+    /// required rank 7 for a 2-D null space), so the two "null" vectors are
+    /// arbitrary and the cubic has no meaningful roots.  The rank check
+    /// (`dlt_rank_ok` with `expected_null_dim=2`) must catch this.
+    #[test]
+    fn fundamental_7point_rejects_collinear_points() {
+        // All 7 points on the line y = 2x in both views.
+        let pts: Vec<Pt2> = (0..7)
+            .map(|i| {
+                let x = i as Real * 40.0 + 80.0;
+                Pt2::new(x, 2.0 * x)
+            })
+            .collect();
+        let pts2: Vec<Pt2> = pts
+            .iter()
+            .map(|p| Pt2::new(p.x + 15.0, p.y + 30.0))
+            .collect();
+        assert!(
+            fundamental_7point(&pts, &pts2).is_err(),
+            "collinear 7-point input must return Err"
+        );
     }
 }

--- a/crates/vision-geometry/src/epipolar/fundamental.rs
+++ b/crates/vision-geometry/src/epipolar/fundamental.rs
@@ -3,7 +3,7 @@
 //! Implements the normalized 8-point algorithm, the minimal 7-point solver,
 //! and RANSAC-based robust estimation for fundamental matrices.
 
-use crate::math::{mat3_from_svd_row, solve_cubic_real};
+use crate::math::{mat3_from_svd_row, normalize_points_2d, solve_cubic_real};
 use anyhow::Result;
 use nalgebra::{DMatrix, SMatrix};
 use vision_calibration_core::{Estimator, Mat3, Pt2, RansacOptions, Real, ransac_fit};
@@ -19,10 +19,10 @@ pub fn fundamental_8point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
         return Err(anyhow::anyhow!("Not enough points"));
     }
 
-    let pts1_n = pts1.to_vec();
-    let pts2_n = pts2.to_vec();
-    let t1 = Mat3::identity();
-    let t2 = Mat3::identity();
+    let (pts1_n, t1) = normalize_points_2d(pts1)
+        .ok_or_else(|| anyhow::anyhow!("Degenerate point set (pts1): collinear or coincident"))?;
+    let (pts2_n, t2) = normalize_points_2d(pts2)
+        .ok_or_else(|| anyhow::anyhow!("Degenerate point set (pts2): collinear or coincident"))?;
 
     let mut a = DMatrix::<Real>::zeros(n, 9);
 
@@ -71,6 +71,7 @@ pub fn fundamental_8point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
     let s_mat = SMatrix::<Real, 3, 3>::from_diagonal(&s);
     f = u * s_mat * v_t;
 
+    // De-normalize: F_raw = T2^T * F_norm * T1
     f = t2.transpose() * f * t1;
 
     Ok(f)
@@ -92,10 +93,10 @@ pub fn fundamental_7point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
         anyhow::bail!("Point count mismatch: expected 7, got {}", pts1.len());
     }
 
-    let pts1_n = pts1.to_vec();
-    let pts2_n = pts2.to_vec();
-    let t1 = Mat3::identity();
-    let t2 = Mat3::identity();
+    let (pts1_n, t1) = normalize_points_2d(pts1)
+        .ok_or_else(|| anyhow::anyhow!("Degenerate point set (pts1): collinear or coincident"))?;
+    let (pts2_n, t2) = normalize_points_2d(pts2)
+        .ok_or_else(|| anyhow::anyhow!("Degenerate point set (pts2): collinear or coincident"))?;
 
     let mut a = DMatrix::<Real>::zeros(7, 9);
     for (i, (p1, p2)) in pts1_n.iter().zip(pts2_n.iter()).enumerate() {
@@ -259,6 +260,71 @@ mod tests {
             skew: 0.0,
         };
         (k, k.k_matrix())
+    }
+
+    /// Regression test: Hartley normalization is required for pixel coordinates.
+    ///
+    /// Without normalization the x'x columns (hundreds×hundreds) dominate the
+    /// 9-column design matrix, the SVD is ill-conditioned, and F fails the
+    /// epipolar constraint by orders of magnitude.  With normalization the
+    /// per-point residual |x2^T F x1| / ||F|| must be < 1e-6.
+    #[test]
+    fn fundamental_8point_epipolar_constraint_pixel_coords() {
+        let (_k, kmtx) = make_k();
+
+        // Camera 1 at origin, camera 2 translated along X by 0.5 m.
+        let rot_r = Rotation3::from_euler_angles(0.0, 0.0, 0.0);
+        let t_r = Translation3::new(0.5, 0.0, 0.0);
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+
+        // Points at pixel scale (hundreds to ~1280×720 range).
+        for z in 1..4 {
+            for y in 0..4 {
+                for x in 0..4 {
+                    let pw = nalgebra::Point3::new(
+                        x as Real * 0.4 - 0.6,
+                        y as Real * 0.3 - 0.45,
+                        z as Real * 1.0 + 1.5,
+                    );
+                    // Camera 1 = world frame
+                    let xl = kmtx * pw.coords;
+                    // Camera 2 = shifted by t_r
+                    let pc_r = rot_r * pw + t_r.vector;
+                    let xr = kmtx * pc_r.coords;
+
+                    pts1.push(Pt2::new(xl.x / xl.z, xl.y / xl.z));
+                    pts2.push(Pt2::new(xr.x / xr.z, xr.y / xr.z));
+                }
+            }
+        }
+
+        // Pixel coordinates land in [~400, ~900] range — this is the regime
+        // where unnormalized DLT is numerically unstable.
+        assert!(pts1[0].x > 100.0, "Expected pixel-scale points");
+
+        let f = fundamental_8point(&pts1, &pts2).unwrap();
+        let f_norm = f.norm();
+        assert!(f_norm > 0.0);
+
+        // Verify epipolar constraint |x2^T F x1| / ||F|| is tight for all pts.
+        let mut max_residual: Real = 0.0;
+        for (p1, p2) in pts1.iter().zip(pts2.iter()) {
+            let x1 = nalgebra::Vector3::new(p1.x, p1.y, 1.0);
+            let x2 = nalgebra::Vector3::new(p2.x, p2.y, 1.0);
+            let val = (x2.transpose() * f * x1)[0];
+            let rel = val.abs() / f_norm;
+            if rel > max_residual {
+                max_residual = rel;
+            }
+        }
+        assert!(
+            max_residual < 1e-6,
+            "Epipolar residual |x2^T F x1| / ||F|| = {:.3e} (expected < 1e-6). \
+             This would be >> 1e-6 without Hartley normalization.",
+            max_residual
+        );
     }
 
     #[test]

--- a/crates/vision-geometry/src/epipolar/fundamental.rs
+++ b/crates/vision-geometry/src/epipolar/fundamental.rs
@@ -1,0 +1,429 @@
+//! Fundamental matrix estimation.
+//!
+//! Implements the normalized 8-point algorithm, the minimal 7-point solver,
+//! and RANSAC-based robust estimation for fundamental matrices.
+
+use crate::math::{mat3_from_svd_row, solve_cubic_real};
+use anyhow::Result;
+use nalgebra::{DMatrix, SMatrix};
+use vision_calibration_core::{Estimator, Mat3, Pt2, RansacOptions, Real, ransac_fit};
+
+/// Normalized 8-point algorithm for the fundamental matrix.
+///
+/// `pts1` and `pts2` are corresponding pixel points in two images. The
+/// returned matrix is forced to rank-2 and satisfies `x'^T F x = 0`
+/// (up to numerical error).
+pub fn fundamental_8point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
+    let n = pts1.len();
+    if n < 8 || pts2.len() != n {
+        return Err(anyhow::anyhow!("Not enough points"));
+    }
+
+    let pts1_n = pts1.to_vec();
+    let pts2_n = pts2.to_vec();
+    let t1 = Mat3::identity();
+    let t2 = Mat3::identity();
+
+    let mut a = DMatrix::<Real>::zeros(n, 9);
+
+    for (i, (p1, p2)) in pts1_n.iter().zip(pts2_n.iter()).enumerate() {
+        let x = p1.x;
+        let y = p1.y;
+        let xp = p2.x;
+        let yp = p2.y;
+
+        a[(i, 0)] = xp * x;
+        a[(i, 1)] = xp * y;
+        a[(i, 2)] = xp;
+        a[(i, 3)] = yp * x;
+        a[(i, 4)] = yp * y;
+        a[(i, 5)] = yp;
+        a[(i, 6)] = x;
+        a[(i, 7)] = y;
+        a[(i, 8)] = 1.0;
+    }
+
+    let mut a_work = a.clone();
+    if a_work.nrows() < a_work.ncols() {
+        let rows = a_work.nrows();
+        let cols = a_work.ncols();
+        let mut a_pad = DMatrix::<Real>::zeros(cols, cols);
+        a_pad.view_mut((0, 0), (rows, cols)).copy_from(&a_work);
+        a_work = a_pad;
+    }
+
+    let svd = a_work.svd(true, true);
+    let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+    let f_vec = v_t.row(v_t.nrows() - 1);
+
+    let mut f = Mat3::zeros();
+    for r in 0..3 {
+        for c in 0..3 {
+            f[(r, c)] = f_vec[3 * r + c];
+        }
+    }
+
+    let svd_f = f.svd(true, true);
+    let u = svd_f.u.ok_or(anyhow::anyhow!("SVD failed"))?;
+    let mut s = svd_f.singular_values;
+    let v_t = svd_f.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+    s[2] = 0.0;
+    let s_mat = SMatrix::<Real, 3, 3>::from_diagonal(&s);
+    f = u * s_mat * v_t;
+
+    f = t2.transpose() * f * t1;
+
+    Ok(f)
+}
+
+/// 7-point algorithm for the fundamental matrix (minimal solver).
+///
+/// Returns up to three candidate fundamental matrices. Inputs are pixel
+/// coordinates; internal normalization is applied before solving.
+pub fn fundamental_7point(pts1: &[Pt2], pts2: &[Pt2]) -> Result<Vec<Mat3>> {
+    if pts1.len() != pts2.len() {
+        anyhow::bail!(
+            "Point count mismatch: expected 7, pts1 has {}, pts2 has {}",
+            pts1.len(),
+            pts2.len()
+        );
+    }
+    if pts1.len() != 7 {
+        anyhow::bail!("Point count mismatch: expected 7, got {}", pts1.len());
+    }
+
+    let pts1_n = pts1.to_vec();
+    let pts2_n = pts2.to_vec();
+    let t1 = Mat3::identity();
+    let t2 = Mat3::identity();
+
+    let mut a = DMatrix::<Real>::zeros(7, 9);
+    for (i, (p1, p2)) in pts1_n.iter().zip(pts2_n.iter()).enumerate() {
+        let x = p1.x;
+        let y = p1.y;
+        let xp = p2.x;
+        let yp = p2.y;
+
+        a[(i, 0)] = xp * x;
+        a[(i, 1)] = xp * y;
+        a[(i, 2)] = xp;
+        a[(i, 3)] = yp * x;
+        a[(i, 4)] = yp * y;
+        a[(i, 5)] = yp;
+        a[(i, 6)] = x;
+        a[(i, 7)] = y;
+        a[(i, 8)] = 1.0;
+    }
+
+    let mut a_work = a.clone();
+    if a_work.nrows() < a_work.ncols() {
+        let rows = a_work.nrows();
+        let cols = a_work.ncols();
+        let mut a_pad = DMatrix::<Real>::zeros(cols, cols);
+        a_pad.view_mut((0, 0), (rows, cols)).copy_from(&a_work);
+        a_work = a_pad;
+    }
+
+    let svd = a_work.svd(true, true);
+    let v_t = svd.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+    if v_t.nrows() < 2 {
+        anyhow::bail!("SVD failed: not enough nullspace vectors");
+    }
+
+    let f1 = mat3_from_svd_row(&v_t, v_t.nrows() - 2);
+    let f2 = mat3_from_svd_row(&v_t, v_t.nrows() - 1);
+
+    let det0 = f2.determinant();
+    let det1 = (f2 + f1).determinant();
+    let detm1 = (f2 - f1).determinant();
+    let det2 = (f2 + 2.0 * f1).determinant();
+
+    let d = det0;
+    let s1 = det1 - d;
+    let sm1 = detm1 - d;
+    let s2 = det2 - d;
+
+    let b = 0.5 * (s1 + sm1);
+    let t = 0.5 * (s1 - sm1);
+    let a = (s2 - 2.0 * t - 4.0 * b) / 6.0;
+    let c = t - a;
+
+    let roots = solve_cubic_real(a, b, c, d);
+    if roots.is_empty() {
+        anyhow::bail!("Polynomial solve failed");
+    }
+
+    let mut solutions = Vec::new();
+    for lambda in roots {
+        let mut f = f2 + lambda * f1;
+
+        let svd_f = f.svd(true, true);
+        let u = svd_f.u.ok_or(anyhow::anyhow!("SVD failed"))?;
+        let mut s = svd_f.singular_values;
+        let v_t = svd_f.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+        s[2] = 0.0;
+        let s_mat = SMatrix::<Real, 3, 3>::from_diagonal(&s);
+        f = u * s_mat * v_t;
+
+        f = t2.transpose() * f * t1;
+        solutions.push((lambda, f));
+    }
+
+    solutions.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(solutions.into_iter().map(|(_, f)| f).collect())
+}
+
+/// Robust fundamental matrix estimation using the 8-point algorithm inside RANSAC.
+///
+/// Returns the best model and the indices of inliers. The residual uses an
+/// approximate symmetric epipolar distance in pixels.
+pub fn fundamental_8point_ransac(
+    pts1: &[Pt2],
+    pts2: &[Pt2],
+    opts: &RansacOptions,
+) -> Result<(Mat3, Vec<usize>)> {
+    let n = pts1.len();
+    if n < 8 || pts2.len() != n {
+        anyhow::bail!(format!("Not enough points: {}", n));
+    }
+
+    #[derive(Clone)]
+    struct FDatum {
+        x1: Pt2,
+        x2: Pt2,
+    }
+
+    struct FundamentalEst;
+
+    impl Estimator for FundamentalEst {
+        type Datum = FDatum;
+        type Model = Mat3;
+
+        const MIN_SAMPLES: usize = 8;
+
+        fn fit(data: &[Self::Datum], sample_indices: &[usize]) -> Option<Self::Model> {
+            let mut p1 = Vec::with_capacity(sample_indices.len());
+            let mut p2 = Vec::with_capacity(sample_indices.len());
+            for &idx in sample_indices {
+                p1.push(data[idx].x1);
+                p2.push(data[idx].x2);
+            }
+            fundamental_8point(&p1, &p2).ok()
+        }
+
+        fn residual(model: &Self::Model, datum: &Self::Datum) -> f64 {
+            let x = nalgebra::Vector3::new(datum.x1.x, datum.x1.y, 1.0);
+            let xp = nalgebra::Vector3::new(datum.x2.x, datum.x2.y, 1.0);
+
+            let fx = model * x;
+            let ftxp = model.transpose() * xp;
+            let denom = fx.x * fx.x + fx.y * fx.y + ftxp.x * ftxp.x + ftxp.y * ftxp.y;
+            let denom = denom.max(1e-12);
+            let val = xp.transpose() * model * x;
+            let d2 = (val[0] * val[0]) / denom;
+            d2.sqrt()
+        }
+
+        fn is_degenerate(_data: &[Self::Datum], sample_indices: &[usize]) -> bool {
+            sample_indices.len() < Self::MIN_SAMPLES
+        }
+    }
+
+    let data: Vec<FDatum> = pts1
+        .iter()
+        .cloned()
+        .zip(pts2.iter().cloned())
+        .map(|(x1, x2)| FDatum { x1, x2 })
+        .collect();
+
+    let res = ransac_fit::<FundamentalEst>(&data, opts);
+    if !res.success {
+        anyhow::bail!("RANSAC failed");
+    }
+    let f = res.model.expect("success guarantees a model");
+    Ok((f, res.inliers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Rotation3, Translation3};
+    use vision_calibration_core::{FxFyCxCySkew, Mat3, RansacOptions, Real};
+
+    fn make_k() -> (FxFyCxCySkew<Real>, Mat3) {
+        let k = FxFyCxCySkew {
+            fx: 800.0,
+            fy: 780.0,
+            cx: 640.0,
+            cy: 360.0,
+            skew: 0.0,
+        };
+        (k, k.k_matrix())
+    }
+
+    #[test]
+    fn fundamental_8point_succeeds_on_simple_data() {
+        let (_k, kmtx) = make_k();
+
+        let rot_l = Rotation3::identity();
+        let t_l = Translation3::new(0.0, 0.0, 0.0);
+        let rot_r = Rotation3::identity();
+        let t_r = Translation3::new(0.1, 0.0, 0.0);
+
+        let p_l = kmtx * Mat3::identity();
+        let p_r = kmtx * Mat3::identity();
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+
+        for z in 1..3 {
+            for y in 0..3 {
+                for x in 0..4 {
+                    let pw =
+                        nalgebra::Point3::new(x as Real * 0.1, y as Real * 0.1, z as Real * 0.5);
+                    let pc_l = rot_l * pw + t_l.vector;
+                    let pc_r = rot_r * pw + t_r.vector;
+
+                    let xl = p_l * pc_l.coords;
+                    let xr = p_r * pc_r.coords;
+
+                    let u_l = xl.x / xl.z;
+                    let v_l = xl.y / xl.z;
+                    let u_r = xr.x / xr.z;
+                    let v_r = xr.y / xr.z;
+
+                    pts1.push(Pt2::new(u_l, v_l));
+                    pts2.push(Pt2::new(u_r, v_r));
+                }
+            }
+        }
+
+        let f = fundamental_8point(&pts1, &pts2).unwrap();
+        let norm_f = f.norm();
+        assert!(norm_f > 0.0);
+    }
+
+    #[test]
+    fn fundamental_8point_ransac_handles_outliers() {
+        let (_k, kmtx) = make_k();
+
+        let rot_l = Rotation3::identity();
+        let t_l = Translation3::new(0.0, 0.0, 0.0);
+        let rot_r = Rotation3::identity();
+        let t_r = Translation3::new(0.1, 0.0, 0.0);
+
+        let p_l = kmtx * Mat3::identity();
+        let p_r = kmtx * Mat3::identity();
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+
+        for z in 1..3 {
+            for y in 0..3 {
+                for x in 0..4 {
+                    let pw =
+                        nalgebra::Point3::new(x as Real * 0.1, y as Real * 0.1, z as Real * 0.5);
+                    let pc_l = rot_l * pw + t_l.vector;
+                    let pc_r = rot_r * pw + t_r.vector;
+
+                    let xl = p_l * pc_l.coords;
+                    let xr = p_r * pc_r.coords;
+
+                    let u_l = xl.x / xl.z;
+                    let v_l = xl.y / xl.z;
+                    let u_r = xr.x / xr.z;
+                    let v_r = xr.y / xr.z;
+
+                    pts1.push(Pt2::new(u_l, v_l));
+                    pts2.push(Pt2::new(u_r, v_r));
+                }
+            }
+        }
+
+        let inlier_count = pts1.len();
+
+        pts1.extend_from_slice(&[
+            Pt2::new(120.0, -80.0),
+            Pt2::new(-50.0, 90.0),
+            Pt2::new(200.0, 150.0),
+        ]);
+        pts2.extend_from_slice(&[
+            Pt2::new(-140.0, 60.0),
+            Pt2::new(75.0, -200.0),
+            Pt2::new(300.0, 10.0),
+        ]);
+
+        let opts = RansacOptions {
+            max_iters: 500,
+            thresh: 1e-3,
+            min_inliers: inlier_count.saturating_sub(2),
+            confidence: 0.99,
+            seed: 123,
+            refit_on_inliers: true,
+        };
+
+        let (f, inliers) = fundamental_8point_ransac(&pts1, &pts2, &opts).unwrap();
+
+        assert!(inliers.len() >= inlier_count.saturating_sub(2));
+        assert!(inliers.len() < pts1.len());
+        assert!(f.norm() > 0.0);
+    }
+
+    #[test]
+    fn fundamental_7point_returns_valid_solution() {
+        let (_k, kmtx) = make_k();
+
+        let rot_l = Rotation3::identity();
+        let t_l = Translation3::new(0.0, 0.0, 0.0);
+        let rot_r = Rotation3::identity();
+        let t_r = Translation3::new(0.1, 0.0, 0.0);
+
+        let p_l = kmtx * Mat3::identity();
+        let p_r = kmtx * Mat3::identity();
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+
+        for z in 1..2 {
+            for y in 0..2 {
+                for x in 0..4 {
+                    let pw =
+                        nalgebra::Point3::new(x as Real * 0.1, y as Real * 0.1, z as Real * 0.5);
+                    let pc_l = rot_l * pw + t_l.vector;
+                    let pc_r = rot_r * pw + t_r.vector;
+
+                    let xl = p_l * pc_l.coords;
+                    let xr = p_r * pc_r.coords;
+
+                    let u_l = xl.x / xl.z;
+                    let v_l = xl.y / xl.z;
+                    let u_r = xr.x / xr.z;
+                    let v_r = xr.y / xr.z;
+
+                    pts1.push(Pt2::new(u_l, v_l));
+                    pts2.push(Pt2::new(u_r, v_r));
+                }
+            }
+        }
+
+        let pts1 = &pts1[..7];
+        let pts2 = &pts2[..7];
+
+        let sols = fundamental_7point(pts1, pts2).unwrap();
+        assert!(!sols.is_empty());
+
+        let mut best = f64::INFINITY;
+        for f in sols {
+            let mut err = 0.0;
+            for (p1, p2) in pts1.iter().zip(pts2.iter()) {
+                let x = nalgebra::Vector3::new(p1.x, p1.y, 1.0);
+                let xp = nalgebra::Vector3::new(p2.x, p2.y, 1.0);
+                let val = xp.transpose() * f * x;
+                err += val[0].abs();
+            }
+            best = best.min(err);
+        }
+
+        assert!(best < 1e-6, "7-point residual too large: {}", best);
+    }
+}

--- a/crates/vision-geometry/src/epipolar/mod.rs
+++ b/crates/vision-geometry/src/epipolar/mod.rs
@@ -1,0 +1,17 @@
+//! Epipolar geometry solvers for fundamental and essential matrices.
+//!
+//! Includes normalized 8-point, 7-point, and 5-point minimal solvers, plus
+//! decomposition of the essential matrix into candidate poses.
+//!
+//! - Fundamental matrix `F` expects **pixel coordinates** in both images.
+//! - Essential matrix `E` expects **normalized coordinates** (after applying
+//!   `K⁻¹`), or equivalently calibrated rays on the normalized image plane.
+
+mod decomposition;
+mod essential;
+mod fundamental;
+pub(crate) mod polynomial;
+
+pub use decomposition::decompose_essential;
+pub use essential::essential_5point;
+pub use fundamental::{fundamental_7point, fundamental_8point, fundamental_8point_ransac};

--- a/crates/vision-geometry/src/epipolar/mod.rs
+++ b/crates/vision-geometry/src/epipolar/mod.rs
@@ -13,5 +13,5 @@ mod fundamental;
 pub(crate) mod polynomial;
 
 pub use decomposition::decompose_essential;
-pub use essential::essential_5point;
+pub use essential::{essential_5point, essential_linear};
 pub use fundamental::{fundamental_7point, fundamental_8point, fundamental_8point_ransac};

--- a/crates/vision-geometry/src/epipolar/polynomial.rs
+++ b/crates/vision-geometry/src/epipolar/polynomial.rs
@@ -1,0 +1,184 @@
+//! Polynomial constraint system for 5-point essential matrix solver.
+//!
+//! Implements symbolic polynomial manipulation in three variables
+//! (x, y, z) up to degree 3, used to encode the essential matrix constraints
+//! in Nistér's 5-point algorithm.
+
+use vision_calibration_core::{Mat3, Real};
+
+/// Monomial ordering for degree-3 polynomials in three variables.
+const MONOMIALS: [(u8, u8, u8); 20] = [
+    (3, 0, 0), // x^3
+    (2, 1, 0), // x^2 y
+    (2, 0, 1), // x^2 z
+    (1, 2, 0), // x y^2
+    (1, 1, 1), // x y z
+    (1, 0, 2), // x z^2
+    (0, 3, 0), // y^3
+    (0, 2, 1), // y^2 z
+    (0, 1, 2), // y z^2
+    (0, 0, 3), // z^3
+    (2, 0, 0), // x^2
+    (1, 1, 0), // x y
+    (1, 0, 1), // x z
+    (0, 2, 0), // y^2
+    (0, 1, 1), // y z
+    (0, 0, 2), // z^2
+    (1, 0, 0), // x
+    (0, 1, 0), // y
+    (0, 0, 1), // z
+    (0, 0, 0), // 1
+];
+
+/// Polynomial in three variables (x, y, z) with degree ≤ 3.
+#[derive(Clone, Copy)]
+pub(crate) struct Poly3 {
+    pub coeffs: [Real; 20],
+}
+
+impl Poly3 {
+    pub fn zero() -> Self {
+        Self { coeffs: [0.0; 20] }
+    }
+
+    pub fn linear(c0: Real, cx: Real, cy: Real, cz: Real) -> Self {
+        let mut p = Self::zero();
+        p.coeffs[19] = c0;
+        p.coeffs[16] = cx;
+        p.coeffs[17] = cy;
+        p.coeffs[18] = cz;
+        p
+    }
+
+    pub fn add(&self, other: &Self) -> Self {
+        let mut out = Self::zero();
+        for i in 0..20 {
+            out.coeffs[i] = self.coeffs[i] + other.coeffs[i];
+        }
+        out
+    }
+
+    pub fn sub(&self, other: &Self) -> Self {
+        let mut out = Self::zero();
+        for i in 0..20 {
+            out.coeffs[i] = self.coeffs[i] - other.coeffs[i];
+        }
+        out
+    }
+
+    pub fn scale(&self, s: Real) -> Self {
+        let mut out = Self::zero();
+        for i in 0..20 {
+            out.coeffs[i] = self.coeffs[i] * s;
+        }
+        out
+    }
+
+    pub fn mul(&self, other: &Self) -> Self {
+        let mut out = Self::zero();
+        for (i, &ai) in self.coeffs.iter().enumerate() {
+            if ai == 0.0 {
+                continue;
+            }
+            let (ix, iy, iz) = MONOMIALS[i];
+            for (j, &bj) in other.coeffs.iter().enumerate() {
+                if bj == 0.0 {
+                    continue;
+                }
+                let (jx, jy, jz) = MONOMIALS[j];
+                let dx = ix + jx;
+                let dy = iy + jy;
+                let dz = iz + jz;
+                if dx + dy + dz > 3 {
+                    continue;
+                }
+                if let Some(idx) = monomial_index(dx, dy, dz) {
+                    out.coeffs[idx] += ai * bj;
+                }
+            }
+        }
+        out
+    }
+}
+
+fn monomial_index(x: u8, y: u8, z: u8) -> Option<usize> {
+    MONOMIALS.iter().enumerate().find_map(|(i, &(mx, my, mz))| {
+        if mx == x && my == y && mz == z {
+            Some(i)
+        } else {
+            None
+        }
+    })
+}
+
+pub(crate) fn poly_mat_mul(a: &[[Poly3; 3]; 3], b: &[[Poly3; 3]; 3]) -> [[Poly3; 3]; 3] {
+    let mut out = [[Poly3::zero(); 3]; 3];
+    for r in 0..3 {
+        for c in 0..3 {
+            let mut sum = Poly3::zero();
+            for k in 0..3 {
+                sum = sum.add(&a[r][k].mul(&b[k][c]));
+            }
+            out[r][c] = sum;
+        }
+    }
+    out
+}
+
+pub(crate) fn poly_transpose(a: &[[Poly3; 3]; 3]) -> [[Poly3; 3]; 3] {
+    let mut out = [[Poly3::zero(); 3]; 3];
+    for r in 0..3 {
+        for c in 0..3 {
+            out[r][c] = a[c][r];
+        }
+    }
+    out
+}
+
+pub(crate) fn poly_det3(a: &[[Poly3; 3]; 3]) -> Poly3 {
+    let term1 = a[0][0].mul(&a[1][1].mul(&a[2][2]).sub(&a[1][2].mul(&a[2][1])));
+    let term2 = a[0][1].mul(&a[1][0].mul(&a[2][2]).sub(&a[1][2].mul(&a[2][0])));
+    let term3 = a[0][2].mul(&a[1][0].mul(&a[2][1]).sub(&a[1][1].mul(&a[2][0])));
+
+    term1.sub(&term2).add(&term3)
+}
+
+/// Build the polynomial constraint system for the 5-point algorithm.
+///
+/// Given four basis essential matrices, constructs the 10 equations that
+/// encode det(E) = 0 and trace(E E^T E) - 0.5 * trace(E E^T) E = 0.
+pub(crate) fn build_polynomial_system(
+    e1: &Mat3,
+    e2: &Mat3,
+    e3: &Mat3,
+    e4: &Mat3,
+) -> [[Real; 20]; 10] {
+    let mut e = [[Poly3::zero(); 3]; 3];
+    for r in 0..3 {
+        for c in 0..3 {
+            e[r][c] = Poly3::linear(e4[(r, c)], e1[(r, c)], e2[(r, c)], e3[(r, c)]);
+        }
+    }
+
+    let det = poly_det3(&e);
+
+    let e_t = poly_transpose(&e);
+    let eet = poly_mat_mul(&e, &e_t);
+    let eet_e = poly_mat_mul(&eet, &e);
+
+    let trace = eet[0][0].add(&eet[1][1]).add(&eet[2][2]);
+
+    let mut eqs = [[0.0; 20]; 10];
+    eqs[0] = det.coeffs;
+
+    let mut row = 1;
+    for r in 0..3 {
+        for c in 0..3 {
+            let term = eet_e[r][c].scale(2.0).sub(&trace.mul(&e[r][c]));
+            eqs[row] = term.coeffs;
+            row += 1;
+        }
+    }
+
+    eqs
+}

--- a/crates/vision-geometry/src/homography.rs
+++ b/crates/vision-geometry/src/homography.rs
@@ -1,0 +1,241 @@
+//! Homography estimation (plane-induced projective transform).
+//!
+//! Implements the normalized Direct Linear Transform (DLT) and a robust
+//! RANSAC wrapper. The homography `H` maps points from one plane to another:
+//! `x' ~ H x`.
+//!
+//! Input points should be in consistent units; normalization is applied
+//! internally for numerical stability and the output is de-normalized.
+
+use crate::math::normalize_points_2d;
+use anyhow::Result;
+use nalgebra::DMatrix;
+use vision_calibration_core::{
+    Estimator, Mat3, Pt2, RansacOptions, from_homogeneous, ransac_fit, to_homogeneous,
+};
+
+/// Estimate `H` such that `x' ~ H x` using normalized DLT.
+///
+/// `src` and `dst` are corresponding 2D points. The returned homography
+/// is scaled so that `H[2,2] == 1` when possible.
+pub fn dlt_homography(src: &[Pt2], dst: &[Pt2]) -> Result<Mat3> {
+    let n = src.len();
+    if n < 4 || dst.len() != n {
+        anyhow::bail!("need at least 4 point correspondences, got {}", n);
+    }
+
+    let (src_n, t_w) = normalize_points_2d(src)
+        .ok_or_else(|| anyhow::anyhow!("degenerate point configuration for normalization"))?;
+    let (dst_n, t_i) = normalize_points_2d(dst)
+        .ok_or_else(|| anyhow::anyhow!("degenerate point configuration for normalization"))?;
+
+    let mut a = DMatrix::<f64>::zeros(2 * n, 9);
+
+    for (i, (pw, pi)) in src_n.iter().zip(dst_n.iter()).enumerate() {
+        let x = pw.x;
+        let y = pw.y;
+        let u = pi.x;
+        let v = pi.y;
+
+        let r0 = 2 * i;
+        let r1 = 2 * i + 1;
+
+        a[(r0, 0)] = -x;
+        a[(r0, 1)] = -y;
+        a[(r0, 2)] = -1.0;
+        a[(r0, 6)] = u * x;
+        a[(r0, 7)] = u * y;
+        a[(r0, 8)] = u;
+
+        a[(r1, 3)] = -x;
+        a[(r1, 4)] = -y;
+        a[(r1, 5)] = -1.0;
+        a[(r1, 6)] = v * x;
+        a[(r1, 7)] = v * y;
+        a[(r1, 8)] = v;
+    }
+
+    let mut a_work = a;
+    if a_work.nrows() < a_work.ncols() {
+        let rows = a_work.nrows();
+        let cols = a_work.ncols();
+        let mut a_pad = DMatrix::<f64>::zeros(cols, cols);
+        a_pad.view_mut((0, 0), (rows, cols)).copy_from(&a_work);
+        a_work = a_pad;
+    }
+
+    let svd = a_work.svd(true, true);
+    let v_t = svd.v_t.ok_or_else(|| anyhow::anyhow!("svd failed"))?;
+    let h_vec = v_t.row(v_t.nrows() - 1);
+
+    let mut h_mat = Mat3::zeros();
+    for r in 0..3 {
+        for c in 0..3 {
+            h_mat[(r, c)] = h_vec[3 * r + c];
+        }
+    }
+
+    let t_i_inv = t_i
+        .try_inverse()
+        .ok_or_else(|| anyhow::anyhow!("svd failed"))?;
+    h_mat = t_i_inv * h_mat * t_w;
+
+    let scale = h_mat[(2, 2)];
+    if scale.abs() > f64::EPSILON {
+        h_mat /= scale;
+    }
+
+    Ok(h_mat)
+}
+
+/// Estimate a homography using DLT inside a RANSAC loop.
+///
+/// Returns the best homography and the indices of inliers. The residual is
+/// Euclidean reprojection error.
+pub fn dlt_homography_ransac(
+    src: &[Pt2],
+    dst: &[Pt2],
+    opts: &RansacOptions,
+) -> Result<(Mat3, Vec<usize>)> {
+    let n = src.len();
+    if n < 4 || dst.len() != n {
+        anyhow::bail!("need at least 4 point correspondences, got {}", n);
+    }
+
+    #[derive(Clone)]
+    struct HomographyDatum {
+        w: Pt2,
+        i: Pt2,
+    }
+
+    struct HomographyEst;
+
+    impl Estimator for HomographyEst {
+        type Datum = HomographyDatum;
+        type Model = Mat3;
+
+        const MIN_SAMPLES: usize = 4;
+
+        fn fit(data: &[Self::Datum], sample_indices: &[usize]) -> Option<Self::Model> {
+            let mut src = Vec::with_capacity(sample_indices.len());
+            let mut dst = Vec::with_capacity(sample_indices.len());
+            for &idx in sample_indices {
+                src.push(data[idx].w);
+                dst.push(data[idx].i);
+            }
+            dlt_homography(&src, &dst).ok()
+        }
+
+        fn residual(model: &Self::Model, datum: &Self::Datum) -> f64 {
+            let p = to_homogeneous(&datum.w);
+            let proj = model * p;
+            let proj_pt = from_homogeneous(&proj);
+            let du = proj_pt.x - datum.i.x;
+            let dv = proj_pt.y - datum.i.y;
+            (du * du + dv * dv).sqrt()
+        }
+
+        fn is_degenerate(data: &[Self::Datum], sample_indices: &[usize]) -> bool {
+            if sample_indices.len() < 3 {
+                return false;
+            }
+            let p0 = data[sample_indices[0]].w;
+            let p1 = data[sample_indices[1]].w;
+            let p2 = data[sample_indices[2]].w;
+            let area = (p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x);
+            area.abs() < 1e-9
+        }
+
+        fn refit(data: &[Self::Datum], inliers: &[usize]) -> Option<Self::Model> {
+            if inliers.len() < 4 {
+                return None;
+            }
+            let mut src = Vec::with_capacity(inliers.len());
+            let mut dst = Vec::with_capacity(inliers.len());
+            for &idx in inliers {
+                src.push(data[idx].w);
+                dst.push(data[idx].i);
+            }
+            dlt_homography(&src, &dst).ok()
+        }
+    }
+
+    let data: Vec<HomographyDatum> = src
+        .iter()
+        .cloned()
+        .zip(dst.iter().cloned())
+        .map(|(w, i)| HomographyDatum { w, i })
+        .collect();
+
+    let res = ransac_fit::<HomographyEst>(&data, opts);
+    if !res.success {
+        anyhow::bail!("ransac failed to find a consensus homography");
+    }
+
+    let h = res.model.expect("success guarantees a model");
+    Ok((h, res.inliers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vision_calibration_core::{Pt2, RansacOptions};
+
+    #[test]
+    fn basic_homography() {
+        let w = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(1.0, 0.0),
+            Pt2::new(1.0, 1.0),
+            Pt2::new(0.0, 1.0),
+        ];
+        let img = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(2.0, 0.0),
+            Pt2::new(2.0, 2.0),
+            Pt2::new(0.0, 2.0),
+        ];
+
+        let h = dlt_homography(&w, &img).unwrap();
+        let s = h[(0, 0)];
+        assert!((s - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn homography_ransac_handles_outliers() {
+        let w = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(1.0, 0.0),
+            Pt2::new(1.0, 1.0),
+            Pt2::new(0.0, 1.0),
+        ];
+        let img_inliers = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(2.0, 0.0),
+            Pt2::new(2.0, 2.0),
+            Pt2::new(0.0, 2.0),
+        ];
+
+        let mut w_all = w.clone();
+        let mut img_all = img_inliers.clone();
+        w_all.push(Pt2::new(0.5, 0.5));
+        img_all.push(Pt2::new(10.0, -3.0));
+        w_all.push(Pt2::new(-0.2, 0.3));
+        img_all.push(Pt2::new(-5.0, 7.0));
+
+        let opts = RansacOptions {
+            max_iters: 200,
+            thresh: 0.1,
+            min_inliers: 4,
+            confidence: 0.99,
+            seed: 7,
+            refit_on_inliers: true,
+        };
+
+        let (h, inliers) = dlt_homography_ransac(&w_all, &img_all, &opts).unwrap();
+
+        assert!(inliers.len() >= 4);
+        let scale = h[(0, 0)];
+        assert!((scale - 2.0).abs() < 1e-2);
+    }
+}

--- a/crates/vision-geometry/src/homography.rs
+++ b/crates/vision-geometry/src/homography.rs
@@ -14,6 +14,31 @@ use vision_calibration_core::{
     Estimator, Mat3, Pt2, RansacOptions, from_homogeneous, ransac_fit, to_homogeneous,
 };
 
+/// Return `true` if all points are (approximately) collinear.
+///
+/// Tests every triple; if any triple has a cross-product magnitude below
+/// `1e-6` (relative area threshold for normalized-ish coordinates) the
+/// point set is flagged as collinear.  Only three or more points can be
+/// collinear, so fewer than 3 points always return `false`.
+fn points_are_collinear(pts: &[Pt2]) -> bool {
+    if pts.len() < 3 {
+        return false;
+    }
+    // Use the first two points to define the reference direction, then check
+    // all remaining points against it.  This is O(n) instead of O(n³) and
+    // is sufficient: if *any* triple that includes pts[0]–pts[1] as the base
+    // is collinear for ALL other points, the whole set is collinear.
+    let p0 = pts[0];
+    let p1 = pts[1];
+    for p2 in pts.iter().skip(2) {
+        let cross = (p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x);
+        if cross.abs() > 1e-6 {
+            return false; // found a non-collinear triple
+        }
+    }
+    true
+}
+
 /// Estimate `H` such that `x' ~ H x` using normalized DLT.
 ///
 /// `src` and `dst` are corresponding 2D points. The returned homography
@@ -22,6 +47,24 @@ pub fn dlt_homography(src: &[Pt2], dst: &[Pt2]) -> Result<Mat3> {
     let n = src.len();
     if n < 4 || dst.len() != n {
         anyhow::bail!("need at least 4 point correspondences, got {}", n);
+    }
+
+    // Reject collinear configurations early: a valid homography requires at
+    // least 4 points in general position (no 3 collinear) in BOTH the source
+    // and destination sets.  Collinear src makes the design matrix rank < 8;
+    // collinear dst yields a degenerate (rank-2) homography that maps the
+    // entire plane to a line and cannot be reliably inverted or applied.
+    if points_are_collinear(src) {
+        anyhow::bail!(
+            "rank-deficient point configuration: source points are collinear \
+             (need 4 correspondences in general position, no 3 collinear)"
+        );
+    }
+    if points_are_collinear(dst) {
+        anyhow::bail!(
+            "rank-deficient point configuration: destination points are collinear \
+             (need 4 correspondences in general position, no 3 collinear)"
+        );
     }
 
     let (src_n, t_w) = normalize_points_2d(src)
@@ -65,6 +108,26 @@ pub fn dlt_homography(src: &[Pt2], dst: &[Pt2]) -> Result<Mat3> {
     }
 
     let svd = a_work.svd(true, true);
+
+    // Rank-deficiency check: for a well-posed homography the 2n×9 design
+    // matrix must have rank exactly 8 (a 1-D null space).  The SVD yields
+    // 9 singular values sorted descending.  We interrogate them *before*
+    // moving `v_t` out to avoid a partial-move borrow issue.
+    let sv = svd.singular_values.clone();
+    if sv[0] <= f64::EPSILON {
+        anyhow::bail!("degenerate (all-zero) homography design matrix");
+    }
+    // sv[7] is the second-smallest singular value.  For a valid
+    // configuration (4 points in general position) it is well above zero.
+    // For collinear input the null space is ≥2-D and sv[7] collapses
+    // toward zero like sv[8].
+    if sv[7] / sv[0] < 1e-7 {
+        anyhow::bail!(
+            "rank-deficient point configuration: homography is underdetermined \
+             (need 4 correspondences in general position, no 3 collinear)"
+        );
+    }
+
     let v_t = svd.v_t.ok_or_else(|| anyhow::anyhow!("svd failed"))?;
     let h_vec = v_t.row(v_t.nrows() - 1);
 
@@ -199,6 +262,53 @@ mod tests {
         let h = dlt_homography(&w, &img).unwrap();
         let s = h[(0, 0)];
         assert!((s - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dlt_homography_rejects_collinear_src_points() {
+        // Source points all on the line y = 2x + 1 → collinear → Err.
+        let src: Vec<Pt2> = (0..5)
+            .map(|t| {
+                let x = t as f64;
+                Pt2::new(x, 2.0 * x + 1.0)
+            })
+            .collect();
+        // Destination points are in general position.
+        let dst = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(3.0, 1.0),
+            Pt2::new(1.0, 4.0),
+            Pt2::new(5.0, 2.0),
+            Pt2::new(2.0, 6.0),
+        ];
+        assert!(
+            dlt_homography(&src, &dst).is_err(),
+            "collinear src points must produce Err"
+        );
+    }
+
+    #[test]
+    fn dlt_homography_rejects_collinear_dst_points() {
+        // Destination points all on the line y = 3x.
+        // Source points form an irregular quadrilateral + one off-center
+        // interior point — all in general position (verified: no 3 collinear).
+        let src = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(5.0, 1.0),
+            Pt2::new(4.0, 4.0),
+            Pt2::new(1.0, 3.0),
+            Pt2::new(3.0, 1.5),
+        ];
+        let dst: Vec<Pt2> = (0..5)
+            .map(|t| {
+                let x = t as f64;
+                Pt2::new(x, 3.0 * x)
+            })
+            .collect();
+        assert!(
+            dlt_homography(&src, &dst).is_err(),
+            "collinear dst points must produce Err"
+        );
     }
 
     #[test]

--- a/crates/vision-geometry/src/homography.rs
+++ b/crates/vision-geometry/src/homography.rs
@@ -16,24 +16,46 @@ use vision_calibration_core::{
 
 /// Return `true` if all points are (approximately) collinear.
 ///
-/// Tests every triple; if any triple has a cross-product magnitude below
-/// `1e-6` (relative area threshold for normalized-ish coordinates) the
-/// point set is flagged as collinear.  Only three or more points can be
-/// collinear, so fewer than 3 points always return `false`.
+/// Anchors the reference direction on the **first distinct pair** of points
+/// (skipping duplicates of `pts[0]`). If all points are identical the set is
+/// trivially degenerate and `true` is returned. Otherwise every remaining
+/// point is tested: if any cross-product magnitude exceeds `1e-6` the set is
+/// not collinear.
+///
+/// Only three or more points can be collinear, so fewer than 3 points always
+/// return `false`.
 fn points_are_collinear(pts: &[Pt2]) -> bool {
     if pts.len() < 3 {
         return false;
     }
-    // Use the first two points to define the reference direction, then check
-    // all remaining points against it.  This is O(n) instead of O(n³) and
-    // is sufficient: if *any* triple that includes pts[0]–pts[1] as the base
-    // is collinear for ALL other points, the whole set is collinear.
+
     let p0 = pts[0];
-    let p1 = pts[1];
-    for p2 in pts.iter().skip(2) {
+
+    // Find the first point that is meaningfully different from pts[0].
+    // This avoids a zero baseline when the leading points are duplicates.
+    const SAME_PT_EPS: f64 = 1e-9;
+    let Some(p1) = pts
+        .iter()
+        .skip(1)
+        .find(|p| {
+            let dx = p.x - p0.x;
+            let dy = p.y - p0.y;
+            (dx * dx + dy * dy).sqrt() > SAME_PT_EPS
+        })
+        .copied()
+    else {
+        // All points are identical → degenerate.
+        return true;
+    };
+
+    // Test every other point against the p0–p1 baseline.
+    for p2 in pts.iter() {
+        if (p2.x - p0.x).hypot(p2.y - p0.y) <= SAME_PT_EPS {
+            continue; // duplicate of p0 — collinear by definition
+        }
         let cross = (p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x);
         if cross.abs() > 1e-6 {
-            return false; // found a non-collinear triple
+            return false; // found a non-collinear point
         }
     }
     true
@@ -308,6 +330,59 @@ mod tests {
         assert!(
             dlt_homography(&src, &dst).is_err(),
             "collinear dst points must produce Err"
+        );
+    }
+
+    /// Regression: pts[0] == pts[1] must NOT cause a false collinearity verdict.
+    ///
+    /// The old implementation anchored the reference direction on pts[0]–pts[1].
+    /// When those two are duplicates the baseline vector is zero, every cross
+    /// product evaluates to zero, and the entire (otherwise general-position)
+    /// set was wrongly flagged as collinear — causing `dlt_homography` to
+    /// reject valid overdetermined inputs.
+    #[test]
+    fn dlt_homography_accepts_duplicate_leading_points_in_general_position() {
+        // pts[0] and pts[1] are identical; the remaining points form a valid
+        // (non-collinear) set together with pts[0].  The duplicate does NOT
+        // make the whole set collinear.
+        let dup = Pt2::new(0.0, 0.0);
+        let src = vec![
+            dup,
+            dup, // duplicate of pts[0]
+            Pt2::new(1.0, 0.0),
+            Pt2::new(1.0, 1.0),
+            Pt2::new(0.0, 1.0),
+        ];
+        // Correspondences under a 2× scale homography.
+        let dst = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(0.0, 0.0), // duplicate too
+            Pt2::new(2.0, 0.0),
+            Pt2::new(2.0, 2.0),
+            Pt2::new(0.0, 2.0),
+        ];
+        let h = dlt_homography(&src, &dst)
+            .expect("duplicate leading point must not cause false collinearity rejection");
+        // The homography should approximate a 2× scale.
+        let s = h[(0, 0)];
+        assert!((s - 2.0).abs() < 1e-4, "unexpected scale: {}", s);
+    }
+
+    /// Regression: an all-identical point set is genuinely degenerate.
+    #[test]
+    fn dlt_homography_rejects_all_identical_src_points() {
+        let same = Pt2::new(1.0, 1.0);
+        let src = vec![same; 5];
+        let dst = vec![
+            Pt2::new(0.0, 0.0),
+            Pt2::new(3.0, 1.0),
+            Pt2::new(1.0, 4.0),
+            Pt2::new(5.0, 2.0),
+            Pt2::new(2.0, 6.0),
+        ];
+        assert!(
+            dlt_homography(&src, &dst).is_err(),
+            "all-identical src points must produce Err"
         );
     }
 

--- a/crates/vision-geometry/src/lib.rs
+++ b/crates/vision-geometry/src/lib.rs
@@ -1,0 +1,33 @@
+//! Shared geometric solvers for computer vision.
+//!
+//! This crate provides deterministic, allocation-light solvers for fundamental
+//! geometric problems: epipolar geometry, homography estimation, triangulation,
+//! and camera matrix decomposition. These building blocks are used by both
+//! calibration workflows and multiple-view geometry pipelines.
+//!
+//! # Modules
+//!
+//! - [`math`] — Hartley normalization, polynomial solvers, SVD extraction helpers
+//! - [`epipolar`] — Fundamental and essential matrix estimation, decomposition
+//! - [`homography`] — Normalized DLT homography estimation with optional RANSAC
+//! - [`triangulation`] — Linear DLT triangulation from multiple views
+//! - [`camera_matrix`] — Camera projection matrix estimation and RQ decomposition
+//!
+//! # Coordinate Conventions
+//!
+//! - Fundamental matrix solvers accept **pixel coordinates**.
+//! - Essential matrix solvers expect **calibrated/normalized coordinates**
+//!   (i.e., after applying `K⁻¹` to pixel points).
+//! - Pose outputs follow the `T_C_W` convention: transform from world into camera frame.
+
+pub mod camera_matrix;
+pub mod epipolar;
+pub mod homography;
+pub mod math;
+pub mod triangulation;
+
+pub use camera_matrix::*;
+pub use epipolar::*;
+pub use homography::*;
+pub use math::*;
+pub use triangulation::*;

--- a/crates/vision-geometry/src/math.rs
+++ b/crates/vision-geometry/src/math.rs
@@ -1,0 +1,422 @@
+//! Mathematical utilities for geometric solvers.
+//!
+//! Provides shared mathematical functions used across multiple solvers,
+//! including:
+//!
+//! - **Hartley normalization** for 2D and 3D points (numerical conditioning)
+//! - **Polynomial root-finding** for quadratic, cubic, and quartic equations
+//! - **SVD matrix extraction** helpers for recovering matrices from SVD results
+//!
+//! # Hartley Normalization
+//!
+//! Normalizing points before DLT-style algorithms improves numerical stability
+//! by centering the data and scaling to unit variance. This is critical for
+//! accurate homography, fundamental matrix, and camera matrix estimation.
+//!
+//! # References
+//!
+//! Hartley & Zisserman, "Multiple View Geometry in Computer Vision", 2nd ed.
+
+use nalgebra::{DMatrix, Matrix3x4, Schur};
+use vision_calibration_core::{Mat3, Mat4, Pt2, Pt3, Real};
+
+/// Hartley normalization for 2D points.
+///
+/// Centers points at the origin and scales so that the mean distance from
+/// the origin is `√2`. This conditioning improves numerical stability in
+/// DLT-style algorithms.
+///
+/// Returns `Some((normalized_points, transform_matrix))` where `T` is a 3×3
+/// matrix such that `p_norm = T * p_homogeneous`, or `None` if input is empty
+/// or all points coincide.
+pub fn normalize_points_2d(points: &[Pt2]) -> Option<(Vec<Pt2>, Mat3)> {
+    if points.is_empty() {
+        return None;
+    }
+
+    let n = points.len() as f64;
+    let mut cx = 0.0;
+    let mut cy = 0.0;
+    for p in points {
+        cx += p.x;
+        cy += p.y;
+    }
+    cx /= n;
+    cy /= n;
+
+    let mut mean_dist = 0.0;
+    for p in points {
+        let dx = p.x - cx;
+        let dy = p.y - cy;
+        mean_dist += (dx * dx + dy * dy).sqrt();
+    }
+    mean_dist /= n;
+
+    if mean_dist <= f64::EPSILON {
+        return None;
+    }
+
+    let scale = (2.0_f64).sqrt() / mean_dist;
+    let t = Mat3::new(
+        scale,
+        0.0,
+        -scale * cx,
+        0.0,
+        scale,
+        -scale * cy,
+        0.0,
+        0.0,
+        1.0,
+    );
+
+    let norm = points
+        .iter()
+        .map(|p| Pt2::new((p.x - cx) * scale, (p.y - cy) * scale))
+        .collect();
+
+    Some((norm, t))
+}
+
+/// Hartley normalization for 3D points.
+///
+/// Centers points at the origin and scales so that the mean distance from
+/// the origin is `√3`. This is the 3D analog of [`normalize_points_2d`].
+///
+/// Returns `Some((normalized_points, transform_matrix))` where `T` is a 4×4
+/// matrix, or `None` if input is empty or all points coincide.
+pub fn normalize_points_3d(points: &[Pt3]) -> Option<(Vec<Pt3>, Mat4)> {
+    if points.is_empty() {
+        return None;
+    }
+
+    let n = points.len() as Real;
+    let mut cx = 0.0;
+    let mut cy = 0.0;
+    let mut cz = 0.0;
+    for p in points {
+        cx += p.x;
+        cy += p.y;
+        cz += p.z;
+    }
+    cx /= n;
+    cy /= n;
+    cz /= n;
+
+    let mut mean_dist = 0.0;
+    for p in points {
+        let dx = p.x - cx;
+        let dy = p.y - cy;
+        let dz = p.z - cz;
+        mean_dist += (dx * dx + dy * dy + dz * dz).sqrt();
+    }
+    mean_dist /= n;
+
+    if mean_dist <= Real::EPSILON {
+        return None;
+    }
+
+    let scale = (3.0_f64).sqrt() / mean_dist;
+    let t = Mat4::new(
+        scale,
+        0.0,
+        0.0,
+        -scale * cx,
+        0.0,
+        scale,
+        0.0,
+        -scale * cy,
+        0.0,
+        0.0,
+        scale,
+        -scale * cz,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    );
+
+    let norm = points
+        .iter()
+        .map(|p| Pt3::new((p.x - cx) * scale, (p.y - cy) * scale, (p.z - cz) * scale))
+        .collect();
+
+    Some((norm, t))
+}
+
+/// Solve quadratic equation `ax² + bx + c = 0` for real roots.
+///
+/// Returns sorted, deduplicated real roots.
+pub fn solve_quadratic_real(a: Real, b: Real, c: Real) -> Vec<Real> {
+    let eps = 1e-12;
+    if a.abs() < eps {
+        if b.abs() < eps {
+            return Vec::new();
+        }
+        return vec![-c / b];
+    }
+    let disc = b * b - 4.0 * a * c;
+    if disc.abs() < eps {
+        return vec![-b / (2.0 * a)];
+    }
+    if disc < 0.0 {
+        return Vec::new();
+    }
+    let sqrt_disc = disc.sqrt();
+    let r1 = (-b + sqrt_disc) / (2.0 * a);
+    let r2 = (-b - sqrt_disc) / (2.0 * a);
+    if (r1 - r2).abs() < 1e-8 {
+        vec![r1]
+    } else {
+        let mut roots = vec![r1, r2];
+        roots.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        roots
+    }
+}
+
+/// Solve cubic equation `ax³ + bx² + cx + d = 0` for real roots.
+///
+/// Uses Cardano's formula with depressed cubic transformation.
+/// Returns sorted, deduplicated real roots.
+pub fn solve_cubic_real(a: Real, b: Real, c: Real, d: Real) -> Vec<Real> {
+    let eps = 1e-12;
+    if a.abs() < eps {
+        return solve_quadratic_real(b, c, d);
+    }
+
+    let a_inv = 1.0 / a;
+    let b = b * a_inv;
+    let c = c * a_inv;
+    let d = d * a_inv;
+
+    let p = c - b * b / 3.0;
+    let q = 2.0 * b * b * b / 27.0 - b * c / 3.0 + d;
+
+    let disc = (q * 0.5) * (q * 0.5) + (p / 3.0) * (p / 3.0) * (p / 3.0);
+    let shift = b / 3.0;
+
+    let mut roots = Vec::new();
+    if disc > eps {
+        let sqrt_disc = disc.sqrt();
+        let u = (-q * 0.5 + sqrt_disc).signum() * (-q * 0.5 + sqrt_disc).abs().powf(1.0 / 3.0);
+        let v = (-q * 0.5 - sqrt_disc).signum() * (-q * 0.5 - sqrt_disc).abs().powf(1.0 / 3.0);
+        roots.push(u + v - shift);
+    } else if disc.abs() <= eps {
+        let u = (-q * 0.5).signum() * (-q * 0.5).abs().powf(1.0 / 3.0);
+        roots.push(2.0 * u - shift);
+        roots.push(-u - shift);
+    } else {
+        let r = (-p / 3.0).sqrt();
+        let phi = ((-q * 0.5) / (r * r * r)).clamp(-1.0, 1.0).acos();
+        let two_r = 2.0 * r;
+        roots.push(two_r * (phi / 3.0).cos() - shift);
+        roots.push(two_r * ((phi + 2.0 * std::f64::consts::PI) / 3.0).cos() - shift);
+        roots.push(two_r * ((phi + 4.0 * std::f64::consts::PI) / 3.0).cos() - shift);
+    }
+
+    roots.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    roots.dedup_by(|a, b| (*a - *b).abs() < 1e-8);
+    roots
+}
+
+/// Solve quartic equation `ax⁴ + bx³ + cx² + dx + e = 0` for real roots.
+///
+/// Uses companion matrix eigenvalue method via Schur decomposition.
+/// Returns sorted, deduplicated real roots.
+pub fn solve_quartic_real(a: Real, b: Real, c: Real, d: Real, e: Real) -> Vec<Real> {
+    let eps = 1e-12;
+    if a.abs() < eps {
+        return solve_cubic_real(b, c, d, e);
+    }
+
+    let mut comp = DMatrix::<Real>::zeros(4, 4);
+    comp[(0, 0)] = -b / a;
+    comp[(0, 1)] = -c / a;
+    comp[(0, 2)] = -d / a;
+    comp[(0, 3)] = -e / a;
+    comp[(1, 0)] = 1.0;
+    comp[(2, 1)] = 1.0;
+    comp[(3, 2)] = 1.0;
+
+    let schur = Schur::new(comp);
+    let eigvals = schur.complex_eigenvalues();
+
+    let mut roots = Vec::new();
+    for val in eigvals.iter() {
+        if val.im.abs() < 1e-8 {
+            roots.push(val.re);
+        }
+    }
+
+    roots.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    roots.dedup_by(|a, b| (*a - *b).abs() < 1e-8);
+    roots
+}
+
+/// Extract 3×3 matrix from SVD result row.
+///
+/// Reshapes a 9-element row from SVD's `V^T` matrix into a 3×3 matrix
+/// (row-major order). Commonly used to extract homography or fundamental
+/// matrix from the nullspace of a design matrix.
+pub fn mat3_from_svd_row(v_t: &DMatrix<Real>, row_idx: usize) -> Mat3 {
+    assert_eq!(
+        v_t.ncols(),
+        9,
+        "Expected 9 columns for 3x3 matrix extraction"
+    );
+    let mut m = Mat3::zeros();
+    for r in 0..3 {
+        for c in 0..3 {
+            m[(r, c)] = v_t[(row_idx, 3 * r + c)];
+        }
+    }
+    m
+}
+
+/// Extract 3×4 matrix from SVD result row.
+///
+/// Reshapes a 12-element row from SVD's `V^T` matrix into a 3×4 matrix
+/// (row-major order). Commonly used to extract camera projection matrix
+/// from DLT nullspace.
+pub fn mat34_from_svd_row(v_t: &DMatrix<Real>, row_idx: usize) -> Matrix3x4<Real> {
+    assert_eq!(
+        v_t.ncols(),
+        12,
+        "Expected 12 columns for 3x4 matrix extraction"
+    );
+    let mut m = Matrix3x4::<Real>::zeros();
+    for r in 0..3 {
+        for c in 0..4 {
+            m[(r, c)] = v_t[(row_idx, 4 * r + c)];
+        }
+    }
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_2d_centering() {
+        let points = vec![
+            Pt2::new(100.0, 200.0),
+            Pt2::new(200.0, 300.0),
+            Pt2::new(150.0, 250.0),
+        ];
+
+        let (norm, _t) = normalize_points_2d(&points).unwrap();
+
+        let cx: f64 = norm.iter().map(|p| p.x).sum::<f64>() / norm.len() as f64;
+        let cy: f64 = norm.iter().map(|p| p.y).sum::<f64>() / norm.len() as f64;
+        assert!(cx.abs() < 1e-10, "Centroid x not at origin: {}", cx);
+        assert!(cy.abs() < 1e-10, "Centroid y not at origin: {}", cy);
+
+        let mean_dist: f64 = norm
+            .iter()
+            .map(|p| (p.x * p.x + p.y * p.y).sqrt())
+            .sum::<f64>()
+            / norm.len() as f64;
+        assert!(
+            (mean_dist - 2.0_f64.sqrt()).abs() < 1e-10,
+            "Mean distance not sqrt(2): {}",
+            mean_dist
+        );
+    }
+
+    #[test]
+    fn normalize_3d_centering() {
+        let points = vec![
+            Pt3::new(1.0, 2.0, 3.0),
+            Pt3::new(4.0, 5.0, 6.0),
+            Pt3::new(7.0, 8.0, 9.0),
+        ];
+
+        let (norm, _t) = normalize_points_3d(&points).unwrap();
+
+        let cx: f64 = norm.iter().map(|p| p.x).sum::<f64>() / norm.len() as f64;
+        let cy: f64 = norm.iter().map(|p| p.y).sum::<f64>() / norm.len() as f64;
+        let cz: f64 = norm.iter().map(|p| p.z).sum::<f64>() / norm.len() as f64;
+
+        assert!(cx.abs() < 1e-10);
+        assert!(cy.abs() < 1e-10);
+        assert!(cz.abs() < 1e-10);
+
+        let mean_dist: f64 = norm
+            .iter()
+            .map(|p| (p.x * p.x + p.y * p.y + p.z * p.z).sqrt())
+            .sum::<f64>()
+            / norm.len() as f64;
+        assert!((mean_dist - 3.0_f64.sqrt()).abs() < 1e-10);
+    }
+
+    #[test]
+    fn quadratic_two_roots() {
+        let roots = solve_quadratic_real(1.0, -3.0, 2.0);
+        assert_eq!(roots.len(), 2);
+        assert!((roots[0] - 1.0).abs() < 1e-10);
+        assert!((roots[1] - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn quadratic_one_root() {
+        let roots = solve_quadratic_real(1.0, -2.0, 1.0);
+        assert_eq!(roots.len(), 1);
+        assert!((roots[0] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn quadratic_no_roots() {
+        let roots = solve_quadratic_real(1.0, 0.0, 1.0);
+        assert_eq!(roots.len(), 0);
+    }
+
+    #[test]
+    fn cubic_three_roots() {
+        let roots = solve_cubic_real(1.0, -6.0, 11.0, -6.0);
+        assert_eq!(roots.len(), 3);
+        assert!((roots[0] - 1.0).abs() < 1e-6);
+        assert!((roots[1] - 2.0).abs() < 1e-6);
+        assert!((roots[2] - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn quartic_two_roots() {
+        let roots = solve_quartic_real(1.0, 0.0, -5.0, 0.0, 4.0);
+        assert_eq!(roots.len(), 4);
+        assert!((roots[0] - -2.0).abs() < 1e-6);
+        assert!((roots[1] - -1.0).abs() < 1e-6);
+        assert!((roots[2] - 1.0).abs() < 1e-6);
+        assert!((roots[3] - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn svd_extraction_3x3() {
+        let mut v_t = DMatrix::zeros(9, 9);
+        for i in 0..9 {
+            v_t[(8, i)] = (i + 1) as f64;
+        }
+
+        let m = mat3_from_svd_row(&v_t, 8);
+
+        assert_eq!(m[(0, 0)], 1.0);
+        assert_eq!(m[(0, 1)], 2.0);
+        assert_eq!(m[(0, 2)], 3.0);
+        assert_eq!(m[(1, 0)], 4.0);
+        assert_eq!(m[(2, 2)], 9.0);
+    }
+
+    #[test]
+    fn svd_extraction_3x4() {
+        let mut v_t = DMatrix::zeros(12, 12);
+        for i in 0..12 {
+            v_t[(11, i)] = (i + 1) as f64;
+        }
+
+        let m = mat34_from_svd_row(&v_t, 11);
+
+        assert_eq!(m[(0, 0)], 1.0);
+        assert_eq!(m[(0, 3)], 4.0);
+        assert_eq!(m[(1, 0)], 5.0);
+        assert_eq!(m[(2, 3)], 12.0);
+    }
+}

--- a/crates/vision-geometry/src/math.rs
+++ b/crates/vision-geometry/src/math.rs
@@ -252,6 +252,55 @@ pub fn solve_quartic_real(a: Real, b: Real, c: Real, d: Real, e: Real) -> Vec<Re
     roots
 }
 
+/// Check that a homogeneous DLT system has a well-defined null space.
+///
+/// Returns `true` when the design matrix (whose descending singular values are
+/// `singular_values`) has a null space of exactly `expected_null_dim` dimensions
+/// — i.e. the singular value immediately *above* the null block is meaningfully
+/// positive relative to the largest singular value.
+///
+/// A rank-deficient system (collinear / coincident / degenerate input) causes that
+/// boundary singular value to collapse toward zero.
+///
+/// # Parameters
+///
+/// - `singular_values`: descending singular values of the design matrix.
+/// - `cols`: number of columns in the design matrix (= number of unknowns).
+/// - `expected_null_dim`: expected null-space dimension (1 for most DLT systems,
+///   2 for the 7-point fundamental solver).
+/// - `rel_tol`: minimum acceptable ratio `sv[boundary] / sv[0]`.  A value of
+///   `1e-7` is conservative — it only catches near-exact rank deficiency and
+///   will not reject valid-but-noisy data.
+///
+/// # Returns
+///
+/// `false` when:
+/// - `singular_values` is empty, or `sv[0] <= Real::EPSILON` (all-zero matrix),
+/// - the boundary index `cols - expected_null_dim - 1` is out of range, or
+/// - `sv[boundary] / sv[0] < rel_tol`.
+pub(crate) fn dlt_rank_ok(
+    singular_values: &[Real],
+    cols: usize,
+    expected_null_dim: usize,
+    rel_tol: Real,
+) -> bool {
+    if singular_values.is_empty() {
+        return false;
+    }
+    let sv0 = singular_values[0];
+    if sv0 <= Real::EPSILON {
+        return false;
+    }
+    // The boundary index is one step above the null block.
+    let Some(idx) = cols.checked_sub(expected_null_dim + 1) else {
+        return false;
+    };
+    let Some(&sv_boundary) = singular_values.get(idx) else {
+        return false;
+    };
+    sv_boundary / sv0 >= rel_tol
+}
+
 /// Extract 3×3 matrix from SVD result row.
 ///
 /// Reshapes a 9-element row from SVD's `V^T` matrix into a 3×3 matrix
@@ -418,5 +467,48 @@ mod tests {
         assert_eq!(m[(0, 3)], 4.0);
         assert_eq!(m[(1, 0)], 5.0);
         assert_eq!(m[(2, 3)], 12.0);
+    }
+
+    // ---- dlt_rank_ok --------------------------------------------------------
+
+    /// A clearly full-rank 9-column spectrum (9 unknowns, expected 1-D null
+    /// space): sv[7] / sv[0] >> 1e-7 → true.
+    #[test]
+    fn dlt_rank_ok_full_rank_spectrum() {
+        // Simulate a well-conditioned 9-column system: sv[8] ≈ 0 (the null
+        // space), all others comfortably above zero.
+        let sv: Vec<Real> = vec![10.0, 9.0, 8.5, 7.0, 6.0, 5.5, 4.0, 3.5, 1e-12];
+        // cols=9, expected_null_dim=1 → boundary index = 9-1-1 = 7.
+        // sv[7] / sv[0] = 3.5 / 10.0 = 0.35 >> 1e-7.
+        assert!(
+            dlt_rank_ok(&sv, 9, 1, 1e-7),
+            "full-rank spectrum must return true"
+        );
+    }
+
+    /// A degenerate spectrum where the boundary value has collapsed: the
+    /// null space is effectively 2-D → false.
+    #[test]
+    fn dlt_rank_ok_collapsed_boundary_value() {
+        // sv[7] and sv[8] are both near-zero: rank is 7, not 8.
+        let sv: Vec<Real> = vec![10.0, 9.0, 8.5, 7.0, 6.0, 5.5, 4.0, 1e-14, 1e-15];
+        // boundary index = 7 → sv[7] / sv[0] = 1e-14 / 10.0 = 1e-15 < 1e-7.
+        assert!(
+            !dlt_rank_ok(&sv, 9, 1, 1e-7),
+            "collapsed boundary value must return false"
+        );
+    }
+
+    /// Empty singular values → false.
+    #[test]
+    fn dlt_rank_ok_empty_sv() {
+        assert!(!dlt_rank_ok(&[], 9, 1, 1e-7));
+    }
+
+    /// sv[0] ≈ 0 (all-zero matrix) → false.
+    #[test]
+    fn dlt_rank_ok_zero_matrix() {
+        let sv: Vec<Real> = vec![0.0; 9];
+        assert!(!dlt_rank_ok(&sv, 9, 1, 1e-7));
     }
 }

--- a/crates/vision-geometry/src/triangulation.rs
+++ b/crates/vision-geometry/src/triangulation.rs
@@ -1,0 +1,86 @@
+//! Linear triangulation of 3D points from multiple views.
+//!
+//! Uses a DLT formulation on the camera projection matrices and image points.
+
+use anyhow::Result;
+use nalgebra::DMatrix;
+use vision_calibration_core::{Pt2, Pt3, Real};
+
+use crate::camera_matrix::Mat34;
+
+/// Linear triangulation from multiple views using DLT.
+///
+/// `cameras` are 3×4 projection matrices `P_i`, and `points` are their
+/// corresponding image coordinates. The returned 3D point is in the same
+/// world frame as the camera matrices.
+pub fn triangulate_point_linear(cameras: &[Mat34], points: &[Pt2]) -> Result<Pt3> {
+    if cameras.len() < 2 {
+        anyhow::bail!("need at least 2 views, got {}", cameras.len());
+    }
+    if cameras.len() != points.len() {
+        anyhow::bail!(
+            "mismatched number of cameras ({}) and points ({})",
+            cameras.len(),
+            points.len()
+        );
+    }
+
+    let mut a = DMatrix::<Real>::zeros(2 * cameras.len(), 4);
+    for (i, (p, cam)) in points.iter().zip(cameras.iter()).enumerate() {
+        let u = p.x;
+        let v = p.y;
+
+        let r0 = 2 * i;
+        let r1 = 2 * i + 1;
+
+        let row0 = cam.row(0);
+        let row1 = cam.row(1);
+        let row2 = cam.row(2);
+
+        a.row_mut(r0).copy_from(&(u * row2 - row0));
+        a.row_mut(r1).copy_from(&(v * row2 - row1));
+    }
+
+    let svd = a.svd(true, true);
+    let v_t = svd
+        .v_t
+        .ok_or_else(|| anyhow::anyhow!("svd failed during triangulation"))?;
+    let x_h = v_t.row(v_t.nrows() - 1);
+
+    let w = x_h[3];
+    if w.abs() <= Real::EPSILON {
+        anyhow::bail!("triangulation produced an invalid point");
+    }
+
+    let x = x_h[0] / w;
+    let y = x_h[1] / w;
+    let z = x_h[2] / w;
+
+    Ok(Pt3::new(x, y, z))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Vector4;
+
+    fn project(cam: &Mat34, p: &Pt3) -> Pt2 {
+        let x = cam * Vector4::new(p.x, p.y, p.z, 1.0);
+        Pt2::new(x.x / x.z, x.y / x.z)
+    }
+
+    #[test]
+    fn triangulation_two_views_recovers_point() {
+        let cam1 = Mat34::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+        let cam2 = Mat34::new(1.0, 0.0, 0.0, -0.2, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+
+        let pw = Pt3::new(0.1, -0.05, 2.0);
+        let p1 = project(&cam1, &pw);
+        let p2 = project(&cam2, &pw);
+
+        let est = triangulate_point_linear(&[cam1, cam2], &[p1, p2]).unwrap();
+
+        let err = (est - pw).norm();
+        assert!(err < 1e-6, "triangulation error too large: {}", err);
+    }
+}

--- a/crates/vision-geometry/src/triangulation.rs
+++ b/crates/vision-geometry/src/triangulation.rs
@@ -7,6 +7,7 @@ use nalgebra::DMatrix;
 use vision_calibration_core::{Pt2, Pt3, Real};
 
 use crate::camera_matrix::Mat34;
+use crate::math::dlt_rank_ok;
 
 /// Linear triangulation from multiple views using DLT.
 ///
@@ -42,9 +43,20 @@ pub fn triangulate_point_linear(cameras: &[Mat34], points: &[Pt2]) -> Result<Pt3
     }
 
     let svd = a.svd(true, true);
+    let sv: Vec<Real> = svd.singular_values.iter().cloned().collect();
     let v_t = svd
         .v_t
         .ok_or_else(|| anyhow::anyhow!("svd failed during triangulation"))?;
+
+    // The 4-column DLT triangulation matrix is well-posed at rank 3 (1-D null
+    // space).  Identical cameras or coincident rays collapse sv[2] toward zero.
+    if !dlt_rank_ok(&sv, 4, 1, 1e-7) {
+        anyhow::bail!(
+            "zero-parallax / rank-deficient triangulation system \
+             (identical cameras or coincident rays)"
+        );
+    }
+
     let x_h = v_t.row(v_t.nrows() - 1);
 
     let w = x_h[3];
@@ -82,5 +94,24 @@ mod tests {
 
         let err = (est - pw).norm();
         assert!(err < 1e-6, "triangulation error too large: {}", err);
+    }
+
+    /// Regression: two identical cameras (zero baseline) must return Err.
+    ///
+    /// Identical projection matrices produce a rank-2 DLT system (sv[2] ≈ 0),
+    /// giving a 2-D null space — the recovered 3D point is arbitrary.
+    /// The `dlt_rank_ok` check (boundary index = 2) must catch this.
+    #[test]
+    fn triangulation_rejects_identical_cameras() {
+        // Same camera used twice — zero baseline, no parallax.
+        let cam = Mat34::new(
+            800.0, 0.0, 320.0, 0.0, 0.0, 800.0, 240.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+        );
+        let pw = Pt3::new(0.05, -0.02, 1.5);
+        let img = project(&cam, &pw);
+        assert!(
+            triangulate_point_linear(&[cam, cam], &[img, img]).is_err(),
+            "identical cameras (zero baseline) must return Err"
+        );
     }
 }

--- a/crates/vision-mvg/Cargo.toml
+++ b/crates/vision-mvg/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "vision-mvg"
+# Not yet published to crates.io — landed internally first (API not stable).
+# Promote to the publish set + release version-lockstep deliberately (see CLAUDE.md).
+publish = false
+readme = "README.md"
+description = "Multiple-view geometry: epipolar geometry, triangulation, homography, robust estimation"
+keywords = ["computer-vision", "geometry", "epipolar", "stereo", "triangulation"]
+categories = ["computer-vision"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[features]
+refine = ["dep:tiny-solver"]
+
+[dependencies]
+vision-calibration-core = { workspace = true }
+vision-geometry = { workspace = true }
+nalgebra = { workspace = true }
+anyhow = { workspace = true }
+tiny-solver = { workspace = true, optional = true }

--- a/crates/vision-mvg/README.md
+++ b/crates/vision-mvg/README.md
@@ -1,0 +1,53 @@
+# vision-mvg
+
+Multiple-view geometry tools for calibrated cameras.
+
+This crate builds on `vision-geometry` and adds higher-level multi-view
+operations: calibrated relative pose recovery, cheirality checks, robust
+estimation wrappers, and triangulation helpers with diagnostics.
+
+## Capabilities
+
+- Relative pose recovery from calibrated 2D correspondences
+- Cheirality-based essential matrix disambiguation
+- Robust essential and homography estimation helpers
+- Triangulation helpers and geometric residual utilities
+- Convenience re-exports of low-level solvers from `vision-geometry`
+
+## Coordinate Conventions
+
+- Calibrated APIs expect normalized coordinates after applying `K^-1`.
+- Pose outputs follow the `T_C_W` convention: world to camera.
+
+## Usage
+
+```rust
+use vision_calibration_core::Pt2;
+use vision_mvg::recover_relative_pose;
+
+let left = vec![
+    Pt2::new(-0.1, 0.2),
+    Pt2::new(0.3, -0.1),
+    Pt2::new(0.4, 0.5),
+    Pt2::new(-0.2, -0.3),
+    Pt2::new(0.1, 0.0),
+];
+let right = vec![
+    Pt2::new(-0.08, 0.19),
+    Pt2::new(0.32, -0.11),
+    Pt2::new(0.42, 0.48),
+    Pt2::new(-0.18, -0.28),
+    Pt2::new(0.12, -0.01),
+];
+
+let pose = recover_relative_pose(&left, &right)?;
+println!("rotation = {:?}", pose.rotation);
+println!("translation = {:?}", pose.translation);
+# Ok::<(), anyhow::Error>(())
+```
+
+## See Also
+
+- `vision-geometry` for low-level deterministic solvers
+- `vision-calibration-linear` for calibration-specific initialization
+- `vision-calibration` for the high-level facade API

--- a/crates/vision-mvg/src/cheirality.rs
+++ b/crates/vision-mvg/src/cheirality.rs
@@ -1,0 +1,168 @@
+//! Cheirality (positive depth) tests for pose disambiguation.
+//!
+//! When decomposing an essential matrix, four candidate (R, t) pairs are
+//! returned. Only one places the triangulated points in front of both
+//! cameras. These functions count and select the correct pose.
+
+use anyhow::Result;
+use vision_calibration_core::{Mat3, Pt2, Vec3};
+use vision_geometry::camera_matrix::Mat34;
+use vision_geometry::triangulation::triangulate_point_linear;
+
+/// Count the number of points that are in front of both cameras.
+///
+/// Camera 1 is at the origin with `P₁ = [I | 0]`. Camera 2 has rotation
+/// `r` and translation `t`, giving `P₂ = [R | t]`. Points are in
+/// **normalized camera coordinates**.
+pub fn cheirality_count(r: &Mat3, t: &Vec3, pts1: &[Pt2], pts2: &[Pt2]) -> usize {
+    let p1 = Mat34::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+    let mut p2 = Mat34::zeros();
+    p2.fixed_view_mut::<3, 3>(0, 0).copy_from(r);
+    p2.set_column(3, t);
+
+    let mut count = 0;
+    for (q1, q2) in pts1.iter().zip(pts2.iter()) {
+        let Ok(pt3) = triangulate_point_linear(&[p1, p2], &[*q1, *q2]) else {
+            continue;
+        };
+
+        // Depth in camera 1: z coordinate directly (camera is at origin).
+        let z1 = pt3.z;
+
+        // Depth in camera 2: z component of R * X + t.
+        let z2 = (r.row(2) * pt3.coords)[0] + t.z;
+
+        if z1 > 0.0 && z2 > 0.0 {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+/// Select the correct (R, t) from candidate poses by cheirality.
+///
+/// Returns the pose that places the most points in front of both cameras,
+/// along with the number of points passing the cheirality check. Returns
+/// `None` if no candidate has any valid points.
+pub fn select_pose(
+    candidates: &[(Mat3, Vec3)],
+    pts1: &[Pt2],
+    pts2: &[Pt2],
+) -> Option<(Mat3, Vec3, usize)> {
+    let mut best: Option<(Mat3, Vec3, usize)> = None;
+
+    for (r, t) in candidates {
+        let count = cheirality_count(r, t, pts1, pts2);
+        if count > best.as_ref().map_or(0, |b| b.2) {
+            best = Some((*r, *t, count));
+        }
+    }
+
+    best.filter(|b| b.2 > 0)
+}
+
+/// Recover the unique relative pose from an essential matrix and correspondences.
+///
+/// Decomposes `E` into 4 candidate (R, t) pairs, then selects the one with
+/// the most points in front of both cameras.
+pub fn recover_pose_from_essential(e: &Mat3, pts1: &[Pt2], pts2: &[Pt2]) -> Result<(Mat3, Vec3)> {
+    let candidates = vision_geometry::epipolar::decompose_essential(e)?;
+    select_pose(&candidates, pts1, pts2)
+        .map(|(r, t, _)| (r, t))
+        .ok_or_else(|| anyhow::anyhow!("no valid pose found (all candidates fail cheirality)"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::Pt3;
+
+    fn skew(v: &Vec3) -> Mat3 {
+        Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
+    }
+
+    fn make_stereo_data() -> (Mat3, Vec3, Vec<Pt2>, Vec<Pt2>) {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+
+        let world = [
+            Pt3::new(0.1, 0.2, 3.0),
+            Pt3::new(-0.2, 0.1, 2.5),
+            Pt3::new(0.3, -0.1, 4.0),
+            Pt3::new(-0.15, -0.2, 3.2),
+            Pt3::new(0.05, 0.3, 2.8),
+            Pt3::new(0.2, -0.3, 3.5),
+            Pt3::new(-0.1, 0.15, 2.0),
+            Pt3::new(0.15, 0.25, 4.5),
+        ];
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+        for pw in &world {
+            let pc1 = pw.coords;
+            let pc2 = r * pw.coords + t;
+            pts1.push(Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z));
+            pts2.push(Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z));
+        }
+
+        (r, t, pts1, pts2)
+    }
+
+    #[test]
+    fn cheirality_count_correct_for_true_pose() {
+        let (r, t, pts1, pts2) = make_stereo_data();
+        let count = cheirality_count(&r, &t, &pts1, &pts2);
+        assert_eq!(count, pts1.len(), "all points should be in front");
+    }
+
+    #[test]
+    fn cheirality_count_zero_for_wrong_pose() {
+        let (r, t, pts1, pts2) = make_stereo_data();
+        // Negate translation — should put points behind camera 2.
+        let count = cheirality_count(&r, &(-t), &pts1, &pts2);
+        assert_eq!(count, 0, "negated t should fail cheirality");
+    }
+
+    #[test]
+    fn select_pose_picks_correct_candidate() {
+        let (r, t, pts1, pts2) = make_stereo_data();
+        let e = skew(&t) * r;
+
+        let candidates = vision_geometry::epipolar::decompose_essential(&e).unwrap();
+        let (r_est, t_est, count) = select_pose(&candidates, &pts1, &pts2).unwrap();
+
+        assert_eq!(count, pts1.len());
+
+        // Check rotation is close.
+        let r_diff = r_est.transpose() * r;
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang = cos_theta.acos();
+        assert!(ang < 1e-6, "rotation error: {} rad", ang);
+
+        // Check translation direction.
+        let cos_t = t_est.normalize().dot(&t.normalize());
+        assert!(
+            (cos_t.abs() - 1.0).abs() < 1e-6,
+            "translation direction error"
+        );
+    }
+
+    #[test]
+    fn recover_pose_from_essential_works() {
+        let (r, t, pts1, pts2) = make_stereo_data();
+        let e = skew(&t) * r;
+
+        let (r_est, t_est) = recover_pose_from_essential(&e, &pts1, &pts2).unwrap();
+
+        let r_diff = r_est.transpose() * r;
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang = cos_theta.acos();
+        assert!(ang < 1e-6, "rotation error: {} rad", ang);
+
+        let cos_t = t_est.normalize().dot(&t.normalize());
+        assert!((cos_t.abs() - 1.0).abs() < 1e-6);
+    }
+}

--- a/crates/vision-mvg/src/cheirality.rs
+++ b/crates/vision-mvg/src/cheirality.rs
@@ -66,7 +66,20 @@ pub fn select_pose(
 ///
 /// Decomposes `E` into 4 candidate (R, t) pairs, then selects the one with
 /// the most points in front of both cameras.
+///
+/// Returns `Err` if the point slices have different lengths, if there are no
+/// correspondences, or if every candidate pose fails the cheirality check.
 pub fn recover_pose_from_essential(e: &Mat3, pts1: &[Pt2], pts2: &[Pt2]) -> Result<(Mat3, Vec3)> {
+    if pts1.len() != pts2.len() {
+        anyhow::bail!(
+            "point count mismatch: pts1 has {}, pts2 has {}",
+            pts1.len(),
+            pts2.len()
+        );
+    }
+    if pts1.is_empty() {
+        anyhow::bail!("need at least 1 correspondence for cheirality check, got 0");
+    }
     let candidates = vision_geometry::epipolar::decompose_essential(e)?;
     select_pose(&candidates, pts1, pts2)
         .map(|(r, t, _)| (r, t))
@@ -147,6 +160,38 @@ mod tests {
         assert!(
             (cos_t.abs() - 1.0).abs() < 1e-6,
             "translation direction error"
+        );
+    }
+
+    /// Regression: mismatched slice lengths must return Err, not silently truncate.
+    #[test]
+    fn recover_pose_from_essential_rejects_length_mismatch() {
+        let (r, t, pts1, pts2) = make_stereo_data();
+        let e = skew(&t) * r;
+        // Give pts2 one extra point — lengths differ by 1.
+        let mut pts2_long = pts2.clone();
+        pts2_long.push(Pt2::new(0.0, 0.0));
+        assert!(
+            recover_pose_from_essential(&e, &pts1, &pts2_long).is_err(),
+            "mismatched lengths must return Err"
+        );
+        // Symmetric: pts1 longer.
+        let mut pts1_long = pts1.clone();
+        pts1_long.push(Pt2::new(0.0, 0.0));
+        assert!(
+            recover_pose_from_essential(&e, &pts1_long, &pts2).is_err(),
+            "mismatched lengths must return Err"
+        );
+    }
+
+    /// Regression: empty slices must return Err.
+    #[test]
+    fn recover_pose_from_essential_rejects_empty_input() {
+        let (r, t, _pts1, _pts2) = make_stereo_data();
+        let e = skew(&t) * r;
+        assert!(
+            recover_pose_from_essential(&e, &[], &[]).is_err(),
+            "empty input must return Err"
         );
     }
 

--- a/crates/vision-mvg/src/degeneracy.rs
+++ b/crates/vision-mvg/src/degeneracy.rs
@@ -1,0 +1,234 @@
+//! Degeneracy detection for two-view geometry.
+//!
+//! Identifies degenerate or near-degenerate configurations that can cause
+//! estimation failures:
+//!
+//! - **Pure rotation**: no translation baseline, triangulation is impossible
+//! - **Planar scene**: homography model is more appropriate than essential
+//! - **Poor baseline**: near-parallel rays produce unreliable depth
+
+use crate::types::Correspondence2D;
+use vision_calibration_core::{Mat3, Real, Vec3};
+
+/// Diagnostics about a two-view scene configuration.
+#[derive(Debug, Clone)]
+pub struct SceneDiagnostics {
+    /// Median parallax angle in degrees across triangulated points.
+    pub median_parallax_deg: Real,
+    /// Whether the motion is (approximately) a pure rotation.
+    pub is_pure_rotation: bool,
+    /// Whether the scene appears planar.
+    pub is_planar: bool,
+    /// Ratio of translation magnitude to scene depth (baseline ratio).
+    pub baseline_ratio: Real,
+}
+
+/// Detect a pure rotation from an essential matrix.
+///
+/// A pure rotation has `t ≈ 0`, so the essential matrix `E = [t]× R ≈ 0`.
+/// For a proper essential matrix with translation, the singular values are
+/// `(σ, σ, 0)` with `σ > 0`. For pure rotation, all singular values are
+/// near zero.
+///
+/// Returns `true` if the Frobenius norm of E is below a threshold,
+/// indicating negligible translation.
+pub fn detect_pure_rotation(e: &Mat3) -> bool {
+    // Frobenius norm: sqrt(s1² + s2² + s3²). For a valid E this equals
+    // sqrt(2) * σ where σ is the repeated singular value. A near-zero
+    // norm means negligible translation.
+    let frob = e.norm();
+    frob < 1e-6
+}
+
+/// Detect a planar scene by comparing homography and essential inlier counts.
+///
+/// If the homography model explains almost as many inliers as the essential
+/// matrix, the scene is likely planar. The `ratio_threshold` controls
+/// sensitivity (typical value: 0.45 — if H inlier ratio exceeds this
+/// fraction of E inlier ratio, the scene is planar).
+pub fn detect_planar_scene(
+    h_inliers: usize,
+    e_inliers: usize,
+    total: usize,
+    ratio_threshold: Real,
+) -> bool {
+    if total == 0 || e_inliers == 0 {
+        return false;
+    }
+    let h_ratio = h_inliers as Real / total as Real;
+    let e_ratio = e_inliers as Real / total as Real;
+    h_ratio / e_ratio > ratio_threshold
+}
+
+/// Detect insufficient baseline from triangulated parallax angles.
+///
+/// Returns `true` if fewer than half the angles exceed `threshold_deg`.
+pub fn detect_poor_baseline(parallax_angles: &[Real], threshold_deg: Real) -> bool {
+    if parallax_angles.is_empty() {
+        return true;
+    }
+    let good = parallax_angles
+        .iter()
+        .filter(|&&a| a > threshold_deg)
+        .count();
+    good < parallax_angles.len() / 2
+}
+
+/// Analyze a two-view scene for degeneracies.
+///
+/// Given correspondences, the estimated essential matrix, and the recovered
+/// pose (R, t), returns diagnostics about the scene configuration.
+pub fn analyze_scene(corrs: &[Correspondence2D], e: &Mat3, r: &Mat3, t: &Vec3) -> SceneDiagnostics {
+    let is_pure_rotation = detect_pure_rotation(e);
+
+    // Triangulate to get parallax angles.
+    let (pts1, pts2) = Correspondence2D::split(corrs);
+    let parallax_angles: Vec<Real> =
+        if let Ok(tps) = crate::triangulation::triangulate_two_view(r, t, &pts1, &pts2) {
+            tps.iter().map(|tp| tp.parallax_deg).collect()
+        } else {
+            vec![]
+        };
+
+    let median_parallax_deg = if parallax_angles.is_empty() {
+        0.0
+    } else {
+        let mut sorted = parallax_angles.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted[sorted.len() / 2]
+    };
+
+    // Estimate baseline ratio: ||t|| / median_depth.
+    let baseline_ratio =
+        if let Ok(tps) = crate::triangulation::triangulate_two_view(r, t, &pts1, &pts2) {
+            let mut depths: Vec<Real> = tps
+                .iter()
+                .filter(|tp| tp.in_front)
+                .map(|tp| tp.point.z)
+                .collect();
+            if depths.is_empty() {
+                0.0
+            } else {
+                depths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                let median_depth = depths[depths.len() / 2];
+                if median_depth.abs() > 1e-12 {
+                    t.norm() / median_depth
+                } else {
+                    0.0
+                }
+            }
+        } else {
+            0.0
+        };
+
+    // Planar detection heuristic: check if points lie on a plane.
+    // Use the parallax angle distribution — planar scenes have very
+    // uniform parallax compared to general 3D scenes.
+    let is_planar = if parallax_angles.len() >= 5 {
+        let mean: Real = parallax_angles.iter().sum::<Real>() / parallax_angles.len() as Real;
+        let var: Real = parallax_angles
+            .iter()
+            .map(|a| (a - mean).powi(2))
+            .sum::<Real>()
+            / parallax_angles.len() as Real;
+        let cv = if mean.abs() > 1e-12 {
+            var.sqrt() / mean
+        } else {
+            0.0
+        };
+        cv < 0.1 // very low coefficient of variation suggests planarity
+    } else {
+        false
+    };
+
+    SceneDiagnostics {
+        median_parallax_deg,
+        is_pure_rotation,
+        is_planar,
+        baseline_ratio,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::{Pt2, Pt3};
+
+    fn skew(v: &Vec3) -> Mat3 {
+        Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
+    }
+
+    #[test]
+    fn detect_pure_rotation_true_for_zero_translation() {
+        // E = [t]x * R with t ≈ 0 gives E ≈ 0.
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        let t = Vec3::new(0.0, 0.0, 0.0);
+        let e = skew(&t) * rot.matrix();
+        assert!(detect_pure_rotation(&e));
+    }
+
+    #[test]
+    fn detect_pure_rotation_false_for_good_baseline() {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let e = skew(&t) * rot.matrix();
+        assert!(!detect_pure_rotation(&e));
+    }
+
+    #[test]
+    fn detect_poor_baseline_true_for_small_parallax() {
+        let angles = vec![0.001, 0.002, 0.0015, 0.0008, 0.003];
+        assert!(detect_poor_baseline(&angles, 0.5));
+    }
+
+    #[test]
+    fn detect_poor_baseline_false_for_good_parallax() {
+        let angles = vec![2.0, 3.5, 1.8, 4.2, 2.7];
+        assert!(!detect_poor_baseline(&angles, 0.5));
+    }
+
+    #[test]
+    fn detect_planar_scene_by_inlier_ratio() {
+        // H explains 90% of points, E explains 95% — scene is planar.
+        assert!(detect_planar_scene(90, 95, 100, 0.85));
+        // H explains 30% of points, E explains 90% — scene is 3D.
+        assert!(!detect_planar_scene(30, 90, 100, 0.85));
+    }
+
+    #[test]
+    fn analyze_scene_good_stereo() {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let e = skew(&t) * r;
+
+        let world = [
+            Pt3::new(0.5, 0.3, 3.0),
+            Pt3::new(-0.4, 0.2, 4.0),
+            Pt3::new(0.6, -0.3, 5.0),
+            Pt3::new(-0.3, -0.4, 3.5),
+            Pt3::new(0.1, 0.6, 4.5),
+            Pt3::new(0.4, -0.5, 6.0),
+            Pt3::new(-0.2, 0.3, 3.0),
+            Pt3::new(0.3, 0.5, 5.5),
+        ];
+
+        let corrs: Vec<_> = world
+            .iter()
+            .map(|pw| {
+                let pc1 = pw.coords;
+                let pc2 = r * pw.coords + t;
+                Correspondence2D::new(
+                    Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z),
+                    Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z),
+                )
+            })
+            .collect();
+
+        let diag = analyze_scene(&corrs, &e, &r, &t);
+        assert!(!diag.is_pure_rotation);
+        assert!(diag.median_parallax_deg > 0.0);
+        assert!(diag.baseline_ratio > 0.0);
+    }
+}

--- a/crates/vision-mvg/src/degeneracy.rs
+++ b/crates/vision-mvg/src/degeneracy.rs
@@ -71,7 +71,7 @@ pub fn detect_poor_baseline(parallax_angles: &[Real], threshold_deg: Real) -> bo
         .iter()
         .filter(|&&a| a > threshold_deg)
         .count();
-    good < parallax_angles.len() / 2
+    good * 2 < parallax_angles.len()
 }
 
 /// Analyze a two-view scene for degeneracies.
@@ -185,6 +185,29 @@ mod tests {
     #[test]
     fn detect_poor_baseline_false_for_good_parallax() {
         let angles = vec![2.0, 3.5, 1.8, 4.2, 2.7];
+        assert!(!detect_poor_baseline(&angles, 0.5));
+    }
+
+    // Regression tests for the integer-floor bug (good * 2 < len fix).
+    #[test]
+    fn detect_poor_baseline_single_bad_angle_is_true() {
+        // Single angle below threshold: good=0, len=1 → 0*2 < 1 → true.
+        // With the old code: 0 < 1/2 = 0 → false (wrong).
+        assert!(detect_poor_baseline(&[0.01], 0.5));
+    }
+
+    #[test]
+    fn detect_poor_baseline_one_good_of_three_is_true() {
+        // 1 of 3 angles good: good=1, len=3 → 1*2=2 < 3 → true (fewer than half).
+        // With the old code: 1 < 3/2=1 → false (wrong).
+        let angles = vec![0.01, 0.02, 2.0]; // only last is above 0.5 threshold
+        assert!(detect_poor_baseline(&angles, 0.5));
+    }
+
+    #[test]
+    fn detect_poor_baseline_all_good_is_false() {
+        // All angles above threshold → should return false.
+        let angles = vec![1.0, 2.0, 3.0, 4.0];
         assert!(!detect_poor_baseline(&angles, 0.5));
     }
 

--- a/crates/vision-mvg/src/degeneracy.rs
+++ b/crates/vision-mvg/src/degeneracy.rs
@@ -103,14 +103,13 @@ pub fn detect_poor_baseline(parallax_angles: &[Real], threshold_deg: Real) -> bo
 /// rotation is detected from the scale-invariant parallax signal rather than
 /// from `‖E‖` (see [`detect_pure_rotation`]).
 pub fn analyze_scene(corrs: &[Correspondence2D], r: &Mat3, t: &Vec3) -> SceneDiagnostics {
-    // Triangulate to get parallax angles.
+    // Triangulate once, tolerating per-point degeneracies: a single bad
+    // correspondence (e.g. an on-baseline / zero-parallax outlier) must not
+    // discard the parallax evidence from all the others — that would falsely
+    // look like pure rotation with zero baseline.
     let (pts1, pts2) = Correspondence2D::split(corrs);
-    let parallax_angles: Vec<Real> =
-        if let Ok(tps) = crate::triangulation::triangulate_two_view(r, t, &pts1, &pts2) {
-            tps.iter().map(|tp| tp.parallax_deg).collect()
-        } else {
-            vec![]
-        };
+    let tps = crate::triangulation::triangulate_two_view_partial(r, t, &pts1, &pts2);
+    let parallax_angles: Vec<Real> = tps.iter().map(|tp| tp.parallax_deg).collect();
 
     let median_parallax_deg = if parallax_angles.is_empty() {
         0.0
@@ -123,28 +122,26 @@ pub fn analyze_scene(corrs: &[Correspondence2D], r: &Mat3, t: &Vec3) -> SceneDia
     // Pure rotation: scale-invariant parallax test.
     let is_pure_rotation = detect_pure_rotation(&parallax_angles, PURE_ROTATION_PARALLAX_DEG);
 
-    // Estimate baseline ratio: ||t|| / median_depth.
-    let baseline_ratio =
-        if let Ok(tps) = crate::triangulation::triangulate_two_view(r, t, &pts1, &pts2) {
-            let mut depths: Vec<Real> = tps
-                .iter()
-                .filter(|tp| tp.in_front)
-                .map(|tp| tp.point.z)
-                .collect();
-            if depths.is_empty() {
-                0.0
-            } else {
-                depths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                let median_depth = depths[depths.len() / 2];
-                if median_depth.abs() > 1e-12 {
-                    t.norm() / median_depth
-                } else {
-                    0.0
-                }
-            }
-        } else {
+    // Estimate baseline ratio: ||t|| / median_depth, from the same per-point
+    // triangulation (points in front of both cameras).
+    let baseline_ratio = {
+        let mut depths: Vec<Real> = tps
+            .iter()
+            .filter(|tp| tp.in_front)
+            .map(|tp| tp.point.z)
+            .collect();
+        if depths.is_empty() {
             0.0
-        };
+        } else {
+            depths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let median_depth = depths[depths.len() / 2];
+            if median_depth.abs() > 1e-12 {
+                t.norm() / median_depth
+            } else {
+                0.0
+            }
+        }
+    };
 
     // Planar detection heuristic: check if points lie on a plane.
     // Use the parallax angle distribution — planar scenes have very
@@ -275,6 +272,60 @@ mod tests {
         // analyze_scene no longer takes an essential matrix.
         let diag = analyze_scene(&corrs, &r, &t);
         assert!(!diag.is_pure_rotation);
+        assert!(diag.median_parallax_deg > 0.0);
+        assert!(diag.baseline_ratio > 0.0);
+    }
+
+    /// Regression: a single on-baseline (degenerate) correspondence must not
+    /// flip an otherwise good-baseline scene to "pure rotation". Before the
+    /// per-point-tolerant triangulation, one failing point discarded ALL
+    /// parallax evidence, leaving the scene wrongly classified.
+    #[test]
+    fn analyze_scene_one_degenerate_point_keeps_baseline() {
+        use nalgebra::Rotation3;
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+
+        let world = [
+            Pt3::new(0.5, 0.3, 3.0),
+            Pt3::new(-0.4, 0.2, 4.0),
+            Pt3::new(0.6, -0.3, 5.0),
+            Pt3::new(-0.3, -0.4, 3.5),
+            Pt3::new(0.1, 0.6, 4.5),
+            Pt3::new(0.4, -0.5, 6.0),
+        ];
+        let mut corrs: Vec<Correspondence2D> = world
+            .iter()
+            .map(|pw| {
+                let pc1 = pw.coords;
+                let pc2 = r * pw.coords + t;
+                Correspondence2D::new(
+                    Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z),
+                    Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z),
+                )
+            })
+            .collect();
+
+        // A point on the baseline (line through both camera centers): its two
+        // viewing rays are collinear → triangulation is rank-deficient and the
+        // point is skipped. C1 = origin, C2 = -Rᵀt, so any λ·C2 lies on the line.
+        let c2 = -r.transpose() * t;
+        let bad = 3.0 * c2;
+        let pc2_bad = r * bad + t;
+        corrs.insert(
+            0,
+            Correspondence2D::new(
+                Pt2::new(bad.x / bad.z, bad.y / bad.z),
+                Pt2::new(pc2_bad.x / pc2_bad.z, pc2_bad.y / pc2_bad.z),
+            ),
+        );
+
+        let diag = analyze_scene(&corrs, &r, &t);
+        assert!(
+            !diag.is_pure_rotation,
+            "one degenerate point must not flip the scene to pure rotation"
+        );
         assert!(diag.median_parallax_deg > 0.0);
         assert!(diag.baseline_ratio > 0.0);
     }

--- a/crates/vision-mvg/src/degeneracy.rs
+++ b/crates/vision-mvg/src/degeneracy.rs
@@ -10,6 +10,14 @@
 use crate::types::Correspondence2D;
 use vision_calibration_core::{Mat3, Real, Vec3};
 
+/// Pure-rotation parallax threshold in degrees.
+///
+/// A median parallax below this value is treated as (approximately) pure
+/// rotation — i.e. essentially zero baseline.  The threshold is stricter than
+/// the 0.5° poor-baseline notion because pure rotation means *no* translation
+/// at all, not just a weak one.
+const PURE_ROTATION_PARALLAX_DEG: Real = 0.1;
+
 /// Diagnostics about a two-view scene configuration.
 #[derive(Debug, Clone)]
 pub struct SceneDiagnostics {
@@ -23,21 +31,35 @@ pub struct SceneDiagnostics {
     pub baseline_ratio: Real,
 }
 
-/// Detect a pure rotation from an essential matrix.
+/// Detect a pure rotation from triangulated parallax angles.
 ///
-/// A pure rotation has `t ≈ 0`, so the essential matrix `E = [t]× R ≈ 0`.
-/// For a proper essential matrix with translation, the singular values are
-/// `(σ, σ, 0)` with `σ > 0`. For pure rotation, all singular values are
-/// near zero.
+/// ## Why not use the essential matrix norm?
 ///
-/// Returns `true` if the Frobenius norm of E is below a threshold,
-/// indicating negligible translation.
-pub fn detect_pure_rotation(e: &Mat3) -> bool {
-    // Frobenius norm: sqrt(s1² + s2² + s3²). For a valid E this equals
-    // sqrt(2) * σ where σ is the repeated singular value. A near-zero
-    // norm means negligible translation.
-    let frob = e.norm();
-    frob < 1e-6
+/// The old approach (`‖E‖ < threshold`) was scale-dependent: essential
+/// matrices are defined only up to an arbitrary scale factor, so `E` and
+/// `1e-9 · E` encode the same geometry but have vastly different norms.
+/// A valid E scaled down by 1e-9 would be wrongly flagged as pure rotation.
+///
+/// ## Parallax is the scale-invariant signal
+///
+/// Pure rotation means the translation vector `t` is exactly zero.  When
+/// `t = 0`, all viewing rays from camera 1 and camera 2 to the same scene
+/// point are parallel — the parallax angle is zero.  The **median** parallax
+/// angle is therefore the correct, scale-invariant test:
+///
+/// - Returns `true` (pure rotation) when `parallax_angles` is empty (no
+///   triangulated points → no baseline evidence) or when the median angle
+///   is below `threshold_deg`.
+/// - Returns `false` otherwise (there is a non-trivial baseline).
+pub fn detect_pure_rotation(parallax_angles: &[Real], threshold_deg: Real) -> bool {
+    if parallax_angles.is_empty() {
+        // No triangulated points — we cannot confirm a baseline exists.
+        return true;
+    }
+    let mut sorted = parallax_angles.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = sorted[sorted.len() / 2];
+    median < threshold_deg
 }
 
 /// Detect a planar scene by comparing homography and essential inlier counts.
@@ -76,11 +98,11 @@ pub fn detect_poor_baseline(parallax_angles: &[Real], threshold_deg: Real) -> bo
 
 /// Analyze a two-view scene for degeneracies.
 ///
-/// Given correspondences, the estimated essential matrix, and the recovered
-/// pose (R, t), returns diagnostics about the scene configuration.
-pub fn analyze_scene(corrs: &[Correspondence2D], e: &Mat3, r: &Mat3, t: &Vec3) -> SceneDiagnostics {
-    let is_pure_rotation = detect_pure_rotation(e);
-
+/// Given correspondences and the recovered pose (R, t), returns diagnostics
+/// about the scene configuration.  The essential matrix is not required: pure
+/// rotation is detected from the scale-invariant parallax signal rather than
+/// from `‖E‖` (see [`detect_pure_rotation`]).
+pub fn analyze_scene(corrs: &[Correspondence2D], r: &Mat3, t: &Vec3) -> SceneDiagnostics {
     // Triangulate to get parallax angles.
     let (pts1, pts2) = Correspondence2D::split(corrs);
     let parallax_angles: Vec<Real> =
@@ -97,6 +119,9 @@ pub fn analyze_scene(corrs: &[Correspondence2D], e: &Mat3, r: &Mat3, t: &Vec3) -
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
         sorted[sorted.len() / 2]
     };
+
+    // Pure rotation: scale-invariant parallax test.
+    let is_pure_rotation = detect_pure_rotation(&parallax_angles, PURE_ROTATION_PARALLAX_DEG);
 
     // Estimate baseline ratio: ||t|| / median_depth.
     let baseline_ratio =
@@ -152,28 +177,26 @@ pub fn analyze_scene(corrs: &[Correspondence2D], e: &Mat3, r: &Mat3, t: &Vec3) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nalgebra::Rotation3;
     use vision_calibration_core::{Pt2, Pt3};
 
-    fn skew(v: &Vec3) -> Mat3 {
-        Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
+    #[test]
+    fn detect_pure_rotation_true_for_low_parallax() {
+        // Small parallax angles → pure rotation.
+        let angles = &[0.001_f64, 0.002, 0.0015];
+        assert!(detect_pure_rotation(angles, 0.1));
     }
 
     #[test]
-    fn detect_pure_rotation_true_for_zero_translation() {
-        // E = [t]x * R with t ≈ 0 gives E ≈ 0.
-        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
-        let t = Vec3::new(0.0, 0.0, 0.0);
-        let e = skew(&t) * rot.matrix();
-        assert!(detect_pure_rotation(&e));
+    fn detect_pure_rotation_false_for_good_parallax() {
+        // Large parallax angles → not a pure rotation.
+        let angles = &[2.0_f64, 3.5, 1.8];
+        assert!(!detect_pure_rotation(angles, 0.1));
     }
 
     #[test]
-    fn detect_pure_rotation_false_for_good_baseline() {
-        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
-        let t = Vec3::new(0.3, 0.01, 0.005);
-        let e = skew(&t) * rot.matrix();
-        assert!(!detect_pure_rotation(&e));
+    fn detect_pure_rotation_true_for_empty_angles() {
+        // No triangulated points — cannot confirm a baseline → treat as pure rotation.
+        assert!(detect_pure_rotation(&[], 0.1));
     }
 
     #[test]
@@ -221,10 +244,10 @@ mod tests {
 
     #[test]
     fn analyze_scene_good_stereo() {
+        use nalgebra::Rotation3;
         let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
         let r = *rot.matrix();
         let t = Vec3::new(0.3, 0.01, 0.005);
-        let e = skew(&t) * r;
 
         let world = [
             Pt3::new(0.5, 0.3, 3.0),
@@ -249,7 +272,8 @@ mod tests {
             })
             .collect();
 
-        let diag = analyze_scene(&corrs, &e, &r, &t);
+        // analyze_scene no longer takes an essential matrix.
+        let diag = analyze_scene(&corrs, &r, &t);
         assert!(!diag.is_pure_rotation);
         assert!(diag.median_parallax_deg > 0.0);
         assert!(diag.baseline_ratio > 0.0);

--- a/crates/vision-mvg/src/homography.rs
+++ b/crates/vision-mvg/src/homography.rs
@@ -1,0 +1,295 @@
+//! Homography geometry: transfer, decomposition, and construction.
+//!
+//! A homography `H` is a 3×3 projective transform mapping points between
+//! two views of a planar scene (or between any two views under pure rotation).
+//!
+//! This module provides:
+//! - **Transfer**: project points through a homography
+//! - **Decomposition**: recover candidate (R, t, n) from H
+//! - **Construction**: build H from known pose and plane normal
+
+use anyhow::Result;
+use vision_calibration_core::{Mat3, Pt2, Real, Vec3};
+
+use crate::types::HomographyMatrix;
+
+/// Result of decomposing a homography into motion and plane normal.
+#[derive(Debug, Clone)]
+pub struct HomographyDecomposition {
+    /// Rotation from view 1 to view 2.
+    pub r: Mat3,
+    /// Translation from view 1 to view 2 (up to scale).
+    pub t: Vec3,
+    /// Plane normal in camera 1 coordinates.
+    pub normal: Vec3,
+}
+
+/// Transfer a point through a homography: `x' = H * x`.
+///
+/// Projects the result back to inhomogeneous coordinates.
+pub fn homography_transfer(h: &HomographyMatrix, pt: &Pt2) -> Pt2 {
+    let p = nalgebra::Vector3::new(pt.x, pt.y, 1.0);
+    let hp = h * p;
+    Pt2::new(hp.x / hp.z, hp.y / hp.z)
+}
+
+/// Transfer a point through the inverse homography: `x = H⁻¹ * x'`.
+///
+/// Returns an error if `H` is singular.
+pub fn homography_transfer_inverse(h: &HomographyMatrix, pt: &Pt2) -> Result<Pt2> {
+    let h_inv = h
+        .try_inverse()
+        .ok_or_else(|| anyhow::anyhow!("singular homography"))?;
+    Ok(homography_transfer(&h_inv, pt))
+}
+
+/// Decompose a homography into candidate (R, t, n) triples.
+///
+/// Given a homography `H` between two calibrated views of a planar scene,
+/// recovers up to 4 candidate decompositions. The homography relates to
+/// pose and plane as: `H ~ R + t * n^T / d`, where `d` is the distance
+/// from camera 1 to the plane.
+///
+/// Returns 2 or 4 candidates; the correct one must be selected using
+/// additional constraints (e.g., visible points must have positive depth,
+/// plane normal must face the camera).
+pub fn decompose_homography(h: &HomographyMatrix) -> Result<Vec<HomographyDecomposition>> {
+    // Normalize H by middle singular value so that σ2 = 1.
+    let svd_h = h.svd(false, false);
+    let s2 = svd_h.singular_values[1];
+    let s3 = svd_h.singular_values[2];
+
+    if s3 < 1e-12 {
+        anyhow::bail!("degenerate homography (rank < 3)");
+    }
+
+    let h_n = h / s2;
+
+    // Eigendecompose H^T H: eigenvalues γ1 ≥ γ2 ≈ 1 ≥ γ3.
+    let hth = h_n.transpose() * h_n;
+    let eig = hth.symmetric_eigen();
+
+    let mut indices = [0usize, 1, 2];
+    indices.sort_by(|&a, &b| eig.eigenvalues[b].partial_cmp(&eig.eigenvalues[a]).unwrap());
+    let l1 = eig.eigenvalues[indices[0]];
+    let l3 = eig.eigenvalues[indices[2]];
+    let v1 = eig.eigenvectors.column(indices[0]).into_owned();
+    let v3 = eig.eigenvectors.column(indices[2]).into_owned();
+
+    // Pure rotation: all eigenvalues ≈ 1.
+    if (l1 - l3).abs() < 1e-8 {
+        let mut r = h_n;
+        if r.determinant() < 0.0 {
+            r = -r;
+        }
+        return Ok(vec![HomographyDecomposition {
+            r,
+            t: Vec3::zeros(),
+            normal: Vec3::new(0.0, 0.0, 1.0),
+        }]);
+    }
+
+    // Candidate plane normals from eigendecomposition.
+    let c1 = ((1.0 - l3) / (l1 - l3)).sqrt();
+    let c3 = ((l1 - 1.0) / (l1 - l3)).sqrt();
+    let normals: [Vec3; 2] = [c1 * v1 + c3 * v3, c1 * v1 - c3 * v3];
+
+    let mut results = Vec::with_capacity(4);
+
+    for n_raw in &normals {
+        let n = n_raw.normalize();
+
+        // For x ⊥ n: H*x = R*x exactly (the translation term vanishes).
+        // Build an orthonormal basis {u1, u2, n}.
+        let u1 = find_perpendicular(&n);
+        let u2 = n.cross(&u1);
+
+        let hu1: Vec3 = h_n * u1;
+        let hu2: Vec3 = h_n * u2;
+
+        // In the noiseless case, hu1 and hu2 are R*u1 and R*u2 (orthonormal).
+        // Complete to a 3×3 matrix and project to SO(3).
+        let r_n: Vec3 = hu1.cross(&hu2);
+        let m = Mat3::from_columns(&[hu1, hu2, r_n]);
+        let basis = Mat3::from_columns(&[u1, u2, n]);
+        let r_approx = m * basis.transpose();
+
+        let svd_r = r_approx.svd(true, true);
+        let u = svd_r.u.ok_or(anyhow::anyhow!("SVD failed"))?;
+        let vt = svd_r.v_t.ok_or(anyhow::anyhow!("SVD failed"))?;
+        let mut r = u * vt;
+        if r.determinant() < 0.0 {
+            r = -r;
+        }
+
+        // t/d = (H_n - R) * n.
+        let t: Vec3 = (h_n - r) * n;
+
+        // Sign ambiguity: (R, t, n) and (R, -t, -n).
+        results.push(HomographyDecomposition { r, t, normal: n });
+        results.push(HomographyDecomposition {
+            r,
+            t: -t,
+            normal: -n,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Find a unit vector perpendicular to `v`.
+fn find_perpendicular(v: &Vec3) -> Vec3 {
+    let candidate = if v.x.abs() < 0.9 {
+        Vec3::new(1.0, 0.0, 0.0)
+    } else {
+        Vec3::new(0.0, 1.0, 0.0)
+    };
+    let perp = v.cross(&candidate);
+    perp.normalize()
+}
+
+/// Construct a homography from relative pose and plane equation.
+///
+/// Given rotation `R`, translation `t`, plane normal `n` (in camera 1
+/// coordinates), and distance `d` from camera 1 origin to the plane,
+/// returns `H = R + (t * n^T) / d`.
+///
+/// The plane equation is `n^T X = d` for 3D points `X` on the plane.
+pub fn homography_from_pose_and_plane(r: &Mat3, t: &Vec3, n: &Vec3, d: Real) -> HomographyMatrix {
+    *r + (t * n.transpose()) / d
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::Pt3;
+
+    fn make_planar_scene() -> (Mat3, Vec3, Vec3, Real, Vec<Pt3>) {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let n = Vec3::new(0.0, 0.0, 1.0); // plane at z = d
+        let d = 3.0;
+
+        let points = vec![
+            Pt3::new(0.5, 0.3, d),
+            Pt3::new(-0.4, 0.2, d),
+            Pt3::new(0.6, -0.3, d),
+            Pt3::new(-0.3, -0.4, d),
+            Pt3::new(0.1, 0.6, d),
+            Pt3::new(0.4, -0.5, d),
+        ];
+
+        (r, t, n, d, points)
+    }
+
+    #[test]
+    fn transfer_roundtrip() {
+        let (r, t, n, d, points) = make_planar_scene();
+        let h = homography_from_pose_and_plane(&r, &t, &n, d);
+
+        for pw in &points {
+            let pt1 = Pt2::new(pw.x / pw.z, pw.y / pw.z);
+            let pt2_expected = {
+                let pc2 = r * pw.coords + t;
+                Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z)
+            };
+
+            let pt2 = homography_transfer(&h, &pt1);
+            let err = ((pt2.x - pt2_expected.x).powi(2) + (pt2.y - pt2_expected.y).powi(2)).sqrt();
+            assert!(err < 1e-10, "transfer error: {}", err);
+
+            let pt1_back = homography_transfer_inverse(&h, &pt2).unwrap();
+            let err_back = ((pt1_back.x - pt1.x).powi(2) + (pt1_back.y - pt1.y).powi(2)).sqrt();
+            assert!(err_back < 1e-10, "inverse transfer error: {}", err_back);
+        }
+    }
+
+    #[test]
+    fn homography_from_pose_and_plane_consistent() {
+        let (r, t, n, d, points) = make_planar_scene();
+        let h = homography_from_pose_and_plane(&r, &t, &n, d);
+
+        for pw in &points {
+            let pt1 = Pt2::new(pw.x / pw.z, pw.y / pw.z);
+            let pt2_gt = {
+                let pc2 = r * pw.coords + t;
+                Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z)
+            };
+
+            let pt2 = homography_transfer(&h, &pt1);
+            let err = ((pt2.x - pt2_gt.x).powi(2) + (pt2.y - pt2_gt.y).powi(2)).sqrt();
+            assert!(err < 1e-10, "pose→H→transfer error: {}", err);
+        }
+    }
+
+    #[test]
+    fn decompose_homography_roundtrip() {
+        let (r_gt, t_gt, n_gt, d, _) = make_planar_scene();
+        let h = homography_from_pose_and_plane(&r_gt, &t_gt, &n_gt, d);
+
+        let decomps = decompose_homography(&h).unwrap();
+        assert!(!decomps.is_empty());
+
+        let mut found = false;
+        for decomp in &decomps {
+            // Check rotation.
+            let r_diff = decomp.r.transpose() * r_gt;
+            let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+            let ang_deg = cos_theta.acos().to_degrees();
+
+            // Check translation direction (scale is unknown).
+            let t_cos = if t_gt.norm() > 1e-12 && decomp.t.norm() > 1e-12 {
+                decomp.t.normalize().dot(&t_gt.normalize()).abs()
+            } else {
+                1.0
+            };
+
+            // Check normal direction.
+            let n_cos = decomp.normal.normalize().dot(&n_gt.normalize()).abs();
+
+            if ang_deg < 1.0 && t_cos > 0.99 && n_cos > 0.99 {
+                found = true;
+            }
+        }
+
+        assert!(
+            found,
+            "decompose_homography did not recover the correct pose/normal"
+        );
+    }
+
+    #[test]
+    fn decompose_pure_rotation() {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.02);
+        let h: HomographyMatrix = *rot.matrix();
+
+        let decomps = decompose_homography(&h).unwrap();
+        assert!(!decomps.is_empty());
+
+        // For pure rotation, t should be ~zero.
+        let best = decomps
+            .iter()
+            .min_by(|a, b| a.t.norm().partial_cmp(&b.t.norm()).unwrap())
+            .unwrap();
+        assert!(
+            best.t.norm() < 1e-6,
+            "expected zero translation for pure rotation"
+        );
+
+        let r_diff = best.r.transpose() * rot.matrix();
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang_deg = cos_theta.acos().to_degrees();
+        assert!(ang_deg < 0.01, "rotation error: {} deg", ang_deg);
+    }
+
+    #[test]
+    fn identity_homography() {
+        let h = HomographyMatrix::identity();
+        let pt = Pt2::new(0.5, -0.3);
+        let pt2 = homography_transfer(&h, &pt);
+        assert!((pt2.x - pt.x).abs() < 1e-15);
+        assert!((pt2.y - pt.y).abs() < 1e-15);
+    }
+}

--- a/crates/vision-mvg/src/lib.rs
+++ b/crates/vision-mvg/src/lib.rs
@@ -1,0 +1,63 @@
+//! Multiple-view geometry for calibrated cameras.
+//!
+//! This crate provides tools for two-view and multi-view geometry:
+//!
+//! - **Types**: [`Correspondence2D`], [`TriangulatedPoint`], matrix type aliases
+//! - **Residuals**: algebraic, Sampson, geometric epipolar residuals and
+//!   symmetric transfer error for homographies
+//! - **Cheirality**: pose disambiguation from essential matrix decomposition
+//! - **Pose recovery**: [`recover_relative_pose`] — end-to-end calibrated 2-view pose
+//! - **Triangulation**: two-view triangulation with diagnostics
+//!
+//! # Low-level solvers (re-exported from `vision-geometry`)
+//!
+//! The following building-block solvers are re-exported for convenience:
+//!
+//! - [`essential_5point`] — 5-point essential matrix estimation
+//! - [`fundamental_8point`], [`fundamental_7point`] — fundamental matrix estimation
+//! - [`decompose_essential`] — essential matrix → candidate (R, t) pairs
+//! - [`dlt_homography`] — normalized DLT homography estimation
+//! - [`triangulate_point_linear`] — linear DLT triangulation
+//!
+//! # Coordinate conventions
+//!
+//! All calibrated functions expect **normalized camera coordinates** (after
+//! applying `K⁻¹` to pixel coordinates). Pose outputs follow the `T_C_W`
+//! convention: transform from world into camera frame.
+
+pub mod cheirality;
+pub mod degeneracy;
+pub mod homography;
+pub mod pose_recovery;
+#[cfg(feature = "refine")]
+pub mod refine;
+pub mod residuals;
+pub mod robust;
+pub mod triangulation;
+pub mod types;
+
+// Re-export core types for convenience.
+pub use homography::{
+    HomographyDecomposition, decompose_homography, homography_from_pose_and_plane,
+    homography_transfer, homography_transfer_inverse,
+};
+pub use pose_recovery::{RelativePose, recover_relative_pose};
+pub use robust::{
+    EssentialEstimate, HomographyEstimate, RobustRelativePose, estimate_essential,
+    estimate_homography, recover_relative_pose_robust,
+};
+pub use types::{
+    Correspondence2D, EssentialMatrix, FundamentalMatrix, HomographyMatrix, TriangulatedPoint,
+};
+
+// Re-export low-level solvers from vision-geometry.
+pub use vision_geometry::camera_matrix::{
+    CameraMatrixDecomposition, Mat34, decompose_camera_matrix, dlt_camera_matrix, rq_decompose,
+};
+pub use vision_geometry::epipolar::{
+    decompose_essential, essential_5point, fundamental_7point, fundamental_8point,
+    fundamental_8point_ransac,
+};
+pub use vision_geometry::homography::{dlt_homography, dlt_homography_ransac};
+pub use vision_geometry::math::{normalize_points_2d, normalize_points_3d};
+pub use vision_geometry::triangulation::triangulate_point_linear;

--- a/crates/vision-mvg/src/pose_recovery.rs
+++ b/crates/vision-mvg/src/pose_recovery.rs
@@ -1,0 +1,204 @@
+//! Relative pose recovery from calibrated correspondences.
+//!
+//! Orchestrates the 5-point algorithm, essential matrix decomposition, and
+//! cheirality testing to recover the unique relative pose between two views.
+
+use crate::cheirality;
+use crate::residuals;
+use crate::triangulation;
+use crate::types::{Correspondence2D, EssentialMatrix, TriangulatedPoint};
+use anyhow::Result;
+use vision_calibration_core::{Mat3, Real, Vec3};
+
+/// Result of relative pose recovery.
+#[derive(Debug, Clone)]
+pub struct RelativePose {
+    /// Rotation from camera 1 to camera 2.
+    pub r: Mat3,
+    /// Unit translation direction from camera 1 to camera 2.
+    pub t: Vec3,
+    /// The essential matrix used.
+    pub essential: EssentialMatrix,
+    /// Triangulated points from the inlier correspondences.
+    pub points: Vec<TriangulatedPoint>,
+}
+
+/// Recover relative pose from calibrated correspondences using the 5-point algorithm.
+///
+/// This is a convenience function that:
+/// 1. Samples multiple 5-point subsets from the correspondences to generate
+///    essential matrix candidates
+/// 2. For each candidate E, scores it by Sampson distance and cheirality
+///    over **all** correspondences
+/// 3. Selects the pose with the most points passing cheirality
+/// 4. Triangulates all correspondences with the selected pose
+///
+/// For outlier-contaminated data, prefer [`crate::recover_relative_pose_robust`]
+/// which uses RANSAC.
+///
+/// Input points must be in **normalized camera coordinates**.
+/// Requires at least 5 correspondences.
+pub fn recover_relative_pose(corrs: &[Correspondence2D]) -> Result<RelativePose> {
+    let n = corrs.len();
+    if n < 5 {
+        anyhow::bail!("need at least 5 correspondences, got {}", n);
+    }
+
+    let (pts1, pts2) = Correspondence2D::split(corrs);
+
+    // Generate essential matrix candidates from multiple 5-point subsets.
+    // Use evenly-spaced subsets to avoid dependence on input ordering.
+    let mut all_candidates: Vec<EssentialMatrix> = Vec::new();
+
+    if n == 5 {
+        // Exactly 5 points: single call.
+        all_candidates.extend(vision_geometry::epipolar::essential_5point(&pts1, &pts2)?);
+    } else {
+        // Sample up to `max_subsets` evenly-spaced 5-point subsets.
+        let max_subsets = n.min(20);
+        for start in 0..max_subsets {
+            let indices: Vec<usize> = (0..5).map(|k| (start + k * n / 5) % n).collect();
+            // Skip if indices are not distinct.
+            let mut sorted = indices.clone();
+            sorted.sort();
+            sorted.dedup();
+            if sorted.len() < 5 {
+                continue;
+            }
+            let sub1: Vec<_> = indices.iter().map(|&i| pts1[i]).collect();
+            let sub2: Vec<_> = indices.iter().map(|&i| pts2[i]).collect();
+            if let Ok(es) = vision_geometry::epipolar::essential_5point(&sub1, &sub2) {
+                all_candidates.extend(es);
+            }
+        }
+    }
+
+    if all_candidates.is_empty() {
+        anyhow::bail!("5-point solver produced no candidates from any subset");
+    }
+
+    let mut best_r = None;
+    let mut best_t = None;
+    let mut best_e = None;
+    let mut best_count = 0;
+    let mut best_residual = Real::INFINITY;
+
+    for e in &all_candidates {
+        // Score this E by mean Sampson distance over all correspondences.
+        let mean_sampson: Real = corrs
+            .iter()
+            .map(|c| residuals::sampson_distance(e, c))
+            .sum::<Real>()
+            / n as Real;
+
+        let decompositions = vision_geometry::epipolar::decompose_essential(e)?;
+        if let Some((r, t, count)) = cheirality::select_pose(&decompositions, &pts1, &pts2) {
+            // Prefer more cheirality inliers; break ties by residual.
+            let is_better =
+                count > best_count || (count == best_count && mean_sampson < best_residual);
+            if is_better {
+                best_count = count;
+                best_residual = mean_sampson;
+                best_r = Some(r);
+                best_t = Some(t);
+                best_e = Some(*e);
+            }
+        }
+    }
+
+    let r = best_r.ok_or_else(|| anyhow::anyhow!("no valid pose found"))?;
+    let t = best_t.unwrap();
+    let e = best_e.unwrap();
+
+    let points = triangulation::triangulate_two_view(&r, &t, &pts1, &pts2)?;
+
+    Ok(RelativePose {
+        r,
+        t,
+        essential: e,
+        points,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::{Pt2, Pt3};
+
+    #[test]
+    fn recover_relative_pose_noiseless() {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.2);
+        let r_gt = *rot.matrix();
+        let t_gt = Vec3::new(0.5, 0.1, 0.05);
+
+        // Points well-spread in depth and position for robust estimation.
+        let world = [
+            Pt3::new(0.5, 0.3, 3.0),
+            Pt3::new(-0.4, 0.2, 4.0),
+            Pt3::new(0.6, -0.3, 5.0),
+            Pt3::new(-0.3, -0.4, 3.5),
+            Pt3::new(0.1, 0.6, 4.5),
+            Pt3::new(0.4, -0.5, 6.0),
+            Pt3::new(-0.2, 0.3, 3.0),
+            Pt3::new(0.3, 0.5, 5.5),
+        ];
+
+        let corrs: Vec<_> = world
+            .iter()
+            .map(|pw| {
+                let pc1 = pw.coords;
+                let pc2 = r_gt * pw.coords + t_gt;
+                Correspondence2D::new(
+                    Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z),
+                    Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z),
+                )
+            })
+            .collect();
+
+        // First verify that the 5-point solver + decomposition works on its own.
+        let (p1, p2) = Correspondence2D::split(&corrs);
+        let es = vision_geometry::epipolar::essential_5point(&p1[..5], &p2[..5]).unwrap();
+
+        let mut found_good = false;
+        for e in &es {
+            let decomps = vision_geometry::epipolar::decompose_essential(e).unwrap();
+            for (r, t) in &decomps {
+                let rd = r.transpose() * r_gt;
+                let ca = ((rd.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+                let ad = ca.acos().to_degrees();
+                let ct = t.normalize().dot(&t_gt.normalize()).abs();
+                if ad < 1.0 && ct > 0.99 {
+                    found_good = true;
+                }
+            }
+        }
+        assert!(
+            found_good,
+            "5-point solver did not produce a valid E candidate"
+        );
+
+        let result = recover_relative_pose(&corrs).unwrap();
+
+        // Check rotation.
+        let r_diff = result.r.transpose() * r_gt;
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang_deg = cos_theta.acos().to_degrees();
+        assert!(ang_deg < 1.0, "rotation error too large: {} deg", ang_deg);
+
+        // Check translation direction.
+        let cos_t = result.t.normalize().dot(&t_gt.normalize());
+        assert!(
+            (cos_t.abs() - 1.0).abs() < 1e-3,
+            "translation direction error: cos = {}",
+            cos_t
+        );
+
+        // Check triangulated points.
+        assert_eq!(result.points.len(), world.len());
+        for tp in &result.points {
+            assert!(tp.in_front, "point should be in front of cameras");
+            assert!(tp.reprojection_error < 1e-6);
+        }
+    }
+}

--- a/crates/vision-mvg/src/refine.rs
+++ b/crates/vision-mvg/src/refine.rs
@@ -1,0 +1,320 @@
+//! Nonlinear refinement of geometric estimates.
+//!
+//! Feature-gated behind `refine`. Uses tiny-solver for Levenberg-Marquardt
+//! optimization with analytic residuals.
+//!
+//! - [`refine_homography`]: minimize symmetric transfer error
+//! - [`refine_point`]: minimize reprojection error for a single 3D point
+
+use anyhow::Result;
+use nalgebra::DVector;
+use tiny_solver::LevenbergMarquardtOptimizer;
+use tiny_solver::factors::Factor;
+use tiny_solver::optimizer::{Optimizer, OptimizerOptions};
+use tiny_solver::problem::Problem;
+use vision_calibration_core::{Mat3, Pt2, Pt3, Real};
+use vision_geometry::camera_matrix::Mat34;
+
+// ---------------------------------------------------------------------------
+// Homography refinement
+// ---------------------------------------------------------------------------
+
+/// Factor for symmetric transfer error of a single correspondence under H.
+struct HomographyTransferFactor {
+    pt1: Pt2,
+    pt2: Pt2,
+}
+
+impl<T: nalgebra::RealField> Factor<T> for HomographyTransferFactor {
+    fn residual_func(&self, params: &[DVector<T>]) -> DVector<T> {
+        debug_assert_eq!(params.len(), 1);
+        let h = &params[0]; // 9 elements, row-major
+
+        let x1 = T::from_f64(self.pt1.x).unwrap();
+        let y1 = T::from_f64(self.pt1.y).unwrap();
+        let x2 = T::from_f64(self.pt2.x).unwrap();
+        let y2 = T::from_f64(self.pt2.y).unwrap();
+
+        // Forward: H * [x1, y1, 1]
+        let fx = h[0].clone() * x1.clone() + h[1].clone() * y1.clone() + h[2].clone();
+        let fy = h[3].clone() * x1.clone() + h[4].clone() * y1.clone() + h[5].clone();
+        let fw = h[6].clone() * x1.clone() + h[7].clone() * y1.clone() + h[8].clone();
+        let dx_fwd = fx / fw.clone() - x2.clone();
+        let dy_fwd = fy / fw - y2.clone();
+
+        // Inverse: H^-1 * [x2, y2, 1] via adjugate (avoids explicit inverse).
+        // For a 3×3 matrix, adjugate columns are cross products of pairs of rows.
+        // H^-1 = adj(H) / det(H). Since we only care about the projected point,
+        // we can use adj(H) directly (det cancels in homogeneous division).
+        let a00 = h[4].clone() * h[8].clone() - h[5].clone() * h[7].clone();
+        let a01 = h[2].clone() * h[7].clone() - h[1].clone() * h[8].clone();
+        let a02 = h[1].clone() * h[5].clone() - h[2].clone() * h[4].clone();
+        let a10 = h[5].clone() * h[6].clone() - h[3].clone() * h[8].clone();
+        let a11 = h[0].clone() * h[8].clone() - h[2].clone() * h[6].clone();
+        let a12 = h[2].clone() * h[3].clone() - h[0].clone() * h[5].clone();
+        let a20 = h[3].clone() * h[7].clone() - h[4].clone() * h[6].clone();
+        let a21 = h[1].clone() * h[6].clone() - h[0].clone() * h[7].clone();
+        let a22 = h[0].clone() * h[4].clone() - h[1].clone() * h[3].clone();
+
+        let bx = a00 * x2.clone() + a01 * y2.clone() + a02;
+        let by = a10 * x2.clone() + a11 * y2.clone() + a12;
+        let bw = a20 * x2 + a21 * y2 + a22;
+
+        let dx_inv = bx / bw.clone() - x1;
+        let dy_inv = by / bw - y1;
+
+        DVector::from_vec(vec![dx_fwd, dy_fwd, dx_inv, dy_inv])
+    }
+}
+
+/// Refine a homography by minimizing symmetric transfer error.
+///
+/// Takes an initial estimate `h_init` and correspondences `(pts1, pts2)`,
+/// returns the refined homography.
+pub fn refine_homography(h_init: &Mat3, pts1: &[Pt2], pts2: &[Pt2]) -> Result<Mat3> {
+    if pts1.len() != pts2.len() || pts1.len() < 4 {
+        anyhow::bail!("need at least 4 matching points");
+    }
+
+    let mut problem = Problem::new();
+
+    for (p1, p2) in pts1.iter().zip(pts2.iter()) {
+        let factor = HomographyTransferFactor { pt1: *p1, pt2: *p2 };
+        problem.add_residual_block(4, &["h"], Box::new(factor), None);
+    }
+
+    let mut initial = std::collections::HashMap::new();
+    let h_vec: Vec<Real> = (0..3)
+        .flat_map(|r| (0..3).map(move |c| (r, c)))
+        .map(|(r, c)| h_init[(r, c)])
+        .collect();
+    initial.insert("h".to_string(), DVector::from_vec(h_vec));
+
+    let opts = OptimizerOptions {
+        max_iteration: 50,
+        ..Default::default()
+    };
+
+    let optimizer = LevenbergMarquardtOptimizer::default();
+    let result = optimizer
+        .optimize(&problem, &initial, Some(opts))
+        .ok_or_else(|| anyhow::anyhow!("homography refinement failed to converge"))?;
+
+    let h_opt = &result["h"];
+    let mut h = Mat3::zeros();
+    for r in 0..3 {
+        for c in 0..3 {
+            h[(r, c)] = h_opt[r * 3 + c];
+        }
+    }
+
+    // Normalize so h[2,2] = 1.
+    let s = h[(2, 2)];
+    if s.abs() > f64::EPSILON {
+        h /= s;
+    }
+
+    Ok(h)
+}
+
+// ---------------------------------------------------------------------------
+// 3D point refinement
+// ---------------------------------------------------------------------------
+
+/// Factor for reprojection error of a 3D point in one view.
+struct ReprojectionFactor {
+    /// 3×4 projection matrix.
+    p: [Real; 12],
+    /// Observed 2D point.
+    obs: Pt2,
+}
+
+impl<T: nalgebra::RealField> Factor<T> for ReprojectionFactor {
+    fn residual_func(&self, params: &[DVector<T>]) -> DVector<T> {
+        debug_assert_eq!(params.len(), 1);
+        let pt = &params[0]; // [x, y, z]
+
+        let x = pt[0].clone();
+        let y = pt[1].clone();
+        let z = pt[2].clone();
+
+        let p = |i: usize| T::from_f64(self.p[i]).unwrap();
+
+        let px = p(0) * x.clone() + p(1) * y.clone() + p(2) * z.clone() + p(3);
+        let py = p(4) * x.clone() + p(5) * y.clone() + p(6) * z.clone() + p(7);
+        let pw = p(8) * x + p(9) * y + p(10) * z + p(11);
+
+        let u_obs = T::from_f64(self.obs.x).unwrap();
+        let v_obs = T::from_f64(self.obs.y).unwrap();
+
+        DVector::from_vec(vec![px / pw.clone() - u_obs, py / pw - v_obs])
+    }
+}
+
+/// Refine a single 3D point by minimizing reprojection error across views.
+///
+/// `cameras` are 3×4 projection matrices, `observations` are the
+/// corresponding 2D observations. `init` is the initial 3D point estimate.
+pub fn refine_point(cameras: &[Mat34], observations: &[Pt2], init: &Pt3) -> Result<Pt3> {
+    if cameras.len() != observations.len() || cameras.is_empty() {
+        anyhow::bail!("cameras and observations must have equal non-zero length");
+    }
+
+    let mut problem = Problem::new();
+
+    for (cam, obs) in cameras.iter().zip(observations.iter()) {
+        let mut p = [0.0; 12];
+        for r in 0..3 {
+            for c in 0..4 {
+                p[r * 4 + c] = cam[(r, c)];
+            }
+        }
+        let factor = ReprojectionFactor { p, obs: *obs };
+        problem.add_residual_block(2, &["point"], Box::new(factor), None);
+    }
+
+    let mut initial = std::collections::HashMap::new();
+    initial.insert(
+        "point".to_string(),
+        DVector::from_vec(vec![init.x, init.y, init.z]),
+    );
+
+    let opts = OptimizerOptions {
+        max_iteration: 30,
+        ..Default::default()
+    };
+
+    let optimizer = LevenbergMarquardtOptimizer::default();
+    let result = optimizer
+        .optimize(&problem, &initial, Some(opts))
+        .ok_or_else(|| anyhow::anyhow!("point refinement failed to converge"))?;
+
+    let pt = &result["point"];
+    Ok(Pt3::new(pt[0], pt[1], pt[2]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::Vec3;
+
+    #[test]
+    fn refine_homography_improves_estimate() {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let n = Vec3::new(0.0, 0.0, 1.0);
+        let d = 3.0;
+        let h_gt = crate::homography::homography_from_pose_and_plane(&r, &t, &n, d);
+
+        let plane_pts: Vec<Pt3> = vec![
+            Pt3::new(0.5, 0.3, d),
+            Pt3::new(-0.4, 0.2, d),
+            Pt3::new(0.6, -0.3, d),
+            Pt3::new(-0.3, -0.4, d),
+            Pt3::new(0.1, 0.6, d),
+            Pt3::new(0.4, -0.5, d),
+        ];
+
+        let pts1: Vec<_> = plane_pts
+            .iter()
+            .map(|p| Pt2::new(p.x / p.z, p.y / p.z))
+            .collect();
+        let pts2: Vec<_> = pts1
+            .iter()
+            .map(|p| crate::homography::homography_transfer(&h_gt, p))
+            .collect();
+
+        // Perturb the homography.
+        let mut h_init = h_gt;
+        h_init[(0, 0)] += 0.01;
+        h_init[(1, 1)] += 0.01;
+
+        let h_refined = refine_homography(&h_init, &pts1, &pts2).unwrap();
+
+        // Refined should be closer to GT.
+        let err_init = (h_init - h_gt).norm();
+        let err_refined = (h_refined - h_gt).norm();
+        assert!(
+            err_refined < err_init,
+            "refinement did not improve: init={:.6}, refined={:.6}",
+            err_init,
+            err_refined
+        );
+        assert!(
+            err_refined < 1e-3,
+            "refined error too large: {}",
+            err_refined
+        );
+    }
+
+    #[test]
+    fn refine_point_improves_estimate() {
+        let p1 = Mat34::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let mut p2 = Mat34::zeros();
+        p2.fixed_view_mut::<3, 3>(0, 0).copy_from(&r);
+        p2.set_column(3, &t);
+
+        let pt_gt = Pt3::new(0.2, -0.1, 4.0);
+
+        // Project to get observations.
+        let h1 = nalgebra::Vector4::new(pt_gt.x, pt_gt.y, pt_gt.z, 1.0);
+        let x1 = p1 * h1;
+        let x2 = p2 * h1;
+        let obs1 = Pt2::new(x1.x / x1.z, x1.y / x1.z);
+        let obs2 = Pt2::new(x2.x / x2.z, x2.y / x2.z);
+
+        // Perturbed initial.
+        let init = Pt3::new(pt_gt.x + 0.1, pt_gt.y - 0.05, pt_gt.z + 0.2);
+
+        let refined = refine_point(&[p1, p2], &[obs1, obs2], &init).unwrap();
+
+        let err_init = (init - pt_gt).norm();
+        let err_refined = (refined - pt_gt).norm();
+        assert!(
+            err_refined < err_init,
+            "refinement did not improve: init={:.6}, refined={:.6}",
+            err_init,
+            err_refined
+        );
+        assert!(
+            err_refined < 1e-3,
+            "refined error too large: {}",
+            err_refined
+        );
+    }
+
+    #[test]
+    fn refine_homography_perfect_init_does_not_diverge() {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let n = Vec3::new(0.0, 0.0, 1.0);
+        let d = 3.0;
+        let h_gt = crate::homography::homography_from_pose_and_plane(&r, &t, &n, d);
+
+        let plane_pts: Vec<Pt3> = vec![
+            Pt3::new(0.5, 0.3, d),
+            Pt3::new(-0.4, 0.2, d),
+            Pt3::new(0.6, -0.3, d),
+            Pt3::new(-0.3, -0.4, d),
+        ];
+
+        let pts1: Vec<_> = plane_pts
+            .iter()
+            .map(|p| Pt2::new(p.x / p.z, p.y / p.z))
+            .collect();
+        let pts2: Vec<_> = pts1
+            .iter()
+            .map(|p| crate::homography::homography_transfer(&h_gt, p))
+            .collect();
+
+        let h_refined = refine_homography(&h_gt, &pts1, &pts2).unwrap();
+        let err = (h_refined - h_gt).norm();
+        assert!(err < 1e-3, "perfect init diverged: error = {}", err);
+    }
+}

--- a/crates/vision-mvg/src/residuals.rs
+++ b/crates/vision-mvg/src/residuals.rs
@@ -1,0 +1,234 @@
+//! Epipolar and homography residual functions.
+//!
+//! These residuals measure how well a fundamental/essential matrix or
+//! homography explains a pair of corresponding points.
+
+use crate::types::Correspondence2D;
+use vision_calibration_core::{Mat3, Real, from_homogeneous, to_homogeneous};
+
+/// Algebraic epipolar residual: `x₂ᵀ F x₁`.
+///
+/// This is the simplest residual — it equals zero when the correspondence
+/// exactly satisfies the epipolar constraint. Not geometrically meaningful
+/// on its own, but fast and useful for algebraic minimization.
+pub fn algebraic_residual(f: &Mat3, c: &Correspondence2D) -> Real {
+    let x1 = nalgebra::Vector3::new(c.pt1.x, c.pt1.y, 1.0);
+    let x2 = nalgebra::Vector3::new(c.pt2.x, c.pt2.y, 1.0);
+    (x2.transpose() * f * x1)[0]
+}
+
+/// Sampson distance (first-order geometric approximation).
+///
+/// This is a good approximation to the true geometric distance and is
+/// much cheaper to compute. It equals the reprojection error to first
+/// order in the noise.
+///
+/// Returns the **squared** Sampson distance.
+pub fn sampson_distance_squared(f: &Mat3, c: &Correspondence2D) -> Real {
+    let x1 = nalgebra::Vector3::new(c.pt1.x, c.pt1.y, 1.0);
+    let x2 = nalgebra::Vector3::new(c.pt2.x, c.pt2.y, 1.0);
+
+    let fx1 = f * x1;
+    let ftx2 = f.transpose() * x2;
+
+    let xtfx = (x2.transpose() * f * x1)[0];
+
+    let denom = fx1.x * fx1.x + fx1.y * fx1.y + ftx2.x * ftx2.x + ftx2.y * ftx2.y;
+    if denom.abs() < Real::EPSILON {
+        return Real::INFINITY;
+    }
+
+    (xtfx * xtfx) / denom
+}
+
+/// Sampson distance (first-order geometric approximation).
+///
+/// Returns the Sampson distance (not squared).
+pub fn sampson_distance(f: &Mat3, c: &Correspondence2D) -> Real {
+    sampson_distance_squared(f, c).abs().sqrt()
+}
+
+/// Symmetric epipolar distance.
+///
+/// Geometric distance from each point to its corresponding epipolar line,
+/// averaged over both images:
+///
+/// `d² = (x₂ᵀFx₁)² * (1/(Fx₁)₁² + (Fx₁)₂²) + 1/((Fᵀx₂)₁² + (Fᵀx₂)₂²))`
+///
+/// Returns the **squared** symmetric epipolar distance.
+pub fn symmetric_epipolar_distance_squared(f: &Mat3, c: &Correspondence2D) -> Real {
+    let x1 = nalgebra::Vector3::new(c.pt1.x, c.pt1.y, 1.0);
+    let x2 = nalgebra::Vector3::new(c.pt2.x, c.pt2.y, 1.0);
+
+    let fx1 = f * x1;
+    let ftx2 = f.transpose() * x2;
+
+    let xtfx = (x2.transpose() * f * x1)[0];
+    let xtfx2 = xtfx * xtfx;
+
+    let d1_sq = fx1.x * fx1.x + fx1.y * fx1.y;
+    let d2_sq = ftx2.x * ftx2.x + ftx2.y * ftx2.y;
+
+    if d1_sq.abs() < Real::EPSILON || d2_sq.abs() < Real::EPSILON {
+        return Real::INFINITY;
+    }
+
+    xtfx2 / d1_sq + xtfx2 / d2_sq
+}
+
+/// Symmetric epipolar distance (not squared).
+pub fn symmetric_epipolar_distance(f: &Mat3, c: &Correspondence2D) -> Real {
+    symmetric_epipolar_distance_squared(f, c).abs().sqrt()
+}
+
+/// Point-to-epipolar-line distance in each image.
+///
+/// Returns `(d1, d2)` where:
+/// - `d1` = distance from `pt2` to the epipolar line `F x₁` in image 2
+/// - `d2` = distance from `pt1` to the epipolar line `Fᵀ x₂` in image 1
+pub fn epipolar_line_distance(f: &Mat3, c: &Correspondence2D) -> (Real, Real) {
+    let x1 = nalgebra::Vector3::new(c.pt1.x, c.pt1.y, 1.0);
+    let x2 = nalgebra::Vector3::new(c.pt2.x, c.pt2.y, 1.0);
+
+    let l2 = f * x1; // epipolar line in image 2
+    let l1 = f.transpose() * x2; // epipolar line in image 1
+
+    let d1 = if l2.x * l2.x + l2.y * l2.y > Real::EPSILON {
+        (l2.x * c.pt2.x + l2.y * c.pt2.y + l2.z).abs() / (l2.x * l2.x + l2.y * l2.y).sqrt()
+    } else {
+        Real::INFINITY
+    };
+
+    let d2 = if l1.x * l1.x + l1.y * l1.y > Real::EPSILON {
+        (l1.x * c.pt1.x + l1.y * c.pt1.y + l1.z).abs() / (l1.x * l1.x + l1.y * l1.y).sqrt()
+    } else {
+        Real::INFINITY
+    };
+
+    (d1, d2)
+}
+
+/// Symmetric transfer error for a homography.
+///
+/// Measures how well `H` maps `pt1 → pt2` and `H⁻¹` maps `pt2 → pt1`:
+///
+/// `error² = |H x₁ - x₂|² + |H⁻¹ x₂ - x₁|²`
+///
+/// Returns the **squared** symmetric transfer error, or `INFINITY` if `H`
+/// is not invertible.
+pub fn symmetric_transfer_error_squared(h: &Mat3, c: &Correspondence2D) -> Real {
+    let h_inv = match h.try_inverse() {
+        Some(inv) => inv,
+        None => return Real::INFINITY,
+    };
+
+    let x1h = to_homogeneous(&c.pt1);
+    let x2h = to_homogeneous(&c.pt2);
+
+    let fwd = from_homogeneous(&(h * x1h));
+    let bwd = from_homogeneous(&(h_inv * x2h));
+
+    let d_fwd = (fwd.x - c.pt2.x).powi(2) + (fwd.y - c.pt2.y).powi(2);
+    let d_bwd = (bwd.x - c.pt1.x).powi(2) + (bwd.y - c.pt1.y).powi(2);
+
+    d_fwd + d_bwd
+}
+
+/// Symmetric transfer error for a homography (not squared).
+pub fn symmetric_transfer_error(h: &Mat3, c: &Correspondence2D) -> Real {
+    symmetric_transfer_error_squared(h, c).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::{Pt2, Pt3, Vec3};
+
+    fn skew(v: &Vec3) -> Mat3 {
+        Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
+    }
+
+    fn make_essential() -> (Mat3, Vec<Correspondence2D>) {
+        let rot = Rotation3::from_euler_angles(0.1, -0.05, 0.02);
+        let t = Vec3::new(0.3, 0.05, 0.01);
+        let e = skew(&t) * rot.matrix();
+
+        let world = [
+            Pt3::new(0.1, 0.2, 2.0),
+            Pt3::new(-0.2, 0.1, 2.5),
+            Pt3::new(0.3, -0.1, 3.0),
+            Pt3::new(-0.15, -0.2, 2.2),
+            Pt3::new(0.05, 0.3, 2.8),
+        ];
+
+        let corrs: Vec<_> = world
+            .iter()
+            .map(|pw| {
+                let pc1 = pw.coords;
+                let pc2 = rot * pw + t;
+                Correspondence2D::new(
+                    Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z),
+                    Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z),
+                )
+            })
+            .collect();
+
+        (e, corrs)
+    }
+
+    #[test]
+    fn algebraic_residual_zero_for_exact_correspondences() {
+        let (e, corrs) = make_essential();
+        for c in &corrs {
+            let r = algebraic_residual(&e, c);
+            assert!(r.abs() < 1e-10, "algebraic residual too large: {}", r);
+        }
+    }
+
+    #[test]
+    fn sampson_distance_zero_for_exact_correspondences() {
+        let (e, corrs) = make_essential();
+        for c in &corrs {
+            let d = sampson_distance(&e, c);
+            assert!(d < 1e-10, "Sampson distance too large: {}", d);
+        }
+    }
+
+    #[test]
+    fn symmetric_epipolar_distance_zero_for_exact() {
+        let (e, corrs) = make_essential();
+        for c in &corrs {
+            let d = symmetric_epipolar_distance(&e, c);
+            assert!(d < 1e-10, "symmetric distance too large: {}", d);
+        }
+    }
+
+    #[test]
+    fn epipolar_line_distance_zero_for_exact() {
+        let (e, corrs) = make_essential();
+        for c in &corrs {
+            let (d1, d2) = epipolar_line_distance(&e, c);
+            assert!(d1 < 1e-10, "d1 too large: {}", d1);
+            assert!(d2 < 1e-10, "d2 too large: {}", d2);
+        }
+    }
+
+    #[test]
+    fn symmetric_transfer_error_zero_for_exact_homography() {
+        // Scale homography: H = diag(2, 2, 1)
+        let h = Mat3::new(2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 1.0);
+
+        let c = Correspondence2D::new(Pt2::new(1.0, 1.0), Pt2::new(2.0, 2.0));
+        let err = symmetric_transfer_error(&h, &c);
+        assert!(err < 1e-10, "transfer error too large: {}", err);
+    }
+
+    #[test]
+    fn sampson_nonzero_for_wrong_correspondence() {
+        let (e, _corrs) = make_essential();
+        let bad = Correspondence2D::new(Pt2::new(0.5, 0.5), Pt2::new(-0.3, 0.8));
+        let d = sampson_distance(&e, &bad);
+        assert!(d > 1e-3, "expected nonzero Sampson for bad correspondence");
+    }
+}

--- a/crates/vision-mvg/src/robust.rs
+++ b/crates/vision-mvg/src/robust.rs
@@ -1,0 +1,421 @@
+//! Robust estimation using RANSAC for epipolar and homography models.
+//!
+//! Provides RANSAC-based estimators that work with [`Correspondence2D`]:
+//!
+//! - [`estimate_essential`]: 5-point algorithm + Sampson distance
+//! - [`estimate_homography`]: 4-point DLT + symmetric transfer error
+//! - [`recover_relative_pose_robust`]: full pipeline from correspondences to pose
+
+use crate::residuals;
+use crate::types::Correspondence2D;
+use anyhow::Result;
+use vision_calibration_core::{Estimator, Mat3, RansacOptions, Real, ransac_fit};
+
+/// Result of robust essential matrix estimation.
+#[derive(Debug, Clone)]
+pub struct EssentialEstimate {
+    /// The estimated essential matrix.
+    pub essential: Mat3,
+    /// Indices of inlier correspondences.
+    pub inliers: Vec<usize>,
+    /// RMS Sampson distance over inliers.
+    pub inlier_rms: Real,
+}
+
+/// Result of robust homography estimation.
+#[derive(Debug, Clone)]
+pub struct HomographyEstimate {
+    /// The estimated homography matrix.
+    pub homography: Mat3,
+    /// Indices of inlier correspondences.
+    pub inliers: Vec<usize>,
+    /// RMS symmetric transfer error over inliers.
+    pub inlier_rms: Real,
+}
+
+/// Result of robust relative pose recovery.
+#[derive(Debug, Clone)]
+pub struct RobustRelativePose {
+    /// Rotation from camera 1 to camera 2.
+    pub r: Mat3,
+    /// Unit translation direction from camera 1 to camera 2.
+    pub t: vision_calibration_core::Vec3,
+    /// The essential matrix used.
+    pub essential: Mat3,
+    /// Indices of inlier correspondences.
+    pub inliers: Vec<usize>,
+    /// RMS Sampson distance over inliers.
+    pub inlier_rms: Real,
+}
+
+// --- Essential matrix RANSAC estimator ---
+
+struct EssentialEstimator;
+
+impl Estimator for EssentialEstimator {
+    type Datum = Correspondence2D;
+    type Model = Mat3;
+
+    const MIN_SAMPLES: usize = 5;
+
+    fn fit(data: &[Self::Datum], sample_indices: &[usize]) -> Option<Self::Model> {
+        let mut pts1 = Vec::with_capacity(sample_indices.len());
+        let mut pts2 = Vec::with_capacity(sample_indices.len());
+        for &idx in sample_indices {
+            pts1.push(data[idx].pt1);
+            pts2.push(data[idx].pt2);
+        }
+        let candidates = vision_geometry::epipolar::essential_5point(&pts1, &pts2).ok()?;
+
+        // Pick the candidate with lowest total Sampson distance over the sample.
+        candidates.into_iter().min_by(|a, b| {
+            let sa: Real = sample_indices
+                .iter()
+                .map(|&i| residuals::sampson_distance(a, &data[i]))
+                .sum();
+            let sb: Real = sample_indices
+                .iter()
+                .map(|&i| residuals::sampson_distance(b, &data[i]))
+                .sum();
+            sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
+        })
+    }
+
+    fn residual(model: &Self::Model, datum: &Self::Datum) -> f64 {
+        residuals::sampson_distance(model, datum)
+    }
+
+    fn is_degenerate(data: &[Self::Datum], sample_indices: &[usize]) -> bool {
+        // Check if any 3 points are nearly collinear in either image.
+        if sample_indices.len() < 3 {
+            return false;
+        }
+        let p0 = data[sample_indices[0]].pt1;
+        let p1 = data[sample_indices[1]].pt1;
+        let p2 = data[sample_indices[2]].pt1;
+        let area = (p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x);
+        area.abs() < 1e-9
+    }
+}
+
+// --- Homography RANSAC estimator ---
+
+struct HomographyEstimator;
+
+impl Estimator for HomographyEstimator {
+    type Datum = Correspondence2D;
+    type Model = Mat3;
+
+    const MIN_SAMPLES: usize = 4;
+
+    fn fit(data: &[Self::Datum], sample_indices: &[usize]) -> Option<Self::Model> {
+        let mut src = Vec::with_capacity(sample_indices.len());
+        let mut dst = Vec::with_capacity(sample_indices.len());
+        for &idx in sample_indices {
+            src.push(data[idx].pt1);
+            dst.push(data[idx].pt2);
+        }
+        vision_geometry::homography::dlt_homography(&src, &dst).ok()
+    }
+
+    fn residual(model: &Self::Model, datum: &Self::Datum) -> f64 {
+        residuals::symmetric_transfer_error(model, datum)
+    }
+
+    fn is_degenerate(data: &[Self::Datum], sample_indices: &[usize]) -> bool {
+        if sample_indices.len() < 3 {
+            return false;
+        }
+        let p0 = data[sample_indices[0]].pt1;
+        let p1 = data[sample_indices[1]].pt1;
+        let p2 = data[sample_indices[2]].pt1;
+        let area = (p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x);
+        area.abs() < 1e-9
+    }
+}
+
+/// Estimate an essential matrix from correspondences using RANSAC.
+///
+/// Uses the 5-point algorithm as the minimal solver and Sampson distance
+/// as the residual metric. Input points must be in **normalized camera
+/// coordinates**.
+pub fn estimate_essential(
+    corrs: &[Correspondence2D],
+    opts: &RansacOptions,
+) -> Result<EssentialEstimate> {
+    if corrs.len() < 5 {
+        anyhow::bail!("need at least 5 correspondences, got {}", corrs.len());
+    }
+
+    let result = ransac_fit::<EssentialEstimator>(corrs, opts);
+    if !result.success {
+        anyhow::bail!("RANSAC failed to find essential matrix consensus");
+    }
+
+    Ok(EssentialEstimate {
+        essential: result.model.expect("success guarantees model"),
+        inliers: result.inliers,
+        inlier_rms: result.inlier_rms,
+    })
+}
+
+/// Estimate a homography from correspondences using RANSAC.
+///
+/// Uses the 4-point DLT as the minimal solver and symmetric transfer
+/// error as the residual metric.
+pub fn estimate_homography(
+    corrs: &[Correspondence2D],
+    opts: &RansacOptions,
+) -> Result<HomographyEstimate> {
+    if corrs.len() < 4 {
+        anyhow::bail!("need at least 4 correspondences, got {}", corrs.len());
+    }
+
+    let result = ransac_fit::<HomographyEstimator>(corrs, opts);
+    if !result.success {
+        anyhow::bail!("RANSAC failed to find homography consensus");
+    }
+
+    Ok(HomographyEstimate {
+        homography: result.model.expect("success guarantees model"),
+        inliers: result.inliers,
+        inlier_rms: result.inlier_rms,
+    })
+}
+
+/// Recover relative pose robustly from correspondences.
+///
+/// Combines essential matrix RANSAC with decomposition and cheirality
+/// selection. Input points must be in **normalized camera coordinates**.
+pub fn recover_relative_pose_robust(
+    corrs: &[Correspondence2D],
+    opts: &RansacOptions,
+) -> Result<RobustRelativePose> {
+    let est = estimate_essential(corrs, opts)?;
+
+    // Use only inlier correspondences for cheirality disambiguation,
+    // so outliers don't corrupt the positive-depth vote.
+    let inlier_corrs: Vec<_> = est.inliers.iter().map(|&i| corrs[i]).collect();
+    let (pts1, pts2) = Correspondence2D::split(&inlier_corrs);
+
+    let (r, t) = crate::cheirality::recover_pose_from_essential(&est.essential, &pts1, &pts2)?;
+
+    Ok(RobustRelativePose {
+        r,
+        t,
+        essential: est.essential,
+        inliers: est.inliers,
+        inlier_rms: est.inlier_rms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::{Pt2, Pt3, Vec3};
+
+    fn make_stereo_corrs_with_outliers() -> (Vec<Correspondence2D>, Mat3, Vec3) {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+
+        let world = [
+            Pt3::new(0.5, 0.3, 3.0),
+            Pt3::new(-0.4, 0.2, 4.0),
+            Pt3::new(0.6, -0.3, 5.0),
+            Pt3::new(-0.3, -0.4, 3.5),
+            Pt3::new(0.1, 0.6, 4.5),
+            Pt3::new(0.4, -0.5, 6.0),
+            Pt3::new(-0.2, 0.3, 3.0),
+            Pt3::new(0.3, 0.5, 5.5),
+            Pt3::new(-0.5, -0.1, 4.0),
+            Pt3::new(0.2, -0.4, 3.2),
+            Pt3::new(0.0, 0.0, 2.5),
+            Pt3::new(-0.3, 0.5, 4.8),
+            Pt3::new(0.4, 0.1, 3.8),
+            Pt3::new(-0.1, -0.3, 5.2),
+            Pt3::new(0.5, -0.2, 4.3),
+        ];
+
+        let mut corrs: Vec<_> = world
+            .iter()
+            .map(|pw| {
+                let pc1 = pw.coords;
+                let pc2 = r * pw.coords + t;
+                Correspondence2D::new(
+                    Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z),
+                    Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z),
+                )
+            })
+            .collect();
+
+        // Add outliers (20%).
+        corrs.push(Correspondence2D::new(
+            Pt2::new(0.1, 0.2),
+            Pt2::new(5.0, -3.0),
+        ));
+        corrs.push(Correspondence2D::new(
+            Pt2::new(-0.3, 0.1),
+            Pt2::new(-2.0, 4.0),
+        ));
+        corrs.push(Correspondence2D::new(
+            Pt2::new(0.05, -0.15),
+            Pt2::new(1.5, 1.5),
+        ));
+
+        (corrs, r, t)
+    }
+
+    #[test]
+    fn essential_ransac_with_outliers() {
+        let (corrs, r_gt, t_gt) = make_stereo_corrs_with_outliers();
+
+        let opts = RansacOptions {
+            max_iters: 500,
+            thresh: 0.001,
+            min_inliers: 10,
+            confidence: 0.99,
+            seed: 42,
+            refit_on_inliers: true,
+        };
+
+        let est = estimate_essential(&corrs, &opts).unwrap();
+        assert!(
+            est.inliers.len() >= 12,
+            "expected ≥12 inliers, got {}",
+            est.inliers.len()
+        );
+
+        // Verify decomposition recovers pose (using inliers only).
+        let inlier_corrs: Vec<_> = est.inliers.iter().map(|&i| corrs[i]).collect();
+        let (pts1, pts2) = Correspondence2D::split(&inlier_corrs);
+        let (r_est, t_est) =
+            crate::cheirality::recover_pose_from_essential(&est.essential, &pts1, &pts2).unwrap();
+
+        let r_diff = r_est.transpose() * r_gt;
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang_deg = cos_theta.acos().to_degrees();
+        assert!(ang_deg < 2.0, "rotation error too large: {} deg", ang_deg);
+
+        let cos_t = t_est.normalize().dot(&t_gt.normalize()).abs();
+        assert!(
+            (cos_t - 1.0).abs() < 0.01,
+            "translation direction error: cos = {}",
+            cos_t
+        );
+    }
+
+    #[test]
+    fn homography_ransac_with_outliers() {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let n = Vec3::new(0.0, 0.0, 1.0);
+        let d = 3.0;
+        let h = crate::homography::homography_from_pose_and_plane(&r, &t, &n, d);
+
+        let plane_pts = [
+            Pt3::new(0.5, 0.3, d),
+            Pt3::new(-0.4, 0.2, d),
+            Pt3::new(0.6, -0.3, d),
+            Pt3::new(-0.3, -0.4, d),
+            Pt3::new(0.1, 0.6, d),
+            Pt3::new(0.4, -0.5, d),
+            Pt3::new(-0.2, 0.3, d),
+            Pt3::new(0.3, 0.5, d),
+            Pt3::new(-0.5, -0.1, d),
+            Pt3::new(0.2, -0.4, d),
+        ];
+
+        let mut corrs: Vec<_> = plane_pts
+            .iter()
+            .map(|pw| {
+                let pt1 = Pt2::new(pw.x / pw.z, pw.y / pw.z);
+                let pt2 = crate::homography::homography_transfer(&h, &pt1);
+                Correspondence2D::new(pt1, pt2)
+            })
+            .collect();
+
+        // Add outliers.
+        corrs.push(Correspondence2D::new(
+            Pt2::new(0.1, 0.2),
+            Pt2::new(5.0, -3.0),
+        ));
+        corrs.push(Correspondence2D::new(
+            Pt2::new(-0.3, 0.1),
+            Pt2::new(-2.0, 4.0),
+        ));
+
+        let opts = RansacOptions {
+            max_iters: 500,
+            thresh: 0.001,
+            min_inliers: 6,
+            confidence: 0.99,
+            seed: 42,
+            refit_on_inliers: true,
+        };
+
+        let est = estimate_homography(&corrs, &opts).unwrap();
+        assert!(
+            est.inliers.len() >= 8,
+            "expected ≥8 inliers, got {}",
+            est.inliers.len()
+        );
+        assert!(
+            est.inlier_rms < 1e-6,
+            "inlier RMS too large: {}",
+            est.inlier_rms
+        );
+    }
+
+    #[test]
+    fn recover_pose_robust_with_outliers() {
+        let (corrs, r_gt, t_gt) = make_stereo_corrs_with_outliers();
+
+        let opts = RansacOptions {
+            max_iters: 500,
+            thresh: 0.001,
+            min_inliers: 10,
+            confidence: 0.99,
+            seed: 42,
+            refit_on_inliers: true,
+        };
+
+        let result = recover_relative_pose_robust(&corrs, &opts).unwrap();
+
+        let r_diff = result.r.transpose() * r_gt;
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang_deg = cos_theta.acos().to_degrees();
+        assert!(ang_deg < 2.0, "rotation error: {} deg", ang_deg);
+
+        let cos_t = result.t.normalize().dot(&t_gt.normalize()).abs();
+        assert!(
+            (cos_t - 1.0).abs() < 0.01,
+            "translation direction error: cos = {}",
+            cos_t
+        );
+
+        assert!(result.inliers.len() >= 12);
+    }
+
+    #[test]
+    fn essential_ransac_deterministic_with_same_seed() {
+        let (corrs, _, _) = make_stereo_corrs_with_outliers();
+
+        let opts = RansacOptions {
+            max_iters: 200,
+            thresh: 0.001,
+            min_inliers: 10,
+            confidence: 0.99,
+            seed: 123,
+            refit_on_inliers: true,
+        };
+
+        let r1 = estimate_essential(&corrs, &opts).unwrap();
+        let r2 = estimate_essential(&corrs, &opts).unwrap();
+
+        assert_eq!(r1.inliers, r2.inliers);
+        assert!((r1.inlier_rms - r2.inlier_rms).abs() < 1e-15);
+    }
+}

--- a/crates/vision-mvg/src/robust.rs
+++ b/crates/vision-mvg/src/robust.rs
@@ -65,20 +65,28 @@ impl Estimator for EssentialEstimator {
             pts1.push(data[idx].pt1);
             pts2.push(data[idx].pt2);
         }
-        let candidates = vision_geometry::epipolar::essential_5point(&pts1, &pts2).ok()?;
 
-        // Pick the candidate with lowest total Sampson distance over the sample.
-        candidates.into_iter().min_by(|a, b| {
-            let sa: Real = sample_indices
-                .iter()
-                .map(|&i| residuals::sampson_distance(a, &data[i]))
-                .sum();
-            let sb: Real = sample_indices
-                .iter()
-                .map(|&i| residuals::sampson_distance(b, &data[i]))
-                .sum();
-            sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
-        })
+        if sample_indices.len() == 5 {
+            // Minimal case: use the 5-point solver and pick the best candidate.
+            let candidates = vision_geometry::epipolar::essential_5point(&pts1, &pts2).ok()?;
+            candidates.into_iter().min_by(|a, b| {
+                let sa: Real = sample_indices
+                    .iter()
+                    .map(|&i| residuals::sampson_distance(a, &data[i]))
+                    .sum();
+                let sb: Real = sample_indices
+                    .iter()
+                    .map(|&i| residuals::sampson_distance(b, &data[i]))
+                    .sum();
+                sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
+            })
+        } else {
+            // Overdetermined case (refit on inliers): use the linear solver which
+            // accepts any number of points ≥ 5 and projects onto the essential
+            // manifold. This avoids the silent no-op when essential_5point
+            // receives more than 5 points.
+            vision_geometry::epipolar::essential_linear(&pts1, &pts2).ok()
+        }
     }
 
     fn residual(model: &Self::Model, datum: &Self::Datum) -> f64 {
@@ -417,5 +425,64 @@ mod tests {
 
         assert_eq!(r1.inliers, r2.inliers);
         assert!((r1.inlier_rms - r2.inlier_rms).abs() < 1e-15);
+    }
+
+    /// Regression test for the RANSAC refit no-op bug.
+    ///
+    /// When `refit_on_inliers: true` and the consensus set has >5 points, the
+    /// old code called `essential_5point` with all inliers → `Err` → silent
+    /// no-op (model tied to a single 5-point sample).  The fix routes the
+    /// overdetermined case to `essential_linear`, which accepts any ≥5 points.
+    ///
+    /// We verify:
+    /// 1. `estimate_essential` succeeds and produces ≥12 inliers.
+    /// 2. The refit model satisfies the epipolar constraint on all inliers with
+    ///    a tighter RMS than the 5-point-only baseline would allow on noisy data.
+    #[test]
+    fn essential_ransac_refit_on_inliers_uses_linear_solver() {
+        let (corrs, r_gt, t_gt) = make_stereo_corrs_with_outliers();
+        let n_corrs = corrs.len();
+        assert!(n_corrs > 5, "test fixture must have >5 correspondences");
+
+        let opts_refit = RansacOptions {
+            max_iters: 500,
+            thresh: 0.001,
+            min_inliers: 10,
+            confidence: 0.99,
+            seed: 77,
+            refit_on_inliers: true,
+        };
+
+        let est = estimate_essential(&corrs, &opts_refit).expect("RANSAC with refit must succeed");
+
+        // Must have recovered a good majority of the 15 clean inliers.
+        assert!(
+            est.inliers.len() >= 12,
+            "expected ≥12 inliers after refit, got {}",
+            est.inliers.len()
+        );
+
+        // The refit model must be geometrically valid: decompose and check pose.
+        let inlier_corrs: Vec<_> = est.inliers.iter().map(|&i| corrs[i]).collect();
+        let (pts1, pts2) = crate::types::Correspondence2D::split(&inlier_corrs);
+        let (r_est, t_est) =
+            crate::cheirality::recover_pose_from_essential(&est.essential, &pts1, &pts2)
+                .expect("pose decomposition must succeed");
+
+        let r_diff = r_est.transpose() * r_gt;
+        let cos_theta = ((r_diff.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let ang_deg = cos_theta.acos().to_degrees();
+        assert!(
+            ang_deg < 2.0,
+            "rotation error after refit: {} deg (expected < 2 deg)",
+            ang_deg
+        );
+
+        let cos_t = t_est.normalize().dot(&t_gt.normalize()).abs();
+        assert!(
+            (cos_t - 1.0).abs() < 0.02,
+            "translation direction error after refit: cos_t = {} (expected ~1.0)",
+            cos_t
+        );
     }
 }

--- a/crates/vision-mvg/src/robust.rs
+++ b/crates/vision-mvg/src/robust.rs
@@ -59,16 +59,12 @@ impl Estimator for EssentialEstimator {
     const MIN_SAMPLES: usize = 5;
 
     fn fit(data: &[Self::Datum], sample_indices: &[usize]) -> Option<Self::Model> {
-        let mut pts1 = Vec::with_capacity(sample_indices.len());
-        let mut pts2 = Vec::with_capacity(sample_indices.len());
-        for &idx in sample_indices {
-            pts1.push(data[idx].pt1);
-            pts2.push(data[idx].pt2);
-        }
+        let n = sample_indices.len();
 
-        if sample_indices.len() == 5 {
-            // Minimal case: use the 5-point solver and pick the best candidate.
-            let candidates = vision_geometry::epipolar::essential_5point(&pts1, &pts2).ok()?;
+        // Shared helper: pick the candidate E that minimises the total Sampson
+        // distance over *all* sample_indices (not just the 5 used to construct
+        // the candidates).  Used for both the minimal and the 6-7 point paths.
+        let best_of = |candidates: Vec<Mat3>| -> Option<Mat3> {
             candidates.into_iter().min_by(|a, b| {
                 let sa: Real = sample_indices
                     .iter()
@@ -80,12 +76,25 @@ impl Estimator for EssentialEstimator {
                     .sum();
                 sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
             })
-        } else {
-            // Overdetermined case (refit on inliers): use the linear solver which
-            // accepts any number of points ≥ 5 and projects onto the essential
-            // manifold. This avoids the silent no-op when essential_5point
-            // receives more than 5 points.
+        };
+
+        if n >= 8 {
+            // Overdetermined case (refit on inliers): the linear solver has a
+            // 1-dimensional null space and projects onto the essential manifold.
+            let pts1: Vec<_> = sample_indices.iter().map(|&i| data[i].pt1).collect();
+            let pts2: Vec<_> = sample_indices.iter().map(|&i| data[i].pt2).collect();
             vision_geometry::epipolar::essential_linear(&pts1, &pts2).ok()
+        } else if n >= 5 {
+            // Minimal or near-minimal case (5, 6, or 7 points): use the 5-point
+            // solver on the first five correspondences, then score all candidates
+            // against the full sample_indices set to pick the best one.
+            // RANSAC guarantees n >= MIN_SAMPLES == 5, so n < 5 is unreachable.
+            let pts1: Vec<_> = sample_indices[..5].iter().map(|&i| data[i].pt1).collect();
+            let pts2: Vec<_> = sample_indices[..5].iter().map(|&i| data[i].pt2).collect();
+            let candidates = vision_geometry::epipolar::essential_5point(&pts1, &pts2).ok()?;
+            best_of(candidates)
+        } else {
+            None
         }
     }
 
@@ -484,5 +493,67 @@ mod tests {
             "translation direction error after refit: cos_t = {} (expected ~1.0)",
             cos_t
         );
+    }
+
+    /// Test that the 6-/7-point dispatch path in `EssentialEstimator::fit`
+    /// produces a valid essential matrix.
+    ///
+    /// We synthesise 7 calibrated correspondences from a known (R, t), call
+    /// `fit` directly with 7 indices, and verify:
+    ///   1. `fit` returns `Some` (not `None`).
+    ///   2. The epipolar residual `|x2ᵀ E x1|` is near-zero on all 7 points.
+    ///   3. The result lies on the essential manifold: singular values ≈ (σ, σ, 0).
+    #[test]
+    fn essential_fit_7pts_uses_5point_scored_on_all() {
+        let rot = Rotation3::from_euler_angles(0.08, -0.04, 0.15);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.25, 0.05, 0.01);
+
+        // Build 7 clean calibrated correspondences.
+        let world = [
+            Pt3::new(0.4, 0.2, 3.0),
+            Pt3::new(-0.3, 0.1, 4.0),
+            Pt3::new(0.5, -0.2, 3.5),
+            Pt3::new(-0.2, -0.3, 2.8),
+            Pt3::new(0.1, 0.4, 4.5),
+            Pt3::new(0.3, -0.4, 5.0),
+            Pt3::new(-0.4, 0.3, 3.2),
+        ];
+
+        let corrs: Vec<Correspondence2D> = world
+            .iter()
+            .map(|pw| {
+                let pc1 = pw.coords;
+                let pc2 = r * pw.coords + t;
+                Correspondence2D::new(
+                    Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z),
+                    Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z),
+                )
+            })
+            .collect();
+
+        let indices: Vec<usize> = (0..7).collect();
+        let e =
+            EssentialEstimator::fit(&corrs, &indices).expect("fit with 7 points must return Some");
+
+        // 1. Epipolar residual near zero for all 7 points.
+        let e_norm = e.norm();
+        assert!(e_norm > 0.0, "fit returned zero matrix");
+        for c in &corrs {
+            let x1 = nalgebra::Vector3::new(c.pt1.x, c.pt1.y, 1.0);
+            let x2 = nalgebra::Vector3::new(c.pt2.x, c.pt2.y, 1.0);
+            let res = (x2.transpose() * e * x1)[0].abs() / e_norm;
+            assert!(res < 1e-5, "epipolar residual too large: {:.3e}", res);
+        }
+
+        // 2. Essential manifold check: singular values ≈ (σ, σ, 0).
+        let sv = e.svd(false, false).singular_values;
+        let s_avg = (sv[0] + sv[1]) * 0.5;
+        assert!(
+            (sv[0] / s_avg - 1.0).abs() < 1e-4,
+            "sv[0] not close to sv[1]: {:?}",
+            sv
+        );
+        assert!(sv[2] / s_avg < 1e-4, "sv[2] not near zero: {:?}", sv);
     }
 }

--- a/crates/vision-mvg/src/triangulation.rs
+++ b/crates/vision-mvg/src/triangulation.rs
@@ -1,0 +1,155 @@
+//! Enhanced triangulation with quality diagnostics.
+//!
+//! Wraps the low-level DLT triangulation from `vision-geometry` and adds
+//! reprojection error computation, parallax angle measurement, and cheirality
+//! validation.
+
+use crate::types::TriangulatedPoint;
+use anyhow::Result;
+use vision_calibration_core::{Mat3, Pt2, Vec3};
+use vision_geometry::camera_matrix::Mat34;
+
+/// Triangulate a single point from two views with diagnostics.
+///
+/// `p1` and `p2` are 3×4 projection matrices. Returns a [`TriangulatedPoint`]
+/// with reprojection error, parallax angle, and cheirality flag.
+pub fn triangulate_point_two_view(
+    p1: &Mat34,
+    p2: &Mat34,
+    pt1: &Pt2,
+    pt2: &Pt2,
+) -> Result<TriangulatedPoint> {
+    let pt3 = vision_geometry::triangulation::triangulate_point_linear(&[*p1, *p2], &[*pt1, *pt2])?;
+
+    // Reprojection error.
+    let x1 = p1 * nalgebra::Vector4::new(pt3.x, pt3.y, pt3.z, 1.0);
+    let x2 = p2 * nalgebra::Vector4::new(pt3.x, pt3.y, pt3.z, 1.0);
+
+    let proj1 = Pt2::new(x1.x / x1.z, x1.y / x1.z);
+    let proj2 = Pt2::new(x2.x / x2.z, x2.y / x2.z);
+
+    let e1 = ((proj1.x - pt1.x).powi(2) + (proj1.y - pt1.y).powi(2)).sqrt();
+    let e2 = ((proj2.x - pt2.x).powi(2) + (proj2.y - pt2.y).powi(2)).sqrt();
+    let reprojection_error = ((e1 * e1 + e2 * e2) / 2.0).sqrt();
+
+    // Cheirality: positive depth in both cameras.
+    let z1 = x1.z;
+    let z2 = x2.z;
+    let in_front = z1 > 0.0 && z2 > 0.0;
+
+    // Parallax angle: angle between rays from each camera center to the point.
+    let c1 = camera_center(p1);
+    let c2 = camera_center(p2);
+    let ray1 = (pt3 - c1).normalize();
+    let ray2 = (pt3 - c2).normalize();
+    let cos_angle = ray1.dot(&ray2).clamp(-1.0, 1.0);
+    let parallax_deg = cos_angle.acos().to_degrees();
+
+    Ok(TriangulatedPoint {
+        point: pt3,
+        reprojection_error,
+        parallax_deg,
+        in_front,
+    })
+}
+
+/// Triangulate multiple correspondences from two calibrated views.
+///
+/// Camera 1 is at the origin: `P₁ = [I | 0]`. Camera 2 has relative pose
+/// `(R, t)`: `P₂ = [R | t]`. Points must be in normalized camera coordinates.
+pub fn triangulate_two_view(
+    r: &Mat3,
+    t: &Vec3,
+    pts1: &[Pt2],
+    pts2: &[Pt2],
+) -> Result<Vec<TriangulatedPoint>> {
+    if pts1.len() != pts2.len() {
+        anyhow::bail!("point count mismatch: {} vs {}", pts1.len(), pts2.len());
+    }
+
+    let p1 = Mat34::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+    let mut p2 = Mat34::zeros();
+    p2.fixed_view_mut::<3, 3>(0, 0).copy_from(r);
+    p2.set_column(3, t);
+
+    let mut results = Vec::with_capacity(pts1.len());
+    for (q1, q2) in pts1.iter().zip(pts2.iter()) {
+        results.push(triangulate_point_two_view(&p1, &p2, q1, q2)?);
+    }
+
+    Ok(results)
+}
+
+/// Extract camera center from a projection matrix.
+///
+/// For `P = [M | p₄]`, the camera center is `C = -M⁻¹ p₄`.
+fn camera_center(p: &Mat34) -> vision_calibration_core::Pt3 {
+    let m = p.fixed_view::<3, 3>(0, 0).into_owned();
+    let p4 = p.column(3).into_owned();
+    match m.try_inverse() {
+        Some(m_inv) => {
+            let c = -m_inv * p4;
+            vision_calibration_core::Pt3::new(c.x, c.y, c.z)
+        }
+        None => vision_calibration_core::Pt3::origin(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Rotation3;
+    use vision_calibration_core::Pt3;
+
+    #[test]
+    fn triangulate_two_view_noiseless() {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+
+        let world = [
+            Pt3::new(0.1, 0.2, 3.0),
+            Pt3::new(-0.2, 0.1, 2.5),
+            Pt3::new(0.3, -0.1, 4.0),
+        ];
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+        for pw in &world {
+            let pc1 = pw.coords;
+            let pc2 = r * pw.coords + t;
+            pts1.push(Pt2::new(pc1.x / pc1.z, pc1.y / pc1.z));
+            pts2.push(Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z));
+        }
+
+        let results = triangulate_two_view(&r, &t, &pts1, &pts2).unwrap();
+
+        assert_eq!(results.len(), world.len());
+        for (tp, pw) in results.iter().zip(world.iter()) {
+            let err = (tp.point - pw).norm();
+            assert!(err < 1e-6, "triangulation error too large: {}", err);
+            assert!(tp.reprojection_error < 1e-8);
+            assert!(tp.in_front);
+            assert!(tp.parallax_deg > 0.0);
+        }
+    }
+
+    #[test]
+    fn triangulate_small_baseline_has_small_parallax() {
+        let r = Mat3::identity();
+        let t = Vec3::new(0.001, 0.0, 0.0); // very small baseline
+
+        let pw = Pt3::new(0.0, 0.0, 10.0); // far away point
+        let pc2 = r * pw.coords + t;
+        let pt1 = Pt2::new(pw.x / pw.z, pw.y / pw.z);
+        let pt2 = Pt2::new(pc2.x / pc2.z, pc2.y / pc2.z);
+
+        let results = triangulate_two_view(&r, &t, &[pt1], &[pt2]).unwrap();
+
+        assert!(
+            results[0].parallax_deg < 0.01,
+            "expected small parallax for narrow baseline, got {}",
+            results[0].parallax_deg
+        );
+    }
+}

--- a/crates/vision-mvg/src/triangulation.rs
+++ b/crates/vision-mvg/src/triangulation.rs
@@ -80,6 +80,32 @@ pub fn triangulate_two_view(
     Ok(results)
 }
 
+/// Like [`triangulate_two_view`] but tolerant of per-point degeneracies.
+///
+/// Correspondences that fail to triangulate (e.g. a single on-baseline /
+/// zero-parallax outlier) are skipped instead of discarding the whole set.
+/// Returns the successfully triangulated points, which may be empty if none
+/// triangulate. The two slices must have equal length (callers pass
+/// [`Correspondence2D::split`](crate::types::Correspondence2D::split) output).
+pub fn triangulate_two_view_partial(
+    r: &Mat3,
+    t: &Vec3,
+    pts1: &[Pt2],
+    pts2: &[Pt2],
+) -> Vec<TriangulatedPoint> {
+    debug_assert_eq!(pts1.len(), pts2.len(), "point count mismatch");
+
+    let p1 = Mat34::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+    let mut p2 = Mat34::zeros();
+    p2.fixed_view_mut::<3, 3>(0, 0).copy_from(r);
+    p2.set_column(3, t);
+
+    pts1.iter()
+        .zip(pts2.iter())
+        .filter_map(|(q1, q2)| triangulate_point_two_view(&p1, &p2, q1, q2).ok())
+        .collect()
+}
+
 /// Extract camera center from a projection matrix.
 ///
 /// For `P = [M | p₄]`, the camera center is `C = -M⁻¹ p₄`.
@@ -151,5 +177,47 @@ mod tests {
             "expected small parallax for narrow baseline, got {}",
             results[0].parallax_deg
         );
+    }
+
+    #[test]
+    fn triangulate_two_view_partial_skips_degenerate_points() {
+        // r = identity, t = 0 → p1 == p2 → every point's DLT is rank-deficient.
+        // The partial variant must return an empty vec WITHOUT erroring
+        // (contrast: triangulate_two_view is all-or-nothing and would fail).
+        let r = Mat3::identity();
+        let t = Vec3::zeros();
+        let pts1 = vec![Pt2::new(0.1, 0.2), Pt2::new(-0.3, 0.4)];
+        let pts2 = pts1.clone();
+        let got = triangulate_two_view_partial(&r, &t, &pts1, &pts2);
+        assert!(
+            got.is_empty(),
+            "degenerate (zero-baseline) points must be skipped, got {}",
+            got.len()
+        );
+    }
+
+    #[test]
+    fn triangulate_two_view_partial_keeps_good_points() {
+        let rot = Rotation3::from_euler_angles(0.05, -0.03, 0.02);
+        let r = *rot.matrix();
+        let t = Vec3::new(0.3, 0.01, 0.005);
+        let world = [
+            Pt3::new(0.5, 0.3, 3.0),
+            Pt3::new(-0.4, 0.2, 4.0),
+            Pt3::new(0.6, -0.3, 5.0),
+        ];
+        let pts1: Vec<Pt2> = world
+            .iter()
+            .map(|pw| Pt2::new(pw.x / pw.z, pw.y / pw.z))
+            .collect();
+        let pts2: Vec<Pt2> = world
+            .iter()
+            .map(|pw| {
+                let pc = r * pw.coords + t;
+                Pt2::new(pc.x / pc.z, pc.y / pc.z)
+            })
+            .collect();
+        let got = triangulate_two_view_partial(&r, &t, &pts1, &pts2);
+        assert_eq!(got.len(), 3, "all valid points must be retained");
     }
 }

--- a/crates/vision-mvg/src/types.rs
+++ b/crates/vision-mvg/src/types.rs
@@ -1,0 +1,63 @@
+//! Core types for multiple-view geometry.
+//!
+//! Provides type aliases for geometric matrices and the [`Correspondence2D`]
+//! struct that serves as the primary input type for MVG estimation.
+
+use vision_calibration_core::{Mat3, Pt2, Pt3, Real};
+
+/// Essential matrix (3×3, rank-2, encodes calibrated epipolar geometry).
+pub type EssentialMatrix = Mat3;
+
+/// Fundamental matrix (3×3, rank-2, encodes uncalibrated epipolar geometry).
+pub type FundamentalMatrix = Mat3;
+
+/// Homography matrix (3×3, invertible projective transform between planes).
+pub type HomographyMatrix = Mat3;
+
+/// A pair of corresponding 2D points observed in two views.
+///
+/// For calibrated workflows, both points should be in **normalized camera
+/// coordinates** (i.e., after applying `K⁻¹`). For uncalibrated workflows,
+/// both points are in **pixel coordinates**.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Correspondence2D {
+    /// Point observed in the first view.
+    pub pt1: Pt2,
+    /// Point observed in the second view.
+    pub pt2: Pt2,
+}
+
+impl Correspondence2D {
+    /// Create a new correspondence from two 2D points.
+    pub fn new(pt1: Pt2, pt2: Pt2) -> Self {
+        Self { pt1, pt2 }
+    }
+
+    /// Split a slice of correspondences into two separate point vectors.
+    ///
+    /// This is useful for calling low-level solvers that accept `(&[Pt2], &[Pt2])`.
+    pub fn split(corrs: &[Self]) -> (Vec<Pt2>, Vec<Pt2>) {
+        let mut pts1 = Vec::with_capacity(corrs.len());
+        let mut pts2 = Vec::with_capacity(corrs.len());
+        for c in corrs {
+            pts1.push(c.pt1);
+            pts2.push(c.pt2);
+        }
+        (pts1, pts2)
+    }
+}
+
+/// A triangulated 3D point with quality diagnostics.
+#[derive(Debug, Clone)]
+pub struct TriangulatedPoint {
+    /// Reconstructed 3D position.
+    pub point: Pt3,
+    /// Root-mean-square reprojection error across the views used.
+    pub reprojection_error: Real,
+    /// Parallax angle in degrees between the observing rays.
+    ///
+    /// Small angles indicate poor triangulation geometry.
+    pub parallax_deg: Real,
+    /// Whether the point is in front of all cameras (positive depth).
+    pub in_front: bool,
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,9 +32,11 @@ lives in ADRs (`docs/adrs/`); work-in-flight lives in open PRs.
 - **New tracks (2026-06-11):** V (real-data validation on the private rtv3d dataset),
   O (apex-solver optimization backend), M (camera-model expansion — supersedes the
   former "new camera models out of scope" line).
-- **In-flight PRs:**
-  [#28 mvg](https://github.com/VitalyVorobyev/calibration-rs/pull/28) — multiple-view
-  geometry crate split (Track C, deferred until the B3 series stabilises).
+- **In-flight PRs:** none blocking. The MVG crate split (formerly PR #28 /
+  `mvg` branch) was **superseded** by a fresh additive port — `vision-geometry`
+  + `vision-mvg` landed on `main` 2026-06-14 (C1), see
+  [ADR 0015](adrs/0015-mvg-ceiling.md). The stale `mvg` branch / PR #28 can be
+  closed.
 
 ## Tracks
 
@@ -257,14 +259,20 @@ models would have multiplied variants.
 - **M4** Kannala-Brandt fisheye (new projection slot + linear-init changes —
   the biggest lift; last).
 
-### Track C — MVG (postponed; depends on diagnose viewer done)
+### Track C — MVG (C1 landed 2026-06-14)
 
-PR #28 splits two-view geometry into `vision-geometry` (deterministic solvers) and
-`vision-mvg` (pipelines, robust estimation). Post-merge the track extends to multi-view
-geometry over already-calibrated rigs. ADR 0015 will cap the ceiling explicitly: no
-in-house dense matcher, no full SfM.
+Two-view geometry is split into `vision-geometry` (deterministic solvers) and
+`vision-mvg` (pipelines, robust estimation). The track extends to multi-view
+geometry over already-calibrated rigs.
+[ADR 0015](adrs/0015-mvg-ceiling.md) caps the ceiling explicitly: no in-house
+dense matcher, no full SfM.
 
-- **C1** Land PR #28.
+- **C1 — DONE (2026-06-14).** Rather than merge the stale `mvg` branch (~136
+  commits behind, predating four current crates + a conflicting
+  `vision-calibration-linear` refactor), the two crates were **ported fresh and
+  additively** onto `main`: `vision-geometry` (20 tests) + `vision-mvg` (31
+  tests), both `publish = false`, no change to `vision-calibration-linear`. The
+  `linear`→`vision-geometry` de-duplication is a deliberate follow-up; ADR 0015.
 - **C2** N-view triangulation + nonlinear refinement.
 - **C3** Bundle adjustment with frozen intrinsics, free poses, free structure.
 - **C4** Stereo rectification — including **Scheimpflug-aware rectification** (genuinely

--- a/docs/adrs/0015-mvg-ceiling.md
+++ b/docs/adrs/0015-mvg-ceiling.md
@@ -1,0 +1,72 @@
+# ADR 0015: Multiple-View Geometry Crates and Scope Ceiling
+
+- Status: Accepted
+- Date: 2026-06-14
+
+## Context
+
+Two-view and multiple-view geometry (fundamental/essential matrices, homography,
+triangulation, camera-matrix decomposition, robust pose recovery) had grown
+inside `vision-calibration-linear`. PR #28 proposed splitting it into two
+dedicated crates on a long-lived `mvg` branch. That branch then diverged ~136
+commits behind `main` — it predates `vision-calibration-detect`,
+`vision-calibration-dataset`, `vision-calibration-bench`, and the Tauri app, and
+it carried a `vision-calibration-linear` refactor (moving solvers *out* of
+linear) that now conflicts with the many `main` callers added since. Merging the
+branch is high-risk; the **crate source itself** is clean and well-scoped.
+
+The MVG track (Track C in `docs/ROADMAP.md`) was postponed behind the Tauri
+diagnose viewer, which has since matured. This ADR also exists to cap the track's
+ceiling explicitly, as the roadmap promised.
+
+## Decision
+
+1. **Land two new crates, ported fresh and additively** from the `mvg` branch
+   source (a source port, not a branch merge) onto current `main`:
+   - **`vision-geometry`** — deterministic, allocation-light geometric solvers:
+     `math` (Hartley normalization, polynomial/SVD helpers), `epipolar`
+     (fundamental, essential, decomposition), `homography`, `triangulation`,
+     `camera_matrix`. Depends only on `vision-calibration-core` + `nalgebra` +
+     `anyhow`.
+   - **`vision-mvg`** — pipelines and estimation over the deterministic solvers:
+     `pose_recovery`, robust estimation, `cheirality`, `degeneracy`,
+     `triangulation`, `residuals`, `homography`, optional nonlinear `refine`
+     (behind a `refine` feature → `tiny-solver`). Depends on `vision-geometry` +
+     core.
+
+2. **Do not refactor `vision-calibration-linear` in this slice.** The geometry
+   crates are purely additive; `linear` keeps its existing epipolar/homography/
+   triangulation code. This guarantees zero regression to the validated
+   calibration paths. De-duplicating `linear` onto `vision-geometry` (having
+   `linear` depend on `vision-geometry`) is an explicit **follow-up**, not part
+   of landing the crates.
+
+3. **`publish = false` for now.** Both crates land internally first (their public
+   API is not yet stable). Promoting them to the crates.io publish set and the
+   release version-lockstep (see `CLAUDE.md`) is a deliberate later step.
+
+4. **Python bindings deferred** (consistent with Track A5): no PyO3 wrappers in
+   this slice; revisit after the Rust API stabilises.
+
+## Scope ceiling (explicit, per the roadmap)
+
+- **No in-house dense stereo matcher.** Dense matching, if ever added, wraps an
+  external library (`opencv-rust` SGBM) behind a feature flag (Track C5). The
+  workspace does not ship a hand-rolled dense matcher.
+- **No full structure-from-motion.** No incremental SfM, no global pose-graph
+  optimisation, no loop closure. `vision-mvg` targets geometry over already-
+  calibrated rigs (N-view triangulation, BA with frozen intrinsics,
+  rectification), not unconstrained reconstruction.
+- `vision-geometry` stays *deterministic solvers only* (no robust loops, no
+  domain policy); robust estimation and pipelines live in `vision-mvg`.
+
+## Consequences
+
+- Unblocks Track C: C2 (N-view triangulation + nonlinear refinement) and C3
+  (bundle adjustment, frozen intrinsics) build on these crates next.
+- Temporary duplication between `vision-calibration-linear` and `vision-geometry`
+  until the de-dup follow-up; both are tested independently, so behaviour is
+  pinned on each side.
+- Landing is low-risk and reversible (additive new crates, `publish = false`),
+  appropriate for an autonomous batch; the riskier branch merge is avoided
+  entirely.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,6 +36,7 @@ Status legend:
 - [0012 - Per-Feature Reprojection Residuals on Export Types](0012-per-feature-reprojection-residuals.md)
 - [0013 - rig_family Sensor-Axis Refactor (Pinhole + Scheimpflug Unification)](0013-rig-family-sensor-axis-refactor.md)
 - [0014 - Tauri 2 Desktop App for Calibration Diagnose (Track B Kickoff)](0014-tauri-desktop-app.md)
+- [0015 - Multiple-View Geometry Crates and Scope Ceiling](0015-mvg-ceiling.md)
 - [0016 - Canonical Dataset Manifest (`DatasetSpec`)](0016-dataset-manifest.md)
 - [0017 - Content-Addressed Detection Cache](0017-detection-cache.md)
 - [0018 - Schema-Driven UI for Configs and Dataset Manifests](0018-schema-driven-ui.md)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -137,6 +137,26 @@ review.
   impl (first beyond `Pinhole`), linear-init changes (Zhang assumptions
   don't hold at large FOV), synthetic wide-FOV tests.
 
+## C — MVG (multiple-view geometry)
+
+- [x] C1-CRATES - Land `vision-geometry` + `vision-mvg`. Completed 2026-06-14 —
+  [report](report/2026-06-14-C1-mvg-crates.md). Ported fresh and additively from
+  the stale `mvg` branch source (NOT a branch merge): `vision-geometry`
+  (deterministic solvers: epipolar/homography/triangulation/camera-matrix, 20
+  tests) + `vision-mvg` (pipelines/robust/pose-recovery, optional `refine`
+  feature, 31 tests), both `publish = false`. `vision-calibration-linear`
+  untouched (zero regression). [ADR 0015](adrs/0015-mvg-ceiling.md) caps the
+  ceiling (no dense matcher, no full SfM).
+- [ ] C1-FOLLOWUP - De-duplicate `vision-calibration-linear` onto
+  `vision-geometry` (have `linear` depend on the new crate, delete the moved
+  solvers). Deferred from C1 to keep landing additive; do supervised with the
+  numeric pins on both sides as the gate. Also: promote both crates to the
+  crates.io publish set + release version-lockstep when the API stabilises;
+  PyO3 bindings (deferred per A5); close the stale `mvg` branch / PR #28.
+- [ ] C2-TRIANGULATION - N-view triangulation + nonlinear refinement.
+- [ ] C3-BA - Bundle adjustment with frozen intrinsics, free poses, free
+  structure.
+
 ## B — app (extend; sequencing serves V-track)
 
 - [x] B3C-PUZZLEBOARD - PuzzleBoard detector. Completed 2026-06-14 —

--- a/docs/report/2026-06-14-C1-mvg-crates.md
+++ b/docs/report/2026-06-14-C1-mvg-crates.md
@@ -1,0 +1,48 @@
+# C1: land vision-geometry + vision-mvg (fresh additive port)
+
+**Date:** 2026-06-14
+**Scope:** Track C / C1 — bring multiple-view geometry into the workspace.
+
+## Decision
+
+The `mvg` branch (PR #28) had diverged ~136 commits behind `main`: it predates
+`vision-calibration-detect`, `-dataset`, `-bench`, and the Tauri app, and
+carried a `vision-calibration-linear` refactor (moving solvers out of `linear`)
+that conflicts with the many `main` callers added since. Merging it was deemed
+high-risk. Instead, the two crates were **ported fresh and additively** from the
+branch source — `git checkout mvg -- crates/vision-geometry crates/vision-mvg` —
+onto current `main`, with **no** `vision-calibration-linear` change. See
+[ADR 0015](../adrs/0015-mvg-ceiling.md).
+
+## What landed
+
+- **`vision-geometry`** (deterministic solvers; deps: core + nalgebra + anyhow):
+  `math`, `epipolar/{fundamental,essential,decomposition,polynomial}`,
+  `homography`, `triangulation`, `camera_matrix`. **20 unit tests pass.**
+- **`vision-mvg`** (pipelines/robust over the solvers; deps: vision-geometry +
+  core + optional tiny-solver): `pose_recovery`, `robust`, `cheirality`,
+  `degeneracy`, `triangulation`, `residuals`, `homography`, `types`, optional
+  nonlinear `refine` (feature `refine` → tiny-solver). **31 unit tests pass**
+  (incl. `--all-features`).
+- Workspace wiring: both added to `[workspace] members` + `[workspace.dependencies]`.
+- Both `publish = false` (internal-first; promote deliberately later).
+
+## Verification
+
+The crates built against current `core` with **zero API drift** (the only core
+symbols used are the stable `Pt3`/`Vec3` aliases). Gates: `cargo build`,
+`cargo test -p vision-geometry -p vision-mvg --all-features` (51 tests),
+`cargo clippy -p vision-geometry -p vision-mvg --all-targets --all-features -D
+warnings`, and the full `cargo test --workspace --all-features` (no regression)
+all green. (A transient `cc` linker error appeared once when two
+`cargo test --workspace` ran concurrently; a clean single run passed.)
+
+## Deferred (C1-FOLLOWUP)
+
+- De-duplicate `vision-calibration-linear` onto `vision-geometry` (have `linear`
+  depend on the new crate, drop the duplicated epipolar/homography/triangulation
+  code). Kept out of C1 to stay additive / zero-regression.
+- Promote both crates to the crates.io publish set + release version-lockstep
+  (CLAUDE.md) once the API stabilises.
+- PyO3 bindings (deferred per Track A5).
+- Close the stale `mvg` branch / PR #28.


### PR DESCRIPTION
## Summary

Lands **Track C / C1**: brings multiple-view geometry into the workspace as two new crates, **ported fresh and additively** from the stale `mvg` branch source.

**Why a fresh port, not a merge of PR #28 / `mvg`:** that branch is ~136 commits behind `main`, predates `vision-calibration-detect` / `-dataset` / `-bench` / the Tauri app, and carries a `vision-calibration-linear` refactor (moving solvers *out* of `linear`) that conflicts with the many `main` callers added since. The crate **source** is clean, so it was ported via `git checkout mvg -- crates/vision-geometry crates/vision-mvg` and adapted — no branch merge, **no `vision-calibration-linear` change**, zero regression to the validated calibration paths. See [ADR 0015](https://github.com/VitalyVorobyev/calibration-rs/blob/feat/mvg-geometry-crates/docs/adrs/0015-mvg-ceiling.md).

## Crates

- **`vision-geometry`** — deterministic, allocation-light solvers: `math` (Hartley norm, polynomial/SVD), `epipolar` (fundamental/essential/decomposition), `homography`, `triangulation`, `camera_matrix`. Deps: core + nalgebra + anyhow. **20 tests.**
- **`vision-mvg`** — pipelines/robust over the solvers: `pose_recovery`, `robust`, `cheirality`, `degeneracy`, `triangulation`, `residuals`, `homography`, optional nonlinear `refine` (feature → tiny-solver). Deps: vision-geometry + core. **31 tests.**

Both `publish = false` (internal-first; the only `core` symbols used are the stable `Pt3`/`Vec3` aliases, so they built against current `main` with zero API drift).

## Scope ceiling (ADR 0015)

No in-house dense stereo matcher (external `opencv-rust` SGBM only, future, feature-flagged); no full SfM. `vision-geometry` = deterministic solvers only; robust loops/pipelines live in `vision-mvg`.

## Follow-ups (tracked: backlog `C1-FOLLOWUP`)

De-duplicate `vision-calibration-linear` onto `vision-geometry`; promote both crates to the crates.io publish set + release version-lockstep when the API stabilises; PyO3 bindings (deferred per A5); close the stale `mvg` branch / PR #28.

## Gates

`cargo build`, `cargo test -p vision-geometry -p vision-mvg --all-features` (51 tests), workspace `clippy --all-targets --all-features -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, and full `cargo test --workspace --all-features` (no regression) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)