### PR TITLE
feat(geometry,mvg): N-view triangulation with Gauss-Newton refinement (C2)

### DIFF
--- a/crates/vision-geometry/src/lib.rs
+++ b/crates/vision-geometry/src/lib.rs
@@ -7,10 +7,13 @@
 //!
 //! # Modules
 //!
-//! - [`math`] — Hartley normalization, polynomial solvers, SVD extraction helpers
+//! - [`math`] — DLT rank guard, plus a re-export of the shared linear-algebra
+//!   primitives (Hartley normalization, polynomial/null-space solvers) from
+//!   [`vision_calibration_core::linalg`]
 //! - [`epipolar`] — Fundamental and essential matrix estimation, decomposition
 //! - [`homography`] — Normalized DLT homography estimation with optional RANSAC
-//! - [`triangulation`] — Linear DLT triangulation from multiple views
+//! - [`triangulation`] — N-view triangulation: linear DLT + Gauss-Newton
+//!   reprojection refinement
 //! - [`camera_matrix`] — Camera projection matrix estimation and RQ decomposition
 //!
 //! # Coordinate Conventions

--- a/crates/vision-geometry/src/triangulation.rs
+++ b/crates/vision-geometry/src/triangulation.rs
@@ -1,19 +1,34 @@
-//! Linear triangulation of 3D points from multiple views.
+//! Triangulation of 3D points from multiple views.
 //!
-//! Uses a DLT formulation on the camera projection matrices and image points.
+//! [`triangulate_point_linear`] solves the homogeneous DLT system directly (a
+//! fast algebraic estimate), and [`triangulate_point`] additionally refines that
+//! estimate with Gauss-Newton iterations that minimize the geometric
+//! reprojection error across all views (the maximum-likelihood point under
+//! isotropic Gaussian image noise).
 
 use anyhow::Result;
-use nalgebra::DMatrix;
+use nalgebra::{DMatrix, Matrix3, Vector3, Vector4};
 use vision_calibration_core::{Pt2, Pt3, Real};
 
 use crate::camera_matrix::Mat34;
-use crate::math::dlt_rank_ok;
+use crate::math::{dlt_rank_ok, null_space};
 
-/// Linear triangulation from multiple views using DLT.
+/// Linear (DLT) triangulation from N ≥ 2 views.
 ///
 /// `cameras` are 3×4 projection matrices `P_i`, and `points` are their
 /// corresponding image coordinates. The returned 3D point is in the same
 /// world frame as the camera matrices.
