### PR TITLE
chore(docs): enforce missing_docs workspace-wide + document public items (D2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ tiny-solver = "0.18"
 faer = "0.23"
 faer-ext = "0.7"
 criterion = "0.5"
+
+[workspace.lints.rust]
+missing_docs = "warn"

--- a/crates/vision-calibration-bench/Cargo.toml
+++ b/crates/vision-calibration-bench/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 rust-version.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 default = ["tier-a"]
 tier-a = []

--- a/crates/vision-calibration-bench/src/bin/calib_bench.rs
+++ b/crates/vision-calibration-bench/src/bin/calib_bench.rs
@@ -1,3 +1,5 @@
+//! Command-line runner for the `calibration-rs` benchmark suite.
+
 use std::io::Read;
 use std::path::{Path, PathBuf};
 

--- a/crates/vision-calibration-bench/src/lib.rs
+++ b/crates/vision-calibration-bench/src/lib.rs
@@ -1,3 +1,6 @@
+//! Benchmarking harness for `calibration-rs`: dataset registry, metric
+//! records, stability testing, and cross-validation runners.
+
 pub mod compare;
 pub mod crossval;
 #[cfg(feature = "tier-b")]

--- a/crates/vision-calibration-bench/src/record.rs
+++ b/crates/vision-calibration-bench/src/record.rs
@@ -211,27 +211,39 @@ pub struct CameraArtifact {
 /// Scalar pinhole intrinsic parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct IntrinsicsArtifact {
+    /// Horizontal focal length in pixels.
     pub fx: f64,
+    /// Vertical focal length in pixels.
     pub fy: f64,
+    /// Principal-point x-coordinate in pixels.
     pub cx: f64,
+    /// Principal-point y-coordinate in pixels.
     pub cy: f64,
+    /// Pixel skew coefficient (zero for square pixels).
     pub skew: f64,
 }
 
 /// Brown-Conrady 5-parameter distortion model.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct DistortionArtifact {
+    /// First radial distortion coefficient.
     pub k1: f64,
+    /// Second radial distortion coefficient.
     pub k2: f64,
+    /// Third radial distortion coefficient (fixed to zero by default).
     pub k3: f64,
+    /// First tangential distortion coefficient.
     pub p1: f64,
+    /// Second tangential distortion coefficient.
     pub p2: f64,
 }
 
 /// Scheimpflug sensor tilt artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ScheimpflugArtifact {
+    /// Sensor tilt angle about the x-axis in radians.
     pub tilt_x_rad: f64,
+    /// Sensor tilt angle about the y-axis in radians.
     pub tilt_y_rad: f64,
 }
 

