### PR TITLE
chore(optim): park apex-solver (Track O) + drop dead Ceres stub (O3)

### DIFF
--- a/crates/vision-calibration-optim/src/backend/mod.rs
+++ b/crates/vision-calibration-optim/src/backend/mod.rs
@@ -95,8 +95,6 @@ pub trait OptimBackend {
 pub enum BackendKind {
     /// tiny-solver Levenberg-Marquardt backend.
     TinySolver,
-    /// Placeholder for a Ceres backend.
-    Ceres,
 }
 
 /// Solve a problem using the selected backend.
@@ -105,7 +103,7 @@ pub enum BackendKind {
 ///
 /// # Errors
 ///
-/// Returns [`Error::Numerical`] if the solver fails or the requested backend is not available.
+/// Returns [`Error::Numerical`] if the solver fails.
 pub fn solve_with_backend(
     backend: BackendKind,
     ir: &ProblemIR,
@@ -116,6 +114,5 @@ pub fn solve_with_backend(
         BackendKind::TinySolver => TinySolverBackend
             .solve(ir, initial, opts)
             .map_err(Error::from),
-        BackendKind::Ceres => Err(Error::numerical("Ceres backend not implemented")),
     }
 }

--- a/crates/vision-calibration-optim/src/error.rs
+++ b/crates/vision-calibration-optim/src/error.rs
@@ -34,11 +34,6 @@ impl Error {
             reason: reason.into(),
         }
     }
-
-    /// Convenience constructor for [`Error::Numerical`].
-    pub(crate) fn numerical(msg: impl Into<String>) -> Self {
-        Self::Numerical(msg.into())
-    }
 }
 
 impl From<anyhow::Error> for Error {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -220,20 +220,35 @@ per device), with a legacy-system oracle calibration to beat.
 - **V6** Settle the dataset's absolute scale against the head's mechanical
   camera spacing.
 
-### Track O — Optimization backends (NEW 2026-06-11)
+### Track O — Optimization backends (O1/O2 PARKED 2026-06-15; O3 DONE)
 
-`OptimBackend` (ADR 0008) gets a second real implementation:
+The premise was that `OptimBackend` (ADR 0008) gets a second real
+implementation:
 [apex-solver](https://crates.io/crates/apex-solver) 1.3 (LM/GN/DogLeg, Lie-group
 support), behind an `apex-solver` cargo feature in `vision-calibration-optim`.
 
-- **O1** `ApexSolverBackend` implementing `OptimBackend`, mirroring
-  `compile_factor` from the tiny-solver backend. Pre-verify: whether apex-solver
-  accepts generic factors (its API is graph-flavored), SE3 quaternion order vs
-  our `[qx,qy,qz,qw,tx,ty,tz]` (round-trip unit test), S2 manifold availability
-  (fallback: R3 + renormalize), robust-loss coverage.
-- **O2** Backend A/B in bench: param parity < 1e-4 on synthetic IR, final cost
-  within 0.1 % on bench datasets, timing comparison on rtv3d.
-- **O3** Drop the `BackendKind::Ceres` stub.
+The **O1 pre-verify gate failed** (report:
+`docs/report/2026-06-14-O1-apex-solver-preverify.md`). apex-solver 1.3 is a
+**hand-Jacobian factor-graph library** (`Factor::linearize` returns a
+caller-supplied Jacobian; no generic scalar / autodiff). Our IR (ADR 0008) and
+the M0 factor generification (ADR 0020) are **autodiff-first**
+(`fn residual<T: RealField>()`, monomorphized per `CameraModelDesc`), so wiring
+apex-solver would mean hand-deriving Jacobians for every factor family —
+defeating M0 and adding correctness risk at the geometry we most need to trust.
+Secondary gaps: no S2 / unit-vector manifold (we use one for laser-plane
+normals), no documented robust losses, undocumented SE3 quaternion order.
+
+- **O1 (PARKED)** `ApexSolverBackend` — blocked on the API mismatch above. A
+  numeric-difference bridge is technically possible but slower, less accurate,
+  and requires re-deriving manifold tangent Jacobians by hand; not recommended
+  unsupervised. Reviving Track O means **choosing an autodiff-capable** Rust
+  optimizer (e.g. a `factrs`/`num-dual` stack) or keeping tiny-solver as the
+  sole backend — a user call.
+- **O2 (PARKED)** Backend A/B validation — depends on O1.
+- **O3 (DONE 2026-06-15)** Dropped the dead `BackendKind::Ceres` stub from
+  `optim/src/backend/mod.rs` (and the now-orphaned `Error::numerical` helper).
+  `BackendKind` is now a single-variant enum; `solve_with_backend` no longer has
+  an unreachable "backend not available" arm.
 
 ### Track M — Camera-model expansion (M0 DONE 2026-06-12)
 