+///
+/// The homogeneous system is solved via [`null_space`] (the smallest-singular
+/// direction of the `2N×4` design matrix), computed from the `AᵀA` symmetric
+/// eigendecomposition rather than a dense SVD — see [`null_space`] for why the
+/// SVD path is deliberately avoided.
+///
+/// # Errors
+///
+/// Returns an error if fewer than 2 views are given, the camera/point counts
+/// disagree, the system is rank-deficient (identical cameras or coincident
+/// rays / zero parallax), or the recovered point is at infinity.
 pub fn triangulate_point_linear(cameras: &[Mat34], points: &[Pt2]) -> Result<Pt3> {
     if cameras.len() < 2 {
         anyhow::bail!("need at least 2 views, got {}", cameras.len());
@@ -42,43 +57,123 @@ pub fn triangulate_point_linear(cameras: &[Mat34], points: &[Pt2]) -> Result<Pt3
         a.row_mut(r1).copy_from(&(v * row2 - row1));
     }
 
-    let svd = a.svd(true, true);
-    let sv: Vec<Real> = svd.singular_values.iter().cloned().collect();
-    let v_t = svd
-        .v_t
-        .ok_or_else(|| anyhow::anyhow!("svd failed during triangulation"))?;
+    let ns = null_space(&a)?;
 
     // The 4-column DLT triangulation matrix is well-posed at rank 3 (1-D null
-    // space).  Identical cameras or coincident rays collapse sv[2] toward zero.
-    if !dlt_rank_ok(&sv, 4, 1, 1e-7) {
+    // space). Identical cameras or coincident rays collapse the boundary
+    // singular value toward zero.
+    if !dlt_rank_ok(&ns.singular_values, 4, 1, 1e-7) {
         anyhow::bail!(
             "zero-parallax / rank-deficient triangulation system \
              (identical cameras or coincident rays)"
         );
     }
 
-    let x_h = v_t.row(v_t.nrows() - 1);
-
+    let x_h = &ns.vector;
     let w = x_h[3];
     if w.abs() <= Real::EPSILON {
         anyhow::bail!("triangulation produced an invalid point");
     }
 
-    let x = x_h[0] / w;
-    let y = x_h[1] / w;
-    let z = x_h[2] / w;
+    Ok(Pt3::new(x_h[0] / w, x_h[1] / w, x_h[2] / w))
+}
 
-    Ok(Pt3::new(x, y, z))
+/// Maximum iterations for the Gauss-Newton reprojection refinement.
+const REFINE_MAX_ITERS: usize = 10;
+/// Convergence threshold on the parameter step norm.
+const REFINE_STEP_EPS: Real = 1e-12;
+
+/// Refine a triangulated point by minimizing total squared reprojection error
+/// across all views via Gauss-Newton.
+///
+/// This is a self-contained 3-parameter least-squares solve (no external
+/// optimizer): each view contributes a 2-vector reprojection residual whose
+/// `2×3` Jacobian w.r.t. the point is formed in closed form. Starting from a
+/// good algebraic estimate (e.g. [`triangulate_point_linear`]) it converges in
+/// a handful of iterations. Views whose depth collapses (`z ≈ 0`) are skipped
+/// for that iteration; a singular normal matrix stops the refinement early and
+/// returns the best estimate so far. The result is never worse-conditioned than
+/// the input — on degenerate input it simply returns `init` unchanged.
+pub fn refine_point(init: &Pt3, cameras: &[Mat34], points: &[Pt2]) -> Pt3 {
+    let mut x = Vector3::new(init.x, init.y, init.z);
+
+    for _ in 0..REFINE_MAX_ITERS {
+        let mut jtj = Matrix3::<Real>::zeros();
+        let mut jtr = Vector3::<Real>::zeros();
+
+        for (cam, pt) in cameras.iter().zip(points.iter()) {
+            let xh = Vector4::new(x[0], x[1], x[2], 1.0);
+            let h = cam * xh;
+            if h.z.abs() <= Real::EPSILON {
+                continue;
+            }
+            let inv_z = 1.0 / h.z;
+            let proj_u = h.x * inv_z;
+            let proj_v = h.y * inv_z;
+
+            // ∂proj/∂X from the left 3×3 block M of the projection matrix:
+            //   ∂(h0/h2)/∂X = (M_row0 - proj_u · M_row2) / h2.
+            let m = cam.fixed_view::<3, 3>(0, 0);
+            let row0 = m.row(0).transpose();
+            let row1 = m.row(1).transpose();
+            let row2 = m.row(2).transpose();
+            let ju = (row0 - proj_u * row2) * inv_z;
+            let jv = (row1 - proj_v * row2) * inv_z;
+
+            let r_u = proj_u - pt.x;
+            let r_v = proj_v - pt.y;
+
+            jtj += ju * ju.transpose() + jv * jv.transpose();
+            jtr += ju * r_u + jv * r_v;
+        }
+
+        // Gauss-Newton step: solve (JᵀJ) Δ = -(Jᵀr).
+        let Some(inv) = jtj.try_inverse() else {
+            break;
+        };
+        let dx = -inv * jtr;
+        x += dx;
+        if dx.norm() < REFINE_STEP_EPS {
+            break;
+        }
+    }
+
+    Pt3::new(x[0], x[1], x[2])
+}
+
+/// Triangulate a point from N ≥ 2 views with nonlinear (reprojection) refinement.
+///
+/// Computes the [`triangulate_point_linear`] DLT estimate, then polishes it with
+/// [`refine_point`] (Gauss-Newton minimization of the geometric reprojection
+/// error). Prefer this over the bare linear solve when accuracy matters and the
+/// image observations carry noise.
+///
+/// # Errors
+///
+/// Propagates the errors of [`triangulate_point_linear`] (too few views, count
+/// mismatch, rank-deficiency, point at infinity).
+pub fn triangulate_point(cameras: &[Mat34], points: &[Pt2]) -> Result<Pt3> {
+    let init = triangulate_point_linear(cameras, points)?;
+    Ok(refine_point(&init, cameras, points))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nalgebra::Vector4;
+    use nalgebra::{Rotation3, Vector3 as NaVector3};
 
     fn project(cam: &Mat34, p: &Pt3) -> Pt2 {
         let x = cam * Vector4::new(p.x, p.y, p.z, 1.0);
         Pt2::new(x.x / x.z, x.y / x.z)
+    }
+
+    /// Build a projection matrix `P = [R | t]` from a rotation and translation.
+    fn camera(rx: Real, ry: Real, rz: Real, t: NaVector3<Real>) -> Mat34 {
+        let r = *Rotation3::from_euler_angles(rx, ry, rz).matrix();
+        let mut p = Mat34::zeros();
+        p.fixed_view_mut::<3, 3>(0, 0).copy_from(&r);
+        p.set_column(3, &t);
+        p
     }
 
     #[test]
@@ -97,13 +192,8 @@ mod tests {
     }
 
     /// Regression: two identical cameras (zero baseline) must return Err.
-    ///
-    /// Identical projection matrices produce a rank-2 DLT system (sv[2] ≈ 0),
-    /// giving a 2-D null space — the recovered 3D point is arbitrary.
-    /// The `dlt_rank_ok` check (boundary index = 2) must catch this.
     #[test]
     fn triangulation_rejects_identical_cameras() {
-        // Same camera used twice — zero baseline, no parallax.
         let cam = Mat34::new(
             800.0, 0.0, 320.0, 0.0, 0.0, 800.0, 240.0, 0.0, 0.0, 0.0, 1.0, 0.0,
         );
@@ -113,5 +203,76 @@ mod tests {
             triangulate_point_linear(&[cam, cam], &[img, img]).is_err(),
             "identical cameras (zero baseline) must return Err"
         );
+    }
+
+    /// Four spread-out views recover a noiseless point essentially exactly.
+    #[test]
+    fn triangulation_nview_recovers_point() {
+        let cams = [
+            camera(0.0, 0.0, 0.0, NaVector3::new(0.0, 0.0, 0.0)),
+            camera(0.02, -0.03, 0.01, NaVector3::new(-0.4, 0.05, 0.02)),
+            camera(-0.05, 0.04, 0.0, NaVector3::new(0.3, -0.2, 0.1)),
+            camera(0.01, 0.06, -0.02, NaVector3::new(0.1, 0.35, -0.05)),
+        ];
+        let pw = Pt3::new(0.15, -0.1, 3.0);
+        let pts: Vec<Pt2> = cams.iter().map(|c| project(c, &pw)).collect();
+
+        let est = triangulate_point(&cams, &pts).unwrap();
+        assert!(
+            (est - pw).norm() < 1e-9,
+            "n-view error: {}",
+            (est - pw).norm()
+        );
+    }
+
+    /// With per-view pixel noise, the Gauss-Newton refinement reduces the 3D
+    /// error of the linear estimate (it minimizes geometric, not algebraic,
+    /// error).
+    #[test]
+    fn refinement_improves_noisy_estimate() {
+        let cams = [
+            camera(0.0, 0.0, 0.0, NaVector3::new(0.0, 0.0, 0.0)),
+            camera(0.03, -0.02, 0.01, NaVector3::new(-0.5, 0.04, 0.03)),
+            camera(-0.04, 0.05, -0.01, NaVector3::new(0.4, -0.25, 0.08)),
+            camera(0.02, 0.05, 0.0, NaVector3::new(0.15, 0.4, -0.06)),
+            camera(-0.01, -0.04, 0.02, NaVector3::new(-0.2, -0.3, 0.12)),
+        ];
+        let pw = Pt3::new(-0.2, 0.12, 2.5);
+
+        // Deterministic, view-dependent perturbation of the image points.
+        let pts: Vec<Pt2> = cams
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let clean = project(c, &pw);
+                let n = 0.002 * ((i as Real) - 2.0); // ±a few mrad in normalized coords
+                Pt2::new(clean.x + n, clean.y - n)
+            })
+            .collect();
+
+        let lin = triangulate_point_linear(&cams, &pts).unwrap();
+        let refined = refine_point(&lin, &cams, &pts);
+
+        let err_lin = (lin - pw).norm();
+        let err_ref = (refined - pw).norm();
+        assert!(
+            err_ref <= err_lin + 1e-12,
+            "refinement worsened the estimate: lin={err_lin}, refined={err_ref}"
+        );
+    }
+
+    /// On degenerate input (zero parallax) the linear solve errors and the
+    /// refinement, given the linear estimate, must not panic.
+    #[test]
+    fn refine_point_is_safe_on_degenerate_camera() {
+        let cam = Mat34::new(
+            800.0, 0.0, 320.0, 0.0, 0.0, 800.0, 240.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+        );
+        let pw = Pt3::new(0.05, -0.02, 1.5);
+        let img = project(&cam, &pw);
+        // Refining from a reasonable guess with identical cameras returns a
+        // finite point without panicking.
+        let out = refine_point(&pw, &[cam, cam], &[img, img]);
+        assert!(out.coords.iter().all(|v| v.is_finite()));
     }
 }