--- a/crates/vision-calibration-bench/src/run.rs
+++ b/crates/vision-calibration-bench/src/run.rs
@@ -244,34 +244,58 @@ pub mod tier_b {
     /// Refined camera parameters used in the diagnostic output.
     #[derive(Debug, Clone, serde::Serialize)]
     pub struct IntrinsicsParamReport {
+        /// Horizontal focal length in pixels.
         pub fx: f64,
+        /// Vertical focal length in pixels.
         pub fy: f64,
+        /// Principal-point x-coordinate in pixels.
         pub cx: f64,
+        /// Principal-point y-coordinate in pixels.
         pub cy: f64,
+        /// Pixel skew coefficient.
         pub skew: f64,
+        /// First radial distortion coefficient.
         pub k1: f64,
+        /// Second radial distortion coefficient.
         pub k2: f64,
+        /// Third radial distortion coefficient.
         pub k3: f64,
+        /// First tangential distortion coefficient.
         pub p1: f64,
+        /// Second tangential distortion coefficient.
         pub p2: f64,
+        /// Scheimpflug tilt angle about the x-axis in radians.
         pub tau_x: f64,
+        /// Scheimpflug tilt angle about the y-axis in radians.
         pub tau_y: f64,
     }
 
     /// Residual distribution for raw Euclidean reprojection errors.
     #[derive(Debug, Clone, serde::Serialize)]
     pub struct IntrinsicsResidualStats {
+        /// Mean reprojection error in pixels.
         pub mean: f64,
+        /// Root-mean-square reprojection error in pixels.
         pub rms: f64,
+        /// Median reprojection error in pixels.
         pub median: f64,
+        /// 90th-percentile reprojection error in pixels.
         pub p90: f64,
+        /// 95th-percentile reprojection error in pixels.
         pub p95: f64,
+        /// 99th-percentile reprojection error in pixels.
         pub p99: f64,
+        /// Maximum reprojection error in pixels.
         pub max: f64,
+        /// Total number of reprojected feature observations.
         pub count: usize,
+        /// Number of observations with error ≤ 0.4 px.
         pub count_le_0_4: usize,
+        /// Number of observations with error ≤ 1 px.
         pub count_le_1: usize,
+        /// Number of observations with error > 2 px.
         pub count_gt_2: usize,
+        /// Number of observations with error > 5 px.
         pub count_gt_5: usize,
         /// Diagnostic only; never used to satisfy the quality gate.
         pub trimmed_mean_95: f64,
@@ -280,18 +304,26 @@ pub mod tier_b {
     /// Residual statistics for one target pose/view.
     #[derive(Debug, Clone, serde::Serialize)]
     pub struct IntrinsicsPoseStats {
+        /// Zero-based index of the target pose (view).
         pub pose: usize,
+        /// Residual statistics for this pose.
         pub stats: IntrinsicsResidualStats,
     }
 
     /// One large-residual feature for drill-down.
     #[derive(Debug, Clone, serde::Serialize)]
     pub struct IntrinsicsOutlier {
+        /// Zero-based index of the target pose containing this outlier.
         pub pose: usize,
+        /// Zero-based index of the feature within the pose.
         pub feature: usize,
+        /// 3-D target point in metres.
         pub target_xyz_m: [f64; 3],
+        /// Observed image coordinate in pixels.
         pub observed_px: [f64; 2],
+        /// Projected image coordinate in pixels, or `None` if projection failed.
         pub projected_px: Option<[f64; 2]>,
+        /// Euclidean reprojection error in pixels.
         pub error_px: f64,
     }
 

--- a/crates/vision-calibration-core/Cargo.toml
+++ b/crates/vision-calibration-core/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 tracing = ["dep:tracing"]
 schemars = ["dep:schemars"]

--- a/crates/vision-calibration-core/src/error.rs
+++ b/crates/vision-calibration-core/src/error.rs
@@ -6,11 +6,19 @@
 pub enum Error {
     /// Input data is invalid (e.g. mismatched lengths, negative weights).
     #[error("invalid input: {reason}")]
-    InvalidInput { reason: String },
+    InvalidInput {
+        /// Human-readable description of why the input was rejected.
+        reason: String,
+    },
 
     /// Not enough data to proceed (e.g. fewer correspondences than required).
     #[error("insufficient data: need {need}, got {got}")]
-    InsufficientData { need: usize, got: usize },
+    InsufficientData {
+        /// Minimum number of observations required.
+        need: usize,
+        /// Actual number of observations supplied.
+        got: usize,
+    },
 
     /// A matrix inversion or decomposition produced a degenerate result.
     #[error("singular matrix or degenerate configuration")]

--- a/crates/vision-calibration-dataset/Cargo.toml
+++ b/crates/vision-calibration-dataset/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 schemars = ["dep:schemars"]
 # CLI-only: pulls in a TOML serializer for the `generate-manifest` binary.

--- a/crates/vision-calibration-detect/Cargo.toml
+++ b/crates/vision-calibration-detect/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["chessboard", "charuco", "puzzleboard", "ringgrid"]
 chessboard = ["dep:calib-targets", "dep:chess-corners"]

--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -11,6 +11,12 @@ publish = false
 [workspace]
 resolver = "2"
 
+[workspace.lints.rust]
+missing_docs = "warn"
+
+[lints]
+workspace = true
+
 [dependencies]
 vision-calibration = { path = "../vision-calibration", version = "0.5.1" }
 vision-calibration-core = { path = "../vision-calibration-core", version = "0.5.1" }

--- a/crates/vision-calibration-linear/Cargo.toml
+++ b/crates/vision-calibration-linear/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 vision-calibration-core = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/vision-calibration-linear/benches/linear_init.rs
+++ b/crates/vision-calibration-linear/benches/linear_init.rs
@@ -6,6 +6,8 @@
 //! for >15 min on dense real data). Deterministic synthetic data keeps the
 //! numbers comparable across runs.
 
+#![allow(missing_docs)]
+
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use nalgebra::{UnitQuaternion, Vector3};
 use vision_calibration_core::{

--- a/crates/vision-calibration-linear/src/error.rs
+++ b/crates/vision-calibration-linear/src/error.rs
@@ -9,11 +9,19 @@ use vision_calibration_core::linalg::MathError;
 pub enum Error {
     /// Input data is invalid (e.g. mismatched lengths, wrong point count).
     #[error("invalid input: {reason}")]
-    InvalidInput { reason: String },
+    InvalidInput {
+        /// Human-readable description of why the input was rejected.
+        reason: String,
+    },
 
     /// Not enough data to proceed (e.g. fewer correspondences than required).
     #[error("insufficient data: need {need}, got {got}")]
-    InsufficientData { need: usize, got: usize },
+    InsufficientData {
+        /// Minimum number of observations required.
+        need: usize,
+        /// Actual number of observations supplied.
+        got: usize,
+    },
 
     /// A matrix inversion or decomposition produced a degenerate result.
     #[error("singular matrix or degenerate configuration")]

--- a/crates/vision-calibration-linear/tests/stereo_linear.rs
+++ b/crates/vision-calibration-linear/tests/stereo_linear.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;

--- a/crates/vision-calibration-optim/Cargo.toml
+++ b/crates/vision-calibration-optim/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 schemars = ["dep:schemars", "vision-calibration-core/schemars"]
 

--- a/crates/vision-calibration-optim/benches/ba_iter.rs
+++ b/crates/vision-calibration-optim/benches/ba_iter.rs
@@ -6,6 +6,8 @@
 //! measure P3 backend work (autodiff Jacobian vs JᵀJ assembly vs linear solve).
 //! Deterministic synthetic data keeps the numbers comparable across runs.
 
+#![allow(missing_docs)]
+
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use nalgebra::{UnitQuaternion, Vector3};
 use vision_calibration_core::{

--- a/crates/vision-calibration-optim/src/error.rs
+++ b/crates/vision-calibration-optim/src/error.rs
@@ -8,11 +8,19 @@ use vision_calibration_core::Error as CoreError;
 pub enum Error {
     /// Input data is invalid (e.g. mismatched lengths, wrong parameter count).
     #[error("invalid input: {reason}")]
-    InvalidInput { reason: String },
+    InvalidInput {
+        /// Human-readable description of why the input was rejected.
+        reason: String,
+    },
 
     /// Not enough data to proceed.
     #[error("insufficient data: need {need}, got {got}")]
-    InsufficientData { need: usize, got: usize },
+    InsufficientData {
+        /// Minimum number of observations required.
+        need: usize,
+        /// Actual number of observations supplied.
+        got: usize,
+    },
 
     /// A matrix inversion or decomposition produced a degenerate result.
     #[error("singular matrix or degenerate configuration")]

--- a/crates/vision-calibration-optim/tests/planar_intrinsics.rs
+++ b/crates/vision-calibration-optim/tests/planar_intrinsics.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use nalgebra::{UnitQuaternion, Vector3};
 use vision_calibration_core::{
     BrownConrady5, CorrespondenceView, DistortionFixMask, FxFyCxCySkew, IntrinsicsFixMask, Iso3,

--- a/crates/vision-calibration-pipeline/Cargo.toml
+++ b/crates/vision-calibration-pipeline/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 schemars = [
     "dep:schemars",

--- a/crates/vision-calibration-pipeline/src/error.rs
+++ b/crates/vision-calibration-pipeline/src/error.rs
@@ -10,15 +10,26 @@ use vision_calibration_optim::Error as OptimError;
 pub enum Error {
     /// An argument violates a documented precondition.
     #[error("invalid input: {reason}")]
-    InvalidInput { reason: String },
+    InvalidInput {
+        /// Human-readable description of why the input was rejected.
+        reason: String,
+    },
 
     /// Not enough observations to proceed.
     #[error("insufficient data: need {need}, got {got}")]
-    InsufficientData { need: usize, got: usize },
+    InsufficientData {
+        /// Minimum number of observations required.
+        need: usize,
+        /// Actual number of observations supplied.
+        got: usize,
+    },
 
     /// A required resource (input, state, output) was not yet set in the session.
     #[error("session resource not available: {resource}")]
-    NotAvailable { resource: &'static str },
+    NotAvailable {
+        /// Name of the session resource that was expected but not yet populated.
+        resource: &'static str,
+    },
 
     /// A numerical failure (singular matrix, divergence, etc.).
     #[error("numerical failure: {0}")]

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
@@ -128,6 +128,7 @@ pub enum RigExtrinsicsOutput {
 }
 
 impl RigExtrinsicsOutput {
+    /// Final solver cost after bundle adjustment converged.
     pub fn final_cost(&self) -> f64 {
         match self {
             Self::Pinhole(e) => e.report.final_cost,
@@ -135,6 +136,7 @@ impl RigExtrinsicsOutput {
         }
     }
 
+    /// Mean reprojection error in pixels across all observations and cameras.
     pub fn mean_reproj_error(&self) -> f64 {
         match self {
             Self::Pinhole(e) => e.mean_reproj_error,
@@ -142,6 +144,7 @@ impl RigExtrinsicsOutput {
         }
     }
 
+    /// Calibrated pinhole intrinsics for each rig camera.
     pub fn cameras(&self) -> &[PinholeCamera] {
         match self {
             Self::Pinhole(e) => &e.params.cameras,
@@ -149,6 +152,7 @@ impl RigExtrinsicsOutput {
         }
     }
 
+    /// Per-camera extrinsics `T_C_R` (camera-from-rig SE(3) transforms).
     pub fn cam_to_rig(&self) -> &[Iso3] {
         match self {
             Self::Pinhole(e) => &e.params.cam_to_rig,
@@ -156,6 +160,7 @@ impl RigExtrinsicsOutput {
         }
     }
 
+    /// Per-pose rig-from-target transforms `T_R_Tgt` estimated during BA.
     pub fn rig_from_target(&self) -> &[Iso3] {
         match self {
             Self::Pinhole(e) => &e.params.rig_from_target,
@@ -163,6 +168,7 @@ impl RigExtrinsicsOutput {
         }
     }
 
+    /// Per-camera Scheimpflug sensor tilt parameters, or `None` for pinhole rigs.
     pub fn sensors(&self) -> Option<&[ScheimpflugParams]> {
         match self {
             Self::Pinhole(_) => None,
@@ -170,6 +176,7 @@ impl RigExtrinsicsOutput {
         }
     }
 
+    /// Mean reprojection error in pixels for each individual camera.
     pub fn per_cam_reproj_errors(&self) -> &[f64] {
         match self {
             Self::Pinhole(e) => &e.per_cam_reproj_errors,

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -225,6 +225,7 @@ pub enum RigHandeyeOutput {
 }
 
 impl RigHandeyeOutput {
+    /// Final solver cost after bundle adjustment converged.
     pub fn final_cost(&self) -> f64 {
         match self {
             Self::Pinhole(e) => e.report.final_cost,
@@ -232,6 +233,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Mean reprojection error in pixels across all observations and cameras.
     pub fn mean_reproj_error(&self) -> f64 {
         match self {
             Self::Pinhole(e) => e.mean_reproj_error,
@@ -239,6 +241,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Calibrated pinhole intrinsics for each rig camera.
     pub fn cameras(&self) -> &[PinholeCamera] {
         match self {
             Self::Pinhole(e) => &e.params.cameras,
@@ -246,6 +249,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Per-camera extrinsics `T_C_R` (camera-from-rig SE(3) transforms).
     pub fn cam_to_rig(&self) -> &[Iso3] {
         match self {
             Self::Pinhole(e) => &e.params.cam_to_rig,
@@ -253,6 +257,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Per-robot-pose target-from-rig transforms estimated during BA.
     pub fn target_poses(&self) -> &[Iso3] {
         match self {
             Self::Pinhole(e) => &e.params.target_poses,
@@ -260,6 +265,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Calibrated hand-eye transform `T_EEF_Rig` (end-effector-from-rig).
     pub fn handeye(&self) -> &Iso3 {
         match self {
             Self::Pinhole(e) => &e.params.handeye,
@@ -267,6 +273,8 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Per-pose robot se(3) correction deltas `[rx, ry, rz, tx, ty, tz]`, or
+    /// `None` when robot-pose refinement was not enabled.
     pub fn robot_deltas(&self) -> Option<&[[f64; 6]]> {
         match self {
             Self::Pinhole(e) => e.robot_deltas.as_deref(),
@@ -274,6 +282,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Per-camera Scheimpflug sensor tilt parameters, or `None` for pinhole rigs.
     pub fn sensors(&self) -> Option<&[ScheimpflugParams]> {
         match self {
             Self::Pinhole(_) => None,
@@ -281,6 +290,7 @@ impl RigHandeyeOutput {
         }
     }
 
+    /// Mean reprojection error in pixels for each individual camera.
     pub fn per_cam_reproj_errors(&self) -> &[f64] {
         match self {
             Self::Pinhole(e) => &e.per_cam_reproj_errors,

--- a/crates/vision-calibration-pipeline/tests/json_contract_traits.rs
+++ b/crates/vision-calibration-pipeline/tests/json_contract_traits.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use serde::{Serialize, de::DeserializeOwned};
 use vision_calibration_pipeline::{
     laserline_device::{

--- a/crates/vision-calibration-pipeline/tests/laserline_device.rs
+++ b/crates/vision-calibration-pipeline/tests/laserline_device.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use nalgebra::{Point3, Rotation3, Translation3, Vector3};
 use vision_calibration_core::{
     BrownConrady5, Camera, CorrespondenceView, FxFyCxCySkew, Iso3, Pinhole, Pt2, Pt3,

--- a/crates/vision-calibration-py/Cargo.toml
+++ b/crates/vision-calibration-py/Cargo.toml
@@ -12,6 +12,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "_vision_calibration"
 crate-type = ["cdylib"]

--- a/crates/vision-calibration-py/build.rs
+++ b/crates/vision-calibration-py/build.rs
@@ -1,3 +1,5 @@
+//! Build script for `vision-calibration-py`: configures PyO3 extension-module link args.
+
 fn main() {
     pyo3_build_config::add_extension_module_link_args();
 }

--- a/crates/vision-calibration-py/src/lib.rs
+++ b/crates/vision-calibration-py/src/lib.rs
@@ -1,3 +1,6 @@
+//! PyO3 extension module (`_vision_calibration`) exposing the
+//! `vision-calibration` Rust API to Python.
+
 use pyo3::exceptions::{PyRuntimeError, PyTypeError};
 use pyo3::prelude::*;
 use pythonize::{depythonize, pythonize};

--- a/crates/vision-calibration/Cargo.toml
+++ b/crates/vision-calibration/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 vision-calibration-core.workspace = true
 vision-calibration-linear.workspace = true

--- a/crates/vision-calibration/tests/facade_compile_surface.rs
+++ b/crates/vision-calibration/tests/facade_compile_surface.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use vision_calibration::*;
 
 #[test]

--- a/crates/vision-calibration/tests/scheimpflug_intrinsics.rs
+++ b/crates/vision-calibration/tests/scheimpflug_intrinsics.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use nalgebra::{Rotation3, Translation3};
 use vision_calibration::core::{
     BrownConrady5, Camera, CorrespondenceView, FxFyCxCySkew, Iso3, Pinhole, PlanarDataset, Pt2,

--- a/crates/vision-geometry/Cargo.toml
+++ b/crates/vision-geometry/Cargo.toml
@@ -14,6 +14,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 vision-calibration-core = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/vision-mvg/Cargo.toml
+++ b/crates/vision-mvg/Cargo.toml
@@ -14,6 +14,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 refine = ["dep:tiny-solver"]
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -325,7 +325,12 @@ dense matcher, no full SfM.
 ### Track D — Earn v1.0 (continuous ratchet)
 
 - **D1** Typed errors only — no `String`-typed escape hatches in public APIs.
-- **D2** Doc-warning-free, MSRV pinned at v1.0 cut (currently 1.93).
+- **D2** Doc-warning-free, MSRV pinned at v1.0 cut (currently 1.93). **Ratchet
+  landed 2026-06-17:** `[workspace.lints.rust] missing_docs = "warn"` enforced
+  across every member crate (CI clippy `-D warnings` makes it a hard gate); all
+  public items documented. The `RUSTDOCFLAGS="-D warnings"` rustdoc gate was
+  already clean. Test/bench targets carry a local `#![allow(missing_docs)]`
+  (not public API).
 - **D3** Python binding parity audited at every minor version bump.
 - **D4** v1.0 release once the puzzle rig runs green end-to-end via the Tauri app,
   PR #28 + the diagnose viewer + C4 have all landed, and the API has been stable across two minor

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## What

Track D / **D2** ratchet. The `RUSTDOCFLAGS="-D warnings"` rustdoc gate was already clean (no broken links), but undocumented **public items** weren't caught anywhere. This makes doc completeness a hard CI gate.

## Changes

- **`[workspace.lints.rust] missing_docs = "warn"`** in the root `Cargo.toml`, with **`[lints] workspace = true`** in every member crate (and the standalone `examples-private` workspace). CI clippy (`-D warnings`) escalates the warning to an error, so any new undocumented public item now fails CI.
- **Documented the ~45 previously-undocumented public items:**
  - error-enum struct fields (`reason` / `need` / `got` / `resource`) in core / linear / optim / pipeline
  - `RigExtrinsicsOutput` (7) + `RigHandeyeOutput` (9) accessor methods
  - bench `record.rs` / `run.rs` report structs + crate-level docs
  - crate-level docs for `vision-calibration-py` lib + build script
- Test/bench targets carry a local `#![allow(missing_docs)]` — their helpers are not public API.

**No logic changes** — doc comments + Cargo.toml lint config only.

## Verification

- `RUSTFLAGS="-W missing_docs" cargo build --workspace --all-targets` → **0** missing-docs
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)