@@ -299,9 +314,10 @@ detectors) → B3d manifest UX → B3e polish.** B3c coverage **and** B3d
 manifest UX are complete as of 2026-06-14 (all 8 topologies + all 4 detectors
 wired; sniff-folder → editable auto-manifest shipped). **B-explore /
 B-infra / B3e are the remaining app slices**; the load-bearing app path is no
-longer blocking. O1/O2 (apex-solver) are parallelizable with the V-track; M0
-(factor generification) is done and M1–M4 can proceed. C resumes now that
-B3c has landed; D is a continuous ratchet.
+longer blocking. O1/O2 (apex-solver) are **parked** (autodiff API mismatch — see
+Track O); O3 landed. M0 (factor generification) is done and M1–M4 can proceed
+(M1–M3 additive layer landed). C1 (vision-geometry + vision-mvg) has landed; D
+is a continuous ratchet.
 
 ## Out of scope (explicit)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -98,7 +98,7 @@ backend).
 - [x] O3-CERES - **DONE 2026-06-15.** Removed the `BackendKind::Ceres` stub from
   `optim/src/backend/mod.rs` plus the now-orphaned `Error::numerical` helper;
   `BackendKind` is a single-variant enum and the dispatch has no unreachable
-  arm.
+  arm. Report: `docs/report/2026-06-15-O3-CERES-drop-ceres-stub.md`.
 
 ## M — camera models (gated on M0)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -79,21 +79,26 @@ review.
   or rational) only if detector residual vector fields remain structured after
   cleaning detections.
 
-## O — apex-solver backend
+## O — apex-solver backend (O1/O2 PARKED 2026-06-15; O3 DONE)
 
-- [ ] O1-BACKEND - `ApexSolverBackend` in
-  `optim/src/backend/apex_solver_backend.rs` behind an `apex-solver` cargo
-  feature; `BackendKind::ApexSolver` + dispatch arm; mirror `compile_factor`
-  from `tiny_solver_backend.rs`. Pre-verify before coding: does apex-solver
-  1.3 accept generic `Factor` impls (its API is graph-flavored)?; SE3
-  quaternion order vs IR `[qx,qy,qz,qw,tx,ty,tz]` (write a round-trip unit
-  test); S2 manifold availability (fallback: Euclidean R3 + renormalize);
-  Huber/Cauchy/Arctan loss coverage.
-- [ ] O2-AB - Backend A/B validation: synthetic IR param parity < 1e-4;
-  bench datasets final cost within 0.1 %, reproj within 0.01 px; timing
-  comparison on rtv3d; backend selector surfaced in `calib-bench`.
-- [ ] O3-CERES - Remove the `BackendKind::Ceres` stub (F2,
-  `optim/src/backend/mod.rs:119`).
+Pre-verify failed: apex-solver 1.3 is a hand-Jacobian factor-graph library, not
+autodiff-capable — fundamentally mismatched to our autodiff-first IR (ADR 0008 /
+M0 ADR 0020). Full findings:
+`docs/report/2026-06-14-O1-apex-solver-preverify.md`. Reviving Track O is a user
+call (pick an autodiff-capable optimizer, or keep tiny-solver as the sole
+backend).
+
+- [~] O1-BACKEND - **PARKED.** `ApexSolverBackend` blocked on the autodiff API
+  mismatch (no generic scalar / dual numbers; `Factor::linearize` takes a
+  caller-supplied Jacobian). Also missing: S2 manifold (we use one for
+  laser-plane normals), documented robust losses, documented SE3 quaternion
+  order. A numeric-difference bridge is possible but slower / less accurate and
+  needs hand-derived manifold Jacobians — not recommended unsupervised.
+- [~] O2-AB - **PARKED** (depends on O1).
+- [x] O3-CERES - **DONE 2026-06-15.** Removed the `BackendKind::Ceres` stub from
+  `optim/src/backend/mod.rs` plus the now-orphaned `Error::numerical` helper;
+  `BackendKind` is a single-variant enum and the dispatch has no unreachable
+  arm.
 
 ## M — camera models (gated on M0)
 

--- a/docs/report/2026-06-14-O1-apex-solver-preverify.md
+++ b/docs/report/2026-06-14-O1-apex-solver-preverify.md
@@ -1,0 +1,67 @@
+# Track O pre-verify: apex-solver 1.3 — ON HOLD (architectural mismatch)
+
+**Date:** 2026-06-14
+**Decision:** Do **not** implement `ApexSolverBackend` against apex-solver 1.3.
+The pre-verify gate (ROADMAP Track O / backlog O1) fails on the load-bearing
+requirement. No backend code written; no branch created.
+
+## What was checked
+
+apex-solver 1.3.0 (latest, published 2026-05-07). Public API per docs.rs.
+
+## Findings
+
+1. **No autodiff — f64-only, caller-supplied Jacobians (blocker).**
+   The core `Factor` trait is:
+   ```rust
+   pub trait Factor: Send + Sync {
+       fn linearize(&self, params: &[DVector<f64>], compute_jacobian: bool)
+           -> (DVector<f64>, Option<DMatrix<f64>>);
+       fn get_dimension(&self) -> usize;
+   }
+   ```
+   The caller must supply the Jacobian (analytic or numeric). There is no
+   generic scalar, no dual numbers, no built-in autodiff or
+   numerical-differentiation.
+
+   Our optimization IR (ADR 0008) and the M0 factor generification
+   (ADR 0020) are built entirely on **autodiff-generic** factors
+   (`fn residual<T: RealField>()`), monomorphized per `CameraModelDesc`, with
+   the tiny-solver backend providing autodiff. To use apex-solver we would have
+   to hand-derive (or finite-difference) Jacobians for all four factor families
+   — `ReprojPoint` across every camera-model × `ReprojChain` combination,
+   `LaserPointToPlane`, `LaserLineDistance`, `Se3TangentPrior` — which defeats
+   the entire point of M0 and is error-prone at exactly the geometry the project
+   most needs to trust.
+
+2. **No S2 / unit-vector manifold (secondary blocker).** apex-solver exposes
+   `SE3/SE2/SO3/SO2/Rn` Lie groups but no sphere manifold. We use a custom S2
+   manifold for laser-plane normals (`UnitVector3Manifold`). Fallback (R3 +
+   renormalize) changes the problem geometry.
+
+3. **No documented robust losses.** We require Huber / Cauchy / Arctan
+   (`RobustLoss` is per-residual in the IR). apex-solver's docs show no loss /
+   robustifier hook on the factor or graph API.
+
+4. **Quaternion component order undocumented** for its `SE3` — the planned
+   round-trip vs our `[qx,qy,qz,qw,tx,ty,tz]` could not be confirmed (moot given
+   #1).
+
+## Recommendation (for the user)
+
+The roadmap premise — "apex-solver gets a second real `OptimBackend`" — assumed
+a Ceres-like API. apex-solver 1.3 is instead a hand-Jacobian factor-graph
+library, fundamentally mismatched to our autodiff-first IR. Options:
+
+- **Drop apex-solver** from Track O. If a second backend is still wanted for the
+  abstraction's sake, pick an **autodiff-capable** Rust optimizer (e.g. a
+  `factrs`/`num-dual`-based stack) or keep tiny-solver as the sole backend.
+- A **numeric-difference bridge backend** is technically possible (we already
+  evaluate `reproj_residual_model_generic` at f64), but it would be slower, less
+  accurate, and require re-deriving manifold tangent Jacobians by hand — low
+  value, real correctness risk. Not recommended as an unsupervised task.
+- **O3 (drop the `BackendKind::Ceres` stub)** is independent of apex-solver and
+  still worth doing — it removes dead code (`backend/mod.rs:119`). It is a small,
+  safe cleanup that can land on its own.
+
+Track O is parked pending the user's call on the backend choice.

--- a/docs/report/2026-06-15-O3-CERES-drop-ceres-stub.md
+++ b/docs/report/2026-06-15-O3-CERES-drop-ceres-stub.md
@@ -1,0 +1,57 @@
+# O3-CERES: drop the dead `BackendKind::Ceres` stub
+
+**Date:** 2026-06-15
+**Task:** `O3-CERES` (docs/backlog.md → Track O)
+**Scope:** Remove the unused `BackendKind::Ceres` placeholder backend and the
+helper it orphaned. Pure dead-code removal — no behavior change on any live
+path.
+
+## Scope (what changed)
+
+`BackendKind::Ceres` was a never-constructed placeholder variant whose only use
+was a dispatch arm in `solve_with_backend` that returned
+`Err(Error::numerical("Ceres backend not implemented"))`. No caller ever
+selected it (the whole codebase only ever uses `BackendKind::TinySolver`), so the
+arm was unreachable and the variant was dead API surface.
+
+- Removed the `BackendKind::Ceres` variant and its doc comment.
+- Removed the unreachable `BackendKind::Ceres => Err(...)` arm in
+  `solve_with_backend`. `BackendKind` is now a single-variant enum and the
+  `match` is exhaustive with one arm.
+- Removed the now-orphaned `Error::numerical` convenience constructor
+  (`pub(crate)`, its only caller was the deleted arm). The `Error::Numerical`
+  variant itself stays — it is still constructed by `From<anyhow::Error>`.
+- Trimmed the stale "or the requested backend is not available" clause from the
+  `solve_with_backend` `# Errors` doc, since that failure path no longer exists.
+
+This is the independent half of Track O. O1/O2 (the apex-solver second backend)
+are **parked** on an autodiff API mismatch — see
+`docs/report/2026-06-14-O1-apex-solver-preverify.md` and the Track O section of
+`docs/ROADMAP.md` / `docs/backlog.md`.
+
+## Files changed
+
+- `crates/vision-calibration-optim/src/backend/mod.rs` — drop variant + doc +
+  dispatch arm; trim `# Errors` doc.
+- `crates/vision-calibration-optim/src/error.rs` — drop the orphaned
+  `Error::numerical` helper.
+- `docs/ROADMAP.md`, `docs/backlog.md` — mark O1/O2 PARKED, O3 DONE.
+- `docs/report/2026-06-14-O1-apex-solver-preverify.md` — committed (the O1
+  pre-verify findings; previously untracked).
+
+## Validation run
+
+- `cargo build -p vision-calibration-optim` — pass.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass.
+- `cargo fmt --all -- --check` — pass.
+- `RUSTDOCFLAGS="-D warnings" cargo doc -p vision-calibration-optim --all-features --no-deps`
+  — pass (no broken intra-doc links from the trimmed doc).
+- `cargo test --workspace --all-features` — pass (45 suites, 0 failures).
+
+## Follow-ups / remaining risks
+
+- **None for O3.** It is pure removal; no live path changes.
+- `BackendKind` being a single-variant enum is intentional. If/when a second
+  backend lands (a revived Track O with an autodiff-capable optimizer), it
+  re-grows a variant and the dispatch arm comes back. Reviving Track O is a user
+  call (autodiff-capable optimizer vs. tiny-solver as sole backend).


### PR DESCRIPTION
## Track O close-out

apex-solver was the candidate second `OptimBackend` (ADR 0008). The **O1 pre-verify gate failed**: apex-solver 1.3 is a **hand-Jacobian factor-graph library** (`Factor::linearize` returns a caller-supplied Jacobian — no generic scalar / dual numbers / autodiff), fundamentally mismatched to our **autodiff-first** IR (`fn residual<T: RealField>()`, monomorphized per `CameraModelDesc`; ADR 0008 / M0 ADR 0020). Secondary gaps: no S2/unit-vector manifold (we use one for laser-plane normals), no documented robust losses, undocumented SE3 quaternion order.

**No backend code was written.** This PR records the decision and does the one independent, safe cleanup that was always worth doing.

### Changes
- **O3 — drop the dead `BackendKind::Ceres` stub** (`optim/src/backend/mod.rs`): removed the variant, its doc comment, and the unreachable `=> Err(...)` dispatch arm. `BackendKind` is now a single-variant enum; `solve_with_backend` no longer has a "backend not available" path. Also removed the now-orphaned `Error::numerical` helper (its only caller was that arm; the `Numerical` variant itself stays — still constructed by `From<anyhow::Error>`).
- **Record the decision**: commit `docs/report/2026-06-14-O1-apex-solver-preverify.md` (force-added; `docs/report/` is gitignored but prior reports are tracked the same way). Mark **O1/O2 PARKED, O3 DONE** in `docs/ROADMAP.md` + `docs/backlog.md`.

### Reviving Track O (user call)
Pick an **autodiff-capable** Rust optimizer (e.g. a `factrs`/`num-dual` stack), or keep tiny-solver as the sole backend. A numeric-difference bridge over apex-solver is technically possible but slower, less accurate, and needs hand-derived manifold tangent Jacobians — not recommended unsupervised.

### Verification
- `cargo build/clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `RUSTDOCFLAGS=-D warnings cargo doc -p vision-calibration-optim --no-deps` clean
- `cargo test --workspace --all-features` green (45 suites, 0 failures)

Pure dead-code removal + docs — no behavior change on any live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)