### PR TITLE
chore(release): promote vision-geometry + vision-mvg to the publish set

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,14 +129,25 @@ update **all four** in the same commit, or the release tag will wedge
 in CI:
 
 1. `Cargo.toml` `workspace.package.version` (line ~21).
-2. `Cargo.toml` `[workspace.dependencies]` path-dep pins for the seven
-   workspace crates (`vision-calibration*`, lines ~33–39).
+2. `Cargo.toml` `[workspace.dependencies]` path-dep pins for the nine
+   publishable workspace crates (`vision-calibration*` plus
+   `vision-geometry` and `vision-mvg`, lines ~33–45).
 3. `crates/vision-calibration-py/pyproject.toml` `project.version` —
    the one that `release-pypi.yml`'s `Verify tag/version sync` job
    reads directly. **Not** wired into `[workspace.package]`.
 4. `crates/vision-calibration-examples-private/Cargo.toml` (1 package
    version + 4 path-dep pins). Out of the publish set but still
    compiled in CI.
+
+**Publish set (2026-06-17):** `vision-geometry` and `vision-mvg` joined the
+publish set — nine publishable crates total. Crates.io publish order follows
+the dependency DAG: `vision-calibration-core` → `vision-geometry` →
+`vision-calibration-linear` → `vision-calibration-optim` →
+`vision-mvg` → `vision-calibration-pipeline` → `vision-calibration` →
+`vision-calibration-py`. `vision-geometry`/`vision-mvg` have never been
+published, so their first crates.io version is the current workspace version
+(a fresh `0.x` crate may be published at `0.5.1`); the already-published crates
+only need re-publishing on the next workspace-wide version bump.
 
 `Cargo.lock` refreshes by running `cargo build --workspace` once after
 the `.toml` edits — only the workspace crate `version` strings change

--- a/crates/vision-geometry/Cargo.toml
+++ b/crates/vision-geometry/Cargo.toml
@@ -1,8 +1,5 @@
 [package]
 name = "vision-geometry"
-# Not yet published to crates.io — landed internally first (API not stable).
-# Promote to the publish set + release version-lockstep deliberately (see CLAUDE.md).
-publish = false
 readme = "README.md"
 description = "Shared geometric solvers: epipolar geometry, homography, triangulation, camera matrix"
 keywords = ["computer-vision", "geometry", "epipolar", "homography", "triangulation"]

--- a/crates/vision-mvg/Cargo.toml
+++ b/crates/vision-mvg/Cargo.toml
@@ -1,8 +1,5 @@
 [package]
 name = "vision-mvg"
-# Not yet published to crates.io — landed internally first (API not stable).
-# Promote to the publish set + release version-lockstep deliberately (see CLAUDE.md).
-publish = false
 readme = "README.md"
 description = "Multiple-view geometry: epipolar geometry, triangulation, homography, robust estimation"
 keywords = ["computer-vision", "geometry", "epipolar", "stereo", "triangulation"]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -270,10 +270,14 @@ Systemic causes:
     numeric equivalence (golden pins on both sides as the gate) before
     collapsing — not a safe unsupervised swap. Whether the shared home is
     `core`, `geometry`, or a new crate is part of that design.
-  - [ ] Promote `vision-geometry` / `vision-mvg` to the crates.io publish set +
-    release version-lockstep when MVG is ready to be first-class; PyO3 bindings
-    (deferred per A5). Not required by this dedup (no published crate depends on
-    geometry).
+  - [x] Promote `vision-geometry` / `vision-mvg` to the crates.io publish set.
+    **Done 2026-06-17** (user call): `publish = false` removed from both; the
+    `[workspace.dependencies]` version pins were already in place; release
+    version-lockstep doc updated to nine publishable crates with the publish
+    order. The actual first `cargo publish` is a manual step the user drives.
+  - [ ] PyO3 bindings for the MVG surface — **deferred** (A5 Python parity was
+    dropped: no Python consumer, and the py crate binds the calibration facade
+    only). Revisit if a consumer appears.
 - [x] C2-TRIANGULATION - N-view triangulation + nonlinear refinement. **Done
   2026-06-17.** `vision-geometry` already had N-view linear DLT; added
   `triangulate_point` (linear init + self-contained Gauss-Newton reprojection


### PR DESCRIPTION
## What

Makes `vision-geometry` and `vision-mvg` first-class, crates.io-publishable workspace members (C1-FOLLOWUP). Removes `publish = false` from both.

## Why now

You opted to make MVG first-class. Note this is **not** a release-blocker fix — the math dedup (#67) that originally would have forced it now routes through `core::linalg`, so no published crate depends on `vision-geometry`. This is a deliberate promotion.

## Changes

- Remove `publish = false` from `vision-geometry` and `vision-mvg`. The `[workspace.dependencies]` `version = "0.5.1"` pins were already in place; the dependency closure is publishable (`vision-geometry` → core; `vision-mvg` → geometry + core + optional tiny-solver).
- Update the CLAUDE.md release **version-lockstep** section to **nine** publishable crates and document the crates.io publish order (core → geometry → linear → optim → mvg → pipeline → facade → py).
- Backlog: C1-FOLLOWUP publish sub-item marked done; PyO3 explicitly deferred (A5 dropped, no consumer).

## What this does NOT do

- **No version bump, no actual publish.** `vision-geometry`/`vision-mvg` have never been published, so their first `cargo publish` (at the current workspace version) is a **manual maintainer step**.
- **No PyO3 bindings** — deferred (A5 Python parity was dropped; the py crate binds the calibration facade only).

## Verification

- `cargo package --list` clean for both crates; READMEs present
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` ✓
- (publish-metadata + docs only — no source changes; full test matrix runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)