### PR TITLE
test(app): B-INFRA Vitest unit slice (inferExportKind / mergeConfig)

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -28,6 +28,7 @@
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
+        "vitest": "^4.1.9",
       },
     },
   },
@@ -100,6 +101,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
@@ -162,7 +165,13 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/draco3d": ["@types/draco3d@1.4.10", "", {}, "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
 
@@ -184,6 +193,22 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
@@ -191,6 +216,10 @@
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "camera-controls": ["camera-controls@3.1.2", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -207,6 +236,12 @@
     "draco3d": ["draco3d@1.5.7", "", {}, "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -268,7 +303,11 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -302,11 +341,17 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "stats-gl": ["stats-gl@2.4.2", "", { "dependencies": { "@types/three": "*", "three": "^0.170.0" } }, "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ=="],
 
     "stats.js": ["stats.js@0.17.0", "", {}, "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
 
@@ -320,7 +365,13 @@
 
     "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
@@ -342,11 +393,15 @@
 
     "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
     "webgl-constants": ["webgl-constants@1.1.1", "", {}, "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="],
 
     "webgl-sdf-generator": ["webgl-sdf-generator@1.1.1", "", {}, "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.7",
@@ -32,6 +34,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vitest": "^4.1.9"
   }
 }

--- a/app/src/store/exportShape.test.ts
+++ b/app/src/store/exportShape.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { exportKindLabel, inferExportKind } from "./exportShape";
+import type { AnyExport, ExportKind } from "./types";
+
+// inferExportKind probes a loose JSON shape and never reads
+// per_feature_residuals, so tests build minimal records and cast. Using
+// `unknown` keeps the probe fields (sensor, scheimpflug, laser_plane_cam)
+// that live outside the AnyExport interface but are part of the shape
+// contract.
+const ex = (obj: Record<string, unknown>): AnyExport => obj as unknown as AnyExport;
+
+const ALL_KINDS: ExportKind[] = [
+  "planar_intrinsics",
+  "scheimpflug_intrinsics",
+  "single_cam_handeye",
+  "laserline_device",
+  "rig_extrinsics",
+  "rig_handeye",
+  "rig_handeye_laserline",
+  "rig_laserline_device",
+  "unknown",
+];
+
+describe("inferExportKind", () => {
+  it("classifies each export shape", () => {
+    expect(inferExportKind(ex({ camera: {} }))).toBe("planar_intrinsics");
+    expect(inferExportKind(ex({ camera: {}, sensor: {} }))).toBe(
+      "scheimpflug_intrinsics",
+    );
+    expect(inferExportKind(ex({ camera: {}, scheimpflug: {} }))).toBe(
+      "scheimpflug_intrinsics",
+    );
+    expect(inferExportKind(ex({ handeye_mode: "EyeInHand" }))).toBe(
+      "single_cam_handeye",
+    );
+    expect(inferExportKind(ex({ laser_planes_cam: [] }))).toBe("laserline_device");
+    expect(inferExportKind(ex({ laser_plane_cam: {} }))).toBe("laserline_device");
+    expect(inferExportKind(ex({ cameras: [] }))).toBe("rig_extrinsics");
+    expect(inferExportKind(ex({ cameras: [], handeye_mode: "EyeToHand" }))).toBe(
+      "rig_handeye",
+    );
+    expect(inferExportKind(ex({ laser_planes_rig: [] }))).toBe(
+      "rig_laserline_device",
+    );
+    expect(
+      inferExportKind(ex({ laser_planes_rig: [], handeye_mode: "EyeToHand" })),
+    ).toBe("rig_handeye_laserline");
+  });
+
+  it("returns 'unknown' for an unrecognized shape", () => {
+    expect(inferExportKind(ex({}))).toBe("unknown");
+    expect(inferExportKind(ex({ per_feature_residuals: {} }))).toBe("unknown");
+  });
+
+  // The probe order is load-bearing: rig exports also expose legacy
+  // top-level `camera`-prefixed fields, so rig shapes must be matched
+  // before single-cam shapes (see the inferExportKind doc comment).
+  describe("probe order is shape-precedence safe", () => {
+    it("rig + laser + handeye + legacy camera → rig_handeye_laserline", () => {
+      expect(
+        inferExportKind(
+          ex({
+            laser_planes_rig: [],
+            handeye_mode: "EyeToHand",
+            cameras: [],
+            camera: {},
+            sensor: {},
+          }),
+        ),
+      ).toBe("rig_handeye_laserline");
+    });
+
+    it("rig laser without handeye → rig_laserline_device, not laserline_device", () => {
+      expect(
+        inferExportKind(ex({ laser_planes_rig: [], laser_planes_cam: [], camera: {} })),
+      ).toBe("rig_laserline_device");
+    });
+
+    it("rig hand-eye with legacy camera → rig_handeye, not single_cam_handeye", () => {
+      expect(
+        inferExportKind(ex({ cameras: [], handeye_mode: "EyeToHand", camera: {} })),
+      ).toBe("rig_handeye");
+    });
+
+    it("rig extrinsics with legacy camera+sensor → rig_extrinsics, not scheimpflug", () => {
+      expect(inferExportKind(ex({ cameras: [], camera: {}, sensor: {} }))).toBe(
+        "rig_extrinsics",
+      );
+    });
+
+    it("hand-eye single-cam outranks a bare camera shape", () => {
+      expect(inferExportKind(ex({ handeye_mode: "EyeInHand", camera: {} }))).toBe(
+        "single_cam_handeye",
+      );
+    });
+  });
+
+  // A scheimpflug discriminator (sensor/scheimpflug) without `camera` is
+  // not enough — the planar/scheimpflug probes both require `camera`.
+  it("requires `camera` for the intrinsics shapes", () => {
+    expect(inferExportKind(ex({ sensor: {} }))).toBe("unknown");
+    expect(inferExportKind(ex({ scheimpflug: {} }))).toBe("unknown");
+  });
+});
+
+describe("exportKindLabel", () => {
+  it("maps every kind to a non-empty, unique label", () => {
+    const labels = ALL_KINDS.map(exportKindLabel);
+    for (const label of labels) {
+      expect(label.length).toBeGreaterThan(0);
+    }
+    expect(new Set(labels).size).toBe(ALL_KINDS.length);
+  });
+
+  it("labels the unknown kind", () => {
+    expect(exportKindLabel("unknown")).toBe("Unknown export");
+  });
+});

--- a/app/src/workspaces/RunWorkspace/presets.test.ts
+++ b/app/src/workspaces/RunWorkspace/presets.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { mergeConfig } from "./presets";
+
+describe("mergeConfig", () => {
+  it("returns the patch when the base is not a mergeable object", () => {
+    expect(mergeConfig(5, { a: 1 })).toEqual({ a: 1 });
+    expect(mergeConfig("x", { a: 1 })).toEqual({ a: 1 });
+    expect(mergeConfig(null, { a: 1 })).toEqual({ a: 1 });
+    // Arrays are not deep-merge targets — the patch replaces them.
+    expect(mergeConfig([1, 2], { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("adds new keys and overrides scalar keys", () => {
+    expect(mergeConfig({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+    expect(mergeConfig({ a: 1 }, { a: 2 })).toEqual({ a: 2 });
+  });
+
+  it("deep-merges nested objects", () => {
+    expect(mergeConfig({ a: { x: 1, y: 2 } }, { a: { y: 3, z: 4 } })).toEqual({
+      a: { x: 1, y: 3, z: 4 },
+    });
+  });
+
+  it("replaces arrays instead of merging them", () => {
+    expect(mergeConfig({ a: [1, 2, 3] }, { a: [9] })).toEqual({ a: [9] });
+  });
+
+  it("replaces when base and patch types disagree at a key", () => {
+    // object base, scalar patch → scalar wins
+    expect(mergeConfig({ a: { x: 1 } }, { a: 5 })).toEqual({ a: 5 });
+    // scalar base, object patch → object wins
+    expect(mergeConfig({ a: 1 }, { a: { x: 1 } })).toEqual({ a: { x: 1 } });
+  });
+
+  it("treats a null patch value as an explicit override (not a deep merge)", () => {
+    // Mirrors RTV3D_JOINT_LASER_MANIFEST_OVERRIDES.upstream_calibration: null.
+    expect(mergeConfig({ upstream: { id: 1 } }, { upstream: null })).toEqual({
+      upstream: null,
+    });
+  });
+
+  it("does not mutate the base object", () => {
+    const base = { a: { x: 1 }, keep: 7 };
+    const frozen = structuredClone(base);
+    const out = mergeConfig(base, { a: { y: 2 } });
+    expect(base).toEqual(frozen); // base untouched
+    expect(out).toEqual({ a: { x: 1, y: 2 }, keep: 7 });
+    expect(out).not.toBe(base);
+  });
+
+  it("applies a realistic two-level config override", () => {
+    const defaults = {
+      sensor: { kind: "Pinhole", init_tilt_x: 0 },
+      solver: { max_iters: 100 },
+    };
+    const overrides = {
+      sensor: { kind: "Scheimpflug" },
+      handeye_init: { handeye_mode: "EyeToHand" },
+    };
+    expect(mergeConfig(defaults, overrides)).toEqual({
+      sensor: { kind: "Scheimpflug", init_tilt_x: 0 },
+      solver: { max_iters: 100 },
+      handeye_init: { handeye_mode: "EyeToHand" },
+    });
+  });
+});

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+// Pure-logic unit tests run in a Node environment — no jsdom, no Tauri,
+// no Vite plugins (React/Tailwind). The functions under test
+// (inferExportKind, exportKindLabel, mergeConfig) are dependency-free,
+// so this keeps `bun run test` fast and isolated from the app shell.
+//
+// This is the B-INFRA "Vitest unit" slice. The heavier B-INFRA items
+// (ts-rs codegen + export discriminator tag, resource_dir presets,
+// Playwright smoke tests) are deferred — see docs/backlog.md.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -223,6 +223,21 @@ backend).
 - [ ] B-INFRA - ts-rs (or specta) codegen for wire types + export
   discriminator tag (F6); `resource_dir` presets
   (`RunWorkspace/presets.ts:16`); Vitest unit + Playwright smoke tests.
+  - [x] Vitest unit slice (2026-06-15) - Vitest scaffold (`vitest@4`,
+    `vitest.config.ts` node env, `test` / `test:watch` scripts) + pure-logic
+    coverage of `inferExportKind` (every probe branch + probe-order precedence),
+    `exportKindLabel` (exhaustive), and `mergeConfig` (deep-merge / array-replace
+    / type-disagreement / null-override / base-immutability). 18 tests. Safe
+    subset — no wire change. Report:
+    `docs/report/2026-06-15-B-INFRA-vitest-unit-slice.md`.
+  - [ ] ts-rs/specta codegen + export discriminator tag (F6) - DEFERRED: a
+    risky wire change that replaces the shape-probe in `inferExportKind` with a
+    Rust-emitted tag; needs supervised design (which exports gain the tag, how
+    `AnyExport` narrows). Tracked in the report's follow-ups.
+  - [ ] `resource_dir` preset resolution (`RunWorkspace/presets.ts:16`) -
+    replace the hard-coded `REPO_ROOT` with Tauri bundle-asset resolution.
+  - [ ] Playwright smoke tests - needs a Tauri/webview harness; out of the
+    pure-logic Vitest scope.
 
 ## Benchmark
 

--- a/docs/report/2026-06-15-B-INFRA-vitest-unit-slice.md
+++ b/docs/report/2026-06-15-B-INFRA-vitest-unit-slice.md
@@ -1,0 +1,65 @@
+# B-INFRA (slice): Vitest unit tests for pure app logic
+
+**Date:** 2026-06-15
+**Task:** `B-INFRA` (docs/backlog.md → Track B) — **partial.** This is the
+"Vitest unit" deliverable only. The rest of B-INFRA (ts-rs/specta codegen +
+export discriminator tag, `resource_dir` presets, Playwright smoke tests) is
+deferred; B-INFRA stays open.
+
+## Scope (what changed)
+
+Stand up a Vitest harness in `app/` and cover the two dependency-free,
+correctness-critical helpers that currently have no tests:
+
+- `inferExportKind` (`src/store/exportShape.ts`) — the shape-probe that maps a
+  loaded calibration export's JSON to one of nine `ExportKind`s. Its **probe
+  order is load-bearing**: rig exports also carry legacy top-level
+  `camera`-prefixed fields, so rig shapes must be matched before single-cam
+  shapes. The tests pin every branch *and* the order-precedence cases, so the
+  eventual ts-rs discriminator swap (deferred) has a behavioral spec to match.
+- `exportKindLabel` (same file) — exhaustive label coverage (non-empty + unique
+  for all nine kinds).
+- `mergeConfig` (`src/workspaces/RunWorkspace/presets.ts`) — the recursive
+  deep-merge used to apply preset config/manifest overrides. Tests cover
+  deep-merge, array-replace (not merge), type-disagreement replacement, the
+  `null` explicit-override case (mirrors `upstream_calibration: null` in the
+  rtv3d joint-laser preset), and base-object immutability.
+
+Tests run in a **Node** environment (no jsdom / Tauri / Vite plugins) because
+the functions are pure — `bun run test` is fast and isolated from the app shell.
+
+## Files changed
+
+- `app/vitest.config.ts` — new; node env, `include: ["src/**/*.test.ts"]`.
+- `app/package.json` — `vitest` devDependency; `test` (`vitest run`) and
+  `test:watch` scripts.
+- `app/bun.lock` — vitest + transitive deps.
+- `app/src/store/exportShape.test.ts` — new; 10 `inferExportKind` cases + 2
+  `exportKindLabel` cases.
+- `app/src/workspaces/RunWorkspace/presets.test.ts` — new; 6 `mergeConfig`
+  cases.
+
+## Validation run
+
+- `bun run test` — pass (2 files, 18 tests).
+- `bunx tsc -b` — pass (test files type-check under the strict app tsconfig:
+  `strict`, `noUnusedLocals`, `noUnusedParameters`).
+
+Note: the Rust CI workflow does not build `app/`, so these tests are a
+local/dev safety net (run with `bun run test`), not a GitHub CI gate. Wiring an
+app test job into CI is a separate, larger change (bun setup + Playwright) and
+is out of this slice.
+
+## Follow-ups / remaining risks
+
+- **ts-rs/specta codegen + export discriminator tag (F6)** — DEFERRED, risky.
+  Replaces the `inferExportKind` shape-probe with a Rust-emitted discriminator.
+  These tests become the conformance spec for that swap. Needs supervised
+  design: which `*Export` types gain the tag, how `AnyExport` narrows on it, and
+  whether old (untagged) exports must still load.
+- **`resource_dir` presets** — `RunWorkspace/presets.ts:16` still hard-codes the
+  repo root; replace with Tauri bundle-asset resolution.
+- **Playwright smoke tests** — need a Tauri/webview harness; outside the
+  pure-logic Vitest scope.
+- **No CI gate yet** — see the validation note; the tests only run locally until
+  an app CI job is added.


### PR DESCRIPTION
## B-INFRA — Vitest unit slice (partial)

Stands up a **Vitest** harness in `app/` and covers the two dependency-free, correctness-critical helpers that had no tests. This is the safe subset of `B-INFRA`; the risky/heavier items stay deferred (see below).

### What's tested
- **`inferExportKind`** (`store/exportShape.ts`) — every probe branch across the nine `ExportKind`s, **plus the load-bearing probe-order precedence**: rig exports also carry legacy top-level `camera`-prefixed fields, so rig shapes must be matched before single-cam shapes. These cases pin a behavioral spec for the eventual ts-rs discriminator swap.
- **`exportKindLabel`** — exhaustive non-empty / unique label coverage.
- **`mergeConfig`** (`RunWorkspace/presets.ts`) — deep-merge, array-replace (not merge), type-disagreement replacement, the `null` explicit-override case (mirrors `upstream_calibration: null` in the rtv3d joint-laser preset), and base-object immutability.

18 tests, all green. Run in a **Node** environment (no jsdom / Tauri / Vite plugins) since the functions are pure.

### Scaffold
- `vitest@4` devDependency, `vitest.config.ts` (node env, `src/**/*.test.ts`), `test` / `test:watch` scripts.

### Deferred (B-INFRA stays open, sub-items in `docs/backlog.md`)
- ts-rs/specta codegen + export discriminator tag (F6) — risky wire change that replaces the shape-probe; needs supervised design. These tests are its conformance spec.
- `resource_dir` preset resolution (replace hard-coded `REPO_ROOT`).
- Playwright smoke tests (needs a Tauri/webview harness).

### Validation
- `bun run test` — pass (2 files, 18 tests)
- `bunx tsc -b` — pass (test files type-check under the strict app tsconfig)

**CI note:** the Rust CI workflow does not build `app/`, so these run as a local/dev safety net (`bun run test`), not a GitHub CI gate. Adding an app CI job (bun + Playwright) is a separate change.

Report: `docs/report/2026-06-15-B-INFRA-vitest-unit-slice.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)