### PR TITLE
chore(release): bump workspace to 0.6.0 (unblock geometry/mvg publish)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -146,7 +146,7 @@ the dependency DAG: `vision-calibration-core` → `vision-geometry` →
 `vision-mvg` → `vision-calibration-pipeline` → `vision-calibration` →
 `vision-calibration-py`. `vision-geometry`/`vision-mvg` have never been
 published, so their first crates.io version is the current workspace version
-(a fresh `0.x` crate may be published at `0.5.1`); the already-published crates
+(a fresh `0.x` crate may be published at `0.6.0`); the already-published crates
 only need re-publishing on the next workspace-wide version bump.
 
 `Cargo.lock` refreshes by running `cargo build --workspace` once after
@@ -158,6 +158,18 @@ but never reached PyPI: each release missed the `pyproject.toml` bump,
 which tripped the `release-pypi.yml` verify gate and skipped the
 wheel build / upload. `0.5.1` repaired this; see the fix commit for
 the full failure map.
+
+`0.6.0` exists because of a second trap: PR #67 added the public
+`vision_calibration_core::linalg` module to the already-published
+`core@0.5.1` **without** a version bump, so local `core@0.5.1` diverged
+from the immutable crates.io `core@0.5.1`. Publishing `vision-geometry`
+(which re-exports `core::linalg`) then failed `--dry-run` with `E0432`,
+because publish strips path deps and resolved the *old* registry
+`core@0.5.1` that has no `linalg`. **Lesson:** adding public API to an
+already-published crate is a release event — it must ride a
+workspace-wide version bump, never land at the same version. The whole
+post-v0.5.1 DAG (PRs #66–#70) was unpublished, so `0.6.0` re-releases
+all nine crates together in DAG order.
 
 **Pre-tag local check** (catches the four most common release breakages
 before the tag is pushed):

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,13 +87,27 @@ jobs:
             version=$(echo "$metadata" \
               | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')
 
-            # Idempotent: skip a version already on crates.io. Lets the
-            # first publish of a new crate be done manually (trusted
-            # publishing must be configured on an existing crate), and
-            # makes the job safe to re-run after a mid-release failure.
+            # Look up this crate on the crates.io sparse index.
             index_url="https://index.crates.io/${crate:0:2}/${crate:2:2}/${crate}"
-            if curl -sf "$index_url" \
-              | jq -e --arg v "$version" 'select(.vers == $v)' >/dev/null; then
+            http_code=$(curl -s -o index_entry.json -w '%{http_code}' "$index_url")
+
+            # A 404 means the crate has never been published. crates.io
+            # trusted publishing can only be configured on a crate that
+            # already exists, so the OIDC token from crates-io-auth-action
+            # cannot authorize the very first upload. Skip with a warning
+            # rather than hard-failing the whole DAG: publish the first
+            # version manually, configure trusted publishing, then re-run.
+            if [ "$http_code" = "404" ]; then
+              echo "::warning::${crate} is not on crates.io yet — its first publish must be done manually, then configure trusted publishing. Skipping."
+              continue
+            elif [ "$http_code" != "200" ]; then
+              echo "crates.io index lookup for ${crate} returned HTTP ${http_code}" >&2
+              exit 1
+            fi
+
+            # Idempotent: skip a version already on crates.io. Makes the
+            # job safe to re-run after a mid-release failure.
+            if jq -e --arg v "$version" 'select(.vers == $v)' index_entry.json >/dev/null; then
               echo "${crate} ${version} already on crates.io — skipping."
               continue
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,21 @@ jobs:
           # `dataset` and `detect` have no internal deps but are
           # non-optional dependencies of `pipeline`, so they must be
           # on the registry before `pipeline` is published.
+          # `vision-geometry` (needs core) and `vision-mvg` (needs
+          # core + geometry) are a standalone MVG island — no
+          # calibration-chain crate depends on them, but they are
+          # part of the publish set, so they ship in DAG order:
+          # geometry after core, mvg after geometry.
+          # `vision-calibration-py` is published to PyPI by
+          # release-pypi.yml, not here.
           crates=(
             vision-calibration-core
+            vision-geometry
             vision-calibration-dataset
             vision-calibration-detect
             vision-calibration-linear
             vision-calibration-optim
+            vision-mvg
             vision-calibration-pipeline
             vision-calibration
           )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,7 +3689,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vision-calibration"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "calib-targets",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-bench"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "calib-targets",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "nalgebra",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-dataset"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-detect"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "calib-targets",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-linear"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-optim"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-pipeline"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-py"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "pyo3",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "vision-geometry"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "nalgebra",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "vision-mvg"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 # MSRV is 1.93. Bumped from 1.88 on 2026-05-23 to drop the
 # `fixed`/`kiddo` lockfile pins that kept breaking under `cargo update`.
@@ -33,16 +33,16 @@ homepage = "https://vitalyvorobyev.github.io/calibration-rs"
 repository = "https://github.com/VitalyVorobyev/calibration-rs"
 
 [workspace.dependencies]
-vision-calibration = { path = "./crates/vision-calibration", version = "0.5.1" }
-vision-calibration-core = { path = "./crates/vision-calibration-core", version = "0.5.1" }
-vision-calibration-linear = { path = "./crates/vision-calibration-linear", version = "0.5.1" }
-vision-calibration-optim = { path = "./crates/vision-calibration-optim", version = "0.5.1" }
-vision-calibration-pipeline = { path = "./crates/vision-calibration-pipeline", version = "0.5.1" }
-vision-calibration-dataset = { path = "./crates/vision-calibration-dataset", version = "0.5.1" }
-vision-calibration-detect = { path = "./crates/vision-calibration-detect", version = "0.5.1" }
-vision-calibration-bench = { path = "./crates/vision-calibration-bench", version = "0.5.1" }
-vision-geometry = { path = "./crates/vision-geometry", version = "0.5.1" }
-vision-mvg = { path = "./crates/vision-mvg", version = "0.5.1" }
+vision-calibration = { path = "./crates/vision-calibration", version = "0.6.0" }
+vision-calibration-core = { path = "./crates/vision-calibration-core", version = "0.6.0" }
+vision-calibration-linear = { path = "./crates/vision-calibration-linear", version = "0.6.0" }
+vision-calibration-optim = { path = "./crates/vision-calibration-optim", version = "0.6.0" }
+vision-calibration-pipeline = { path = "./crates/vision-calibration-pipeline", version = "0.6.0" }
+vision-calibration-dataset = { path = "./crates/vision-calibration-dataset", version = "0.6.0" }
+vision-calibration-detect = { path = "./crates/vision-calibration-detect", version = "0.6.0" }
+vision-calibration-bench = { path = "./crates/vision-calibration-bench", version = "0.6.0" }
+vision-geometry = { path = "./crates/vision-geometry", version = "0.6.0" }
+vision-mvg = { path = "./crates/vision-mvg", version = "0.6.0" }
 
 anyhow = "1"
 thiserror = "2"

--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vision-calibration-examples-private"
 description = "Private end-to-end calibration examples using private sensor datasets"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 authors = ["Vitaly Vorobyev <vit.vorobiev@gmail.com>"]
@@ -18,10 +18,10 @@ missing_docs = "warn"
 workspace = true
 
 [dependencies]
-vision-calibration = { path = "../vision-calibration", version = "0.5.1" }
-vision-calibration-core = { path = "../vision-calibration-core", version = "0.5.1" }
-vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.5.1" }
-vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.5.1" }
+vision-calibration = { path = "../vision-calibration", version = "0.6.0" }
+vision-calibration-core = { path = "../vision-calibration-core", version = "0.6.0" }
+vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.6.0" }
+vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.6.0" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/vision-calibration-py/pyproject.toml
+++ b/crates/vision-calibration-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "vision-calibration"
-version = "0.5.1"
+version = "0.6.0"
 description = "Python bindings for calibration-rs end-to-end camera calibration"
 readme = "README.md"
 authors = [{ name = "Vitaly Vorobyev", email = "vit.vorobiev@gmail.com" }]


### PR DESCRIPTION
## Why

Manual `cargo publish -p vision-geometry --dry-run` failed with:

```
error[E0432]: unresolved import `vision_calibration_core::linalg`
```

**Root cause:** PR #67 added the public `vision_calibration_core::linalg` module to the **already-published** `core@0.5.1` without a version bump. Local `core@0.5.1` therefore diverged from the immutable crates.io `core@0.5.1`. On publish, cargo strips path deps and resolves `vision-calibration-core` from the registry — the *old* 0.5.1 with no `linalg` — so `vision-geometry` (which re-exports `core::linalg`) fails to build.

This isn't fixable by republishing 0.5.1 (immutable). And it isn't isolated to geometry: `vision-calibration-linear` also now depends on `core::linalg`, and the entire post-v0.5.1 DAG (PRs #66–#70) is unpublished. The fix is a coordinated workspace-wide version bump + a full nine-crate re-release.

## What

Bumps **all four lockstep version sources** `0.5.1 → 0.6.0`:

1. `Cargo.toml` `workspace.package.version` + the 10 `[workspace.dependencies]` path-dep pins
2. `crates/vision-calibration-py/pyproject.toml` `project.version`
3. `crates/vision-calibration-examples-private/Cargo.toml` (package version + 4 path pins)
4. `Cargo.lock` refreshed via `cargo build --workspace` (version strings only — no dep resolution)

Minor (not patch) because the changes since v0.5.1 add public API: `core::linalg` + `MathError`, N-view triangulation, and two newly-public crates (`vision-geometry`, `vision-mvg`).

Also records the divergence lesson in the CLAUDE.md release section.

## Post-merge publish (manual, DAG order)

After merge + tag `v0.6.0`:
`core → vision-geometry → linear → optim → vision-mvg → pipeline → vision-calibration → vision-calibration-py`

## Gate — all green locally

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (all pass)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` (no warnings)
- `python3 -m compileall` OK
- `maturin develop` → `vision_calibration-0.6.0` wheel
- py `unittest` — 11 pass (clean venv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)