--- a/crates/vision-mvg/src/lib.rs
+++ b/crates/vision-mvg/src/lib.rs
@@ -7,7 +7,7 @@
 //!   symmetric transfer error for homographies
 //! - **Cheirality**: pose disambiguation from essential matrix decomposition
 //! - **Pose recovery**: [`recover_relative_pose`] — end-to-end calibrated 2-view pose
-//! - **Triangulation**: two-view triangulation with diagnostics
+//! - **Triangulation**: two-view and N-view triangulation with diagnostics
 //!
 //! # Low-level solvers (re-exported from `vision-geometry`)
 //!

--- a/crates/vision-mvg/src/triangulation.rs
+++ b/crates/vision-mvg/src/triangulation.rs
@@ -106,6 +106,67 @@ pub fn triangulate_two_view_partial(
         .collect()
 }
 
+/// Triangulate a single point from N ≥ 2 views with refinement and diagnostics.
+///
+/// `cameras` are 3×4 projection matrices and `points` their corresponding image
+/// coordinates. Uses [`vision_geometry::triangulation::triangulate_point`]
+/// (linear DLT + Gauss-Newton reprojection refinement), then reports:
+///
+/// - `reprojection_error`: RMS reprojection error over all views,
+/// - `parallax_deg`: the **widest** parallax angle across all camera-center
+///   pairs (the best-conditioned baseline; larger ⇒ better depth constraint),
+/// - `in_front`: whether the point has positive depth in **every** view.
+///
+/// # Errors
+///
+/// Returns an error if the camera/point counts disagree, fewer than 2 views are
+/// given, or the system is degenerate (see the linear solver).
+pub fn triangulate_nview(cameras: &[Mat34], points: &[Pt2]) -> Result<TriangulatedPoint> {
+    if cameras.len() != points.len() {
+        anyhow::bail!(
+            "camera/point count mismatch: {} vs {}",
+            cameras.len(),
+            points.len()
+        );
+    }
+
+    let pt3 = vision_geometry::triangulation::triangulate_point(cameras, points)?;
+    let xh = nalgebra::Vector4::new(pt3.x, pt3.y, pt3.z, 1.0);
+
+    // RMS reprojection error + all-views cheirality.
+    let mut sq_sum = 0.0;
+    let mut in_front = true;
+    for (cam, obs) in cameras.iter().zip(points.iter()) {
+        let x = cam * xh;
+        in_front &= x.z > 0.0;
+        let proj = Pt2::new(x.x / x.z, x.y / x.z);
+        sq_sum += (proj.x - obs.x).powi(2) + (proj.y - obs.y).powi(2);
+    }
+    let reprojection_error = (sq_sum / cameras.len() as f64).sqrt();
+
+    // Widest pairwise parallax: the best baseline angle subtended at the point.
+    let centers: Vec<vision_calibration_core::Pt3> = cameras.iter().map(camera_center).collect();
+    let mut parallax_deg = 0.0_f64;
+    for i in 0..centers.len() {
+        for j in (i + 1)..centers.len() {
+            let ray_i = (pt3 - centers[i]).normalize();
+            let ray_j = (pt3 - centers[j]).normalize();
+            let cos_angle = ray_i.dot(&ray_j).clamp(-1.0, 1.0);
+            let angle = cos_angle.acos().to_degrees();
+            if angle > parallax_deg {
+                parallax_deg = angle;
+            }
+        }
+    }
+
+    Ok(TriangulatedPoint {
+        point: pt3,
+        reprojection_error,
+        parallax_deg,
+        in_front,
+    })
+}
+
 /// Extract camera center from a projection matrix.
 ///
 /// For `P = [M | p₄]`, the camera center is `C = -M⁻¹ p₄`.
@@ -194,6 +255,44 @@ mod tests {
             "degenerate (zero-baseline) points must be skipped, got {}",
             got.len()
         );
+    }
+
+    fn camera_rt(rx: f64, ry: f64, rz: f64, t: Vec3) -> Mat34 {
+        let r = *Rotation3::from_euler_angles(rx, ry, rz).matrix();
+        let mut p = Mat34::zeros();
+        p.fixed_view_mut::<3, 3>(0, 0).copy_from(&r);
+        p.set_column(3, &t);
+        p
+    }
+
+    #[test]
+    fn triangulate_nview_noiseless_diagnostics() {
+        let cams = [
+            camera_rt(0.0, 0.0, 0.0, Vec3::new(0.0, 0.0, 0.0)),
+            camera_rt(0.02, -0.03, 0.01, Vec3::new(-0.4, 0.05, 0.02)),
+            camera_rt(-0.05, 0.04, 0.0, Vec3::new(0.3, -0.2, 0.1)),
+            camera_rt(0.01, 0.06, -0.02, Vec3::new(0.1, 0.35, -0.05)),
+        ];
+        let pw = Pt3::new(0.15, -0.1, 3.0);
+        let pts: Vec<Pt2> = cams
+            .iter()
+            .map(|c| {
+                let x = c * nalgebra::Vector4::new(pw.x, pw.y, pw.z, 1.0);
+                Pt2::new(x.x / x.z, x.y / x.z)
+            })
+            .collect();
+
+        let tp = triangulate_nview(&cams, &pts).unwrap();
+        assert!((tp.point - pw).norm() < 1e-9, "n-view 3D error too large");
+        assert!(tp.reprojection_error < 1e-8);
+        assert!(tp.in_front);
+        assert!(tp.parallax_deg > 0.0);
+    }
+
+    #[test]
+    fn triangulate_nview_rejects_count_mismatch() {
+        let cam = Mat34::new(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+        assert!(triangulate_nview(&[cam, cam], &[Pt2::new(0.0, 0.0)]).is_err());
     }
 
     #[test]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -134,9 +134,9 @@ Systemic causes:
   3 moderate sites (`handeye` rotation + `ridge_llsq`, `zhang_intrinsics`) now
   route through `math::null_space` / `ridge_lstsq`; `project_to_so3` deduped
   across 5 sites. All linear/geometry/mvg + downstream optim/pipeline (golden
-  pins) tests green; clippy + doc clean. **Left:** the small/bounded
-  `triangulation.rs` `2N×4` sites (`N` = view count); `linear`→`vision-geometry`
-  helper de-dup is C1-FOLLOWUP.
+  pins) tests green; clippy + doc clean. **Closed 2026-06-17:** the last
+  `triangulation.rs` `2N×4` site now routes through `core::linalg::null_space`
+  (done as part of C2); the shared-helper de-dup landed via C1-FOLLOWUP.
 - [ ] P2-BA-DENSITY - Principled corner budget for the joint rig + hand-eye BA
   (spatially-distributed subsample preserving coverage, or per-stage decimation
   knobs). Extrinsics/hand-eye converge on a fraction of the corners; the
@@ -274,7 +274,16 @@ Systemic causes:
     release version-lockstep when MVG is ready to be first-class; PyO3 bindings
     (deferred per A5). Not required by this dedup (no published crate depends on
     geometry).
-- [ ] C2-TRIANGULATION - N-view triangulation + nonlinear refinement.
+- [x] C2-TRIANGULATION - N-view triangulation + nonlinear refinement. **Done
+  2026-06-17.** `vision-geometry` already had N-view linear DLT; added
+  `triangulate_point` (linear init + self-contained Gauss-Newton reprojection
+  refinement, no external solver) and `refine_point`, and migrated
+  `triangulate_point_linear` off the raw `svd(true,true)` onto `core::linalg::null_space`
+  — closing the last P1 SVD-hang leftover (the `triangulation.rs` `2N×4` site).
+  `vision-mvg` gains `triangulate_nview` (refined N-view + RMS reprojection,
+  widest-baseline parallax, all-views cheirality diagnostics). Synthetic-GT
+  tests: 4-view noiseless recovery, refinement-improves-noisy-estimate,
+  degenerate-camera safety, count-mismatch guard.
 - [ ] C3-BA - Bundle adjustment with frozen intrinsics, free poses, free
   structure.
 


### PR DESCRIPTION
## What

The nonlinear-refinement half of roadmap item **C2** (N-view triangulation). `vision-geometry` already had N-view linear DLT; this adds Gauss-Newton refinement and an N-view wrapper in `vision-mvg`.

## Changes

- **`vision_geometry::triangulation::refine_point`** — self-contained Gauss-Newton minimization of total squared reprojection error over the 3D point (closed-form 2×3 per-view Jacobian; no external optimizer, so `vision-geometry` stays dependency-light). **`triangulate_point`** = linear DLT init + refine — the maximum-likelihood point under isotropic image noise.
- **`triangulate_point_linear`** now solves the homogeneous `2N×4` system via `core::linalg::null_space` (AᵀA symmetric eigen) instead of `svd(true, true)` — **closing the last P1 SVD-hang leftover** (the triangulation `2N×4` site noted in the P1 backlog).
- **`vision_mvg::triangulation::triangulate_nview`** — refined N-view triangulation returning a `TriangulatedPoint` with RMS reprojection error, widest-baseline parallax, and all-views cheirality.

## Tests (synthetic ground-truth)

- 4-view noiseless recovery to `1e-9`
- refinement never worsens a noisy 5-view estimate (geometric vs algebraic error)
- degenerate-camera safety (no panic), count-mismatch guard
- existing two-view geometry/mvg suites unchanged

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (**676 tests**, +5 new)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` ✓
- `python3 -m compileall …` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)