### PR TITLE
feat(mvg): Scheimpflug-aware stereo rectification (C4, D4 gate)

### DIFF
--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -22,6 +22,7 @@ vision-calibration = { path = "../vision-calibration", version = "0.6.0" }
 vision-calibration-core = { path = "../vision-calibration-core", version = "0.6.0" }
 vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.6.0" }
 vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.6.0" }
+vision-mvg = { path = "../vision-mvg", version = "0.6.0" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ref_rectify.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ref_rectify.rs
@@ -1,0 +1,212 @@
+//! Scheimpflug-aware stereo rectification validated against the `rtv3d_ref`
+//! reference oracle (C4 / D4 gate).
+//!
+//! The `rtv3d_ref` `artifacts.json` (the customer's "QUICK" oracle) calibrates a
+//! 6-camera Scheimpflug rig to sub-pixel reprojection error. Each camera carries
+//! a genuine tilted sensor (`τx ≈ -5°`, small `τy`) and the cameras sit on a ring
+//! converging on a central puzzle_board — a real, asymmetric multi-view geometry.
+//!
+//! This harness validates [`vision_mvg::rectification::rectify_stereo_pair`] on
+//! that real calibration. For each pair `(cam0, cam_b)` it:
+//!
+//! 1. Reads the oracle `K`, Scheimpflug tilt, and `camera_se3_sensor` extrinsics.
+//! 2. Builds the Scheimpflug-aware rectifying homographies.
+//! 3. Projects a synthetic 3-D cloud through **both** cameras using the real
+//!    pinhole + Scheimpflug-tilt model at the oracle's K and tilt, with lens
+//!    distortion omitted — the rectification contract takes *undistorted*
+//!    pixels (the Brown-Conrady model itself is validated separately by
+//!    `rtv3d_ref_reproj`).
+//! 4. Applies the rectifying maps and measures how far apart the rectified rows
+//!    of corresponding points are (`|Δv|`, pixels).
+//!
+//! A correct rectification drives `|Δv|` to numerical zero for every
+//! correspondence — corresponding points share a row, the precondition for 1-D
+//! disparity search. The verdict gate is `max |Δv| < 1e-3 px`.
+//!
+//! This is a calibration-only check (no detector, no images): the oracle *is* the
+//! ground truth, so the rectification is exercised against the device's actual
+//! intrinsics, tilts, and inter-camera geometry rather than synthetic stand-ins.
+//!
+//! Run:
+//! `cargo run --manifest-path
+//! crates/vision-calibration-examples-private/Cargo.toml --example
+//! rtv3d_ref_rectify --release`
+//!
+//! Env: `RTV3D_REF_DATA_DIR` (default `privatedata/rtv3d_ref`).
+
+use anyhow::{Context, Result};
+use nalgebra::{Matrix3, Translation3, UnitQuaternion};
+use std::path::PathBuf;
+
+use vision_calibration_core::{BrownConrady5, Camera, FxFyCxCySkew, Iso3, Mat3, Pinhole, Pt2, Pt3};
+use vision_calibration_examples_private::{
+    RefIntrinsic, ScheimpflugCamera, load_ref_artifacts, split_opencv_distortion,
+};
+use vision_mvg::rectification::{RectifyCamera, RectifyOptions, rectify_stereo_pair};
+
+/// Per-camera tile size (the 4320×540 strip splits into 6 × 720×540).
+const TILE_W: f64 = 720.0;
+const TILE_H: f64 = 540.0;
+/// Verdict tolerance on rectified row disagreement (pixels).
+const ROW_TOL_PX: f64 = 1e-3;
+/// Minimum overlapping correspondences a pair must contribute to be meaningful.
+/// Wide-baseline pairs (cameras on opposite sides of the ring) share only a
+/// small field of view, so this is kept modest.
+const MIN_POINTS: usize = 8;
+
+fn main() -> Result<()> {
+    let dir = std::env::var("RTV3D_REF_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("privatedata/rtv3d_ref"));
+    let art_path = dir.join("artifacts.json");
+    let art = load_ref_artifacts(&art_path)
+        .with_context(|| format!("load oracle {}", art_path.display()))?;
+
+    println!(
+        "rtv3d_ref Scheimpflug rectification check — {} cameras\n",
+        art.num_cameras
+    );
+    println!(
+        "{:<8} {:>10} {:>8} {:>12} {:>12}",
+        "pair", "baseline", "points", "mean|Δv|px", "max|Δv|px"
+    );
+    println!("{}", "─".repeat(54));
+
+    let mut worst: f64 = 0.0;
+    let mut any_failed = false;
+
+    // Camera 0 is the reference (left); rectify it against every other camera.
+    let cam0_ext = iso_from_4x4_mm(&art.extrinsic[0].camera_se3_sensor);
+    let left_rect = rectify_camera(&art.intrinsic[0])?;
+    let left_cam = ideal_camera(&art.intrinsic[0])?;
+
+    for b in 1..art.num_cameras {
+        let cam_b_ext = iso_from_4x4_mm(&art.extrinsic[b].camera_se3_sensor);
+        // cam_b_se3_cam0 = T_Cb_S · T_C0_S⁻¹
+        let cam_b_se3_cam0 = cam_b_ext * cam0_ext.inverse();
+
+        let right_rect = rectify_camera(&art.intrinsic[b])?;
+        let right_cam = ideal_camera(&art.intrinsic[b])?;
+
+        let rect = rectify_stereo_pair(
+            &left_rect,
+            &right_rect,
+            &cam_b_se3_cam0,
+            &RectifyOptions::default(),
+        )
+        .with_context(|| format!("rectify pair (0, {b})"))?;
+
+        // Project a cloud at the working distance through both cameras.
+        let mut sum_dv = 0.0;
+        let mut max_dv: f64 = 0.0;
+        let mut n = 0usize;
+        for p0 in working_cloud() {
+            let p_b = cam_b_se3_cam0 * p0;
+            let (Some(px0), Some(pxb)) = (
+                left_cam.project_point_c(&p0.coords),
+                right_cam.project_point_c(&p_b.coords),
+            ) else {
+                continue;
+            };
+            if !in_tile(&px0) || !in_tile(&pxb) {
+                continue;
+            }
+            let dv = (rect.rectify_left(&px0).y - rect.rectify_right(&pxb).y).abs();
+            sum_dv += dv;
+            max_dv = max_dv.max(dv);
+            n += 1;
+        }
+
+        let mean_dv = if n > 0 { sum_dv / n as f64 } else { f64::NAN };
+        let ok = n >= MIN_POINTS && max_dv < ROW_TOL_PX;
+        any_failed |= !ok;
+        worst = worst.max(max_dv);
+        println!(
+            "{:<8} {:>9.3}m {:>8} {:>12.2e} {:>12.2e}{}",
+            format!("0–{b}"),
+            rect.baseline,
+            n,
+            mean_dv,
+            max_dv,
+            if ok { "" } else { "  <-- FAIL" }
+        );
+    }
+
+    println!("{}", "─".repeat(54));
+    if any_failed {
+        println!(
+            "\nVERDICT: FAIL — some pair exceeds {ROW_TOL_PX:e} px row tolerance \
+             (worst {worst:.2e} px)."
+        );
+        std::process::exit(1);
+    }
+    println!(
+        "\nVERDICT: Scheimpflug stereo rectification VALIDATED on rtv3d_ref \
+         (worst row disagreement {worst:.2e} px over all pairs)."
+    );
+    Ok(())
+}
+
+/// Build a [`RectifyCamera`] (K + Scheimpflug tilt) from an oracle intrinsics block.
+fn rectify_camera(intr: &RefIntrinsic) -> Result<RectifyCamera> {
+    let m = &intr.matrix;
+    let k = Mat3::new(
+        m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2],
+    );
+    let (_dist, tilt) = split_opencv_distortion(&intr.distortion)?;
+    Ok(RectifyCamera::scheimpflug(k, tilt))
+}
+
+/// Build a distortion-free pinhole + Scheimpflug-tilt camera at the oracle's K
+/// and tilt. Projecting through this yields the **undistorted** pixels that the
+/// rectification maps expect; lens distortion is intentionally omitted here.
+fn ideal_camera(intr: &RefIntrinsic) -> Result<ScheimpflugCamera> {
+    let m = &intr.matrix;
+    let k = FxFyCxCySkew {
+        fx: m[0][0],
+        fy: m[1][1],
+        cx: m[0][2],
+        cy: m[1][2],
+        skew: m[0][1],
+    };
+    let (_dist, tilt) = split_opencv_distortion(&intr.distortion)?;
+    let no_distortion = BrownConrady5 {
+        k1: 0.0,
+        k2: 0.0,
+        k3: 0.0,
+        p1: 0.0,
+        p2: 0.0,
+        iters: 5,
+    };
+    Ok(Camera::new(Pinhole, no_distortion, tilt.compile(), k))
+}
+
+/// A spread of 3-D points (camera-0 frame, metres) near the rig's working
+/// distance, where the converging cameras' fields of view overlap.
+fn working_cloud() -> Vec<Pt3> {
+    let mut pts = Vec::new();
+    for i in 0..9 {
+        for j in 0..9 {
+            let x = -0.04 + 0.01 * i as f64;
+            let y = -0.04 + 0.01 * j as f64;
+            for &z in &[0.26, 0.30, 0.34, 0.38] {
+                pts.push(Pt3::new(x, y, z));
+            }
+        }
+    }
+    pts
+}
+
+fn in_tile(px: &Pt2) -> bool {
+    px.x >= 0.0 && px.x < TILE_W && px.y >= 0.0 && px.y < TILE_H
+}
+
+/// Build an `Iso3` from a row-major 4×4 transform whose translation is in mm.
+fn iso_from_4x4_mm(m: &[[f64; 4]; 4]) -> Iso3 {
+    let rot = Matrix3::new(
+        m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2],
+    );
+    let q = UnitQuaternion::from_matrix(&rot);
+    let t = Translation3::new(m[0][3] * 1e-3, m[1][3] * 1e-3, m[2][3] * 1e-3);
+    Iso3::from_parts(t, q)
+}

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ref_reproj.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ref_reproj.rs
@@ -38,9 +38,8 @@ use nalgebra::{DMatrix, DVector, Vector3};
 use std::path::PathBuf;
 use std::time::Instant;
 
-use vision_calibration::linear::{
-    homography::dlt_homography, planar_pose::estimate_planar_pose_from_h,
-};
+use vision_calibration::geometry::homography::dlt_homography;
+use vision_calibration::linear::planar_pose::estimate_planar_pose_from_h;
 use vision_calibration_core::{
     CorrespondenceView, DistortionModel, IntrinsicsModel, Iso3, Pt2, SensorModel,
 };

--- a/crates/vision-mvg/src/lib.rs
+++ b/crates/vision-mvg/src/lib.rs
@@ -30,6 +30,7 @@ pub mod degeneracy;
 pub mod error;
 pub mod homography;
 pub mod pose_recovery;
+pub mod rectification;
 #[cfg(feature = "refine")]
 pub mod refine;
 pub mod residuals;
@@ -44,6 +45,7 @@ pub use homography::{
     homography_transfer, homography_transfer_inverse,
 };
 pub use pose_recovery::{RelativePose, recover_relative_pose};
+pub use rectification::{RectifyCamera, RectifyOptions, StereoRectification, rectify_stereo_pair};
 pub use robust::{
     EssentialEstimate, HomographyEstimate, RobustRelativePose, estimate_essential,
     estimate_homography, recover_relative_pose_robust,

--- a/crates/vision-mvg/src/rectification.rs
+++ b/crates/vision-mvg/src/rectification.rs
@@ -1,0 +1,481 @@
+//! Scheimpflug-aware stereo rectification.
+//!
+//! Computes rectifying homographies for a calibrated stereo pair so that
+//! corresponding points fall on the **same image row** — the precondition for
+//! 1-D disparity search. Unlike the textbook (Fusiello / Bouguet) construction,
+//! this handles **Scheimpflug** cameras whose sensor plane is tilted relative to
+//! the optical axis.
+//!
+//! # Why the tilt is "free"
+//!
+//! In this project's camera model (ADR 0005) a pixel is formed as
+//!
+//! ```text
+//! pixel = K · H_tilt · x_n            (homogeneous, then dehomogenize)
+//! ```
+//!
+//! where `x_n` is the undistorted normalized projection of the viewing ray and
+//! `H_tilt` is the Scheimpflug sensor homography
+//! ([`ScheimpflugParams::compile`]). The tilt is therefore just another
+//! projective factor on the normalized plane. Pre-multiplying each camera's
+//! unprojection by `H_tilt⁻¹` collapses a Scheimpflug camera to an **equivalent
+//! frontal pinhole** in `x_n`:
+//!
+//! ```text
+//! x_n = H_tilt⁻¹ · K⁻¹ · pixel
+//! ```
+//!
+//! Standard rectification then applies to the frontal-equivalent cameras. Each
+//! rectifying homography is
+//!
+//! ```text
+//! H_left  = K_rect · R_rect          · H_tilt0⁻¹ · K0⁻¹
+//! H_right = K_rect · (R_rect · Rᵀ)   · H_tilt1⁻¹ · K1⁻¹
+//! ```
+//!
+//! with `R = R_C1_C0` the inter-camera rotation and `R_rect` the common rectified
+//! orientation whose x-axis is the baseline. When the tilt is zero
+//! `H_tilt⁻¹ = I` and this reduces exactly to standard pinhole rectification.
+//!
+//! # Conventions and caveats
+//!
+//! - Inputs are **undistorted** pixel coordinates — remove lens distortion
+//!   (e.g. [`BrownConrady5::undistort`](vision_calibration_core::BrownConrady5)
+//!   in normalized space) before applying these maps. The rectifying homography
+//!   is the *rotation* part of rectification; distortion is handled separately,
+//!   exactly as OpenCV splits `initUndistortRectifyMap`.
+//! - The relative pose is `cam1_se3_cam0` (`T_C1_C0`): it maps a point from
+//!   camera 0's frame into camera 1's frame (ADR 0009). For a
+//!   `RigExtrinsicsExport` with camera 0 as the reference this is simply
+//!   `cam_se3_rig[1]`.
+//! - Camera 0 is treated as the left/reference camera; its frame is the world
+//!   frame of the rectification.
+
+use crate::{MvgError, Result};
+use nalgebra::{Matrix3, Vector3};
+use vision_calibration_core::{Iso3, Mat3, Pt2, Real, ScheimpflugParams, Vec3};
+
+/// Numerical floor for "this vector is effectively zero".
+const EPS: Real = 1e-12;
+/// Largest Scheimpflug tilt (radians) we accept before declaring the sensor
+/// homography degenerate (~80°; physical tilts are a few degrees).
+const MAX_TILT_RAD: Real = 1.4;
+
+/// Frozen calibration of one camera in the stereo pair.
+#[derive(Clone, Copy, Debug)]
+pub struct RectifyCamera {
+    /// Intrinsic matrix `K`.
+    pub k: Mat3,
+    /// Scheimpflug sensor tilt. Use [`ScheimpflugParams::default`] (zero tilt)
+    /// for an ordinary pinhole camera.
+    pub tilt: ScheimpflugParams,
+}
+
+impl RectifyCamera {
+    /// A pinhole camera (no sensor tilt).
+    pub fn pinhole(k: Mat3) -> Self {
+        Self {
+            k,
+            tilt: ScheimpflugParams::default(),
+        }
+    }
+
+    /// A Scheimpflug camera with the given tilt.
+    pub fn scheimpflug(k: Mat3, tilt: ScheimpflugParams) -> Self {
+        Self { k, tilt }
+    }
+}
+
+/// Options controlling the shared rectified intrinsics.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RectifyOptions {
+    /// Explicit shared rectified intrinsics `K_rect`. When `None` (the default)
+    /// the two input cameras' focal lengths and principal points are averaged
+    /// (with zero skew). Both rectified cameras must share `K_rect` for rows to
+    /// align, so this is a single matrix rather than one per camera.
+    pub k_rect: Option<Mat3>,
+}
+
+/// Rectifying maps for a stereo pair.
+#[derive(Clone, Debug)]
+pub struct StereoRectification {
+    /// Homography mapping **undistorted** left (camera 0) pixels to rectified
+    /// pixels.
+    pub h_left: Mat3,
+    /// Homography mapping **undistorted** right (camera 1) pixels to rectified
+    /// pixels.
+    pub h_right: Mat3,
+    /// The shared rectified intrinsics actually used.
+    pub k_rect: Mat3,
+    /// Common rectified orientation: maps a direction in camera 0's frame into
+    /// the rectified frame (rows are the new x/y/z axes).
+    pub r_rect: Mat3,
+    /// Baseline length `‖t‖` between the two optical centres (calibration units).
+    pub baseline: Real,
+}
+
+impl StereoRectification {
+    /// Apply the left rectifying homography to an undistorted pixel.
+    pub fn rectify_left(&self, px: &Pt2) -> Pt2 {
+        apply_homography(&self.h_left, px)
+    }
+
+    /// Apply the right rectifying homography to an undistorted pixel.
+    pub fn rectify_right(&self, px: &Pt2) -> Pt2 {
+        apply_homography(&self.h_right, px)
+    }
+}
+
+/// Compute Scheimpflug-aware rectifying homographies for a calibrated stereo
+/// pair.
+///
+/// `left` / `right` carry each camera's intrinsics and Scheimpflug tilt;
+/// `cam1_se3_cam0` is the relative pose `T_C1_C0` (camera 0 → camera 1).
+///
+/// # Errors
+///
+/// - [`MvgError::Degenerate`] if the baseline is ~zero (coincident centres) or a
+///   Scheimpflug tilt is out of range (≳ 80°, where the sensor homography
+///   degenerates).
+/// - [`MvgError::Numerical`] if an intrinsic matrix is not invertible.
+pub fn rectify_stereo_pair(
+    left: &RectifyCamera,
+    right: &RectifyCamera,
+    cam1_se3_cam0: &Iso3,
+    opts: &RectifyOptions,
+) -> Result<StereoRectification> {
+    // Inter-camera rotation R = R_C1_C0 and translation t = t_C1_C0.
+    let r = *cam1_se3_cam0.rotation.to_rotation_matrix().matrix();
+    let t = cam1_se3_cam0.translation.vector;
+    let baseline = t.norm();
+    if baseline < EPS {
+        return Err(MvgError::degenerate(
+            "zero baseline: the two optical centres coincide",
+        ));
+    }
+
+    // Camera-1 centre expressed in camera-0's frame: c1 = -Rᵀ t (camera-0 centre
+    // is the origin). The rectified x-axis points along the baseline c1 - c0.
+    let c1 = -(r.transpose() * t);
+    let v1 = c1 / c1.norm();
+
+    // y-axis ⟂ to the baseline and the original (camera-0) optical axis z.
+    let z = Vec3::new(0.0, 0.0, 1.0);
+    let mut v2 = z.cross(&v1);
+    if v2.norm() < EPS {
+        // Baseline parallel to the optical axis (forward stereo): fall back to a
+        // different seed so the cross product is well-defined.
+        v2 = Vec3::new(0.0, 1.0, 0.0).cross(&v1);
+    }
+    let v2 = v2 / v2.norm();
+    let v3 = v1.cross(&v2);
+    let r_rect = Matrix3::from_rows(&[v1.transpose(), v2.transpose(), v3.transpose()]);
+
+    let k0_inv = left
+        .k
+        .try_inverse()
+        .ok_or_else(|| MvgError::numerical("left camera matrix K is not invertible"))?;
+    let k1_inv = right
+        .k
+        .try_inverse()
+        .ok_or_else(|| MvgError::numerical("right camera matrix K is not invertible"))?;
+    let h_tilt0_inv = tilt_inverse(&left.tilt)?;
+    let h_tilt1_inv = tilt_inverse(&right.tilt)?;
+
+    let k_rect = opts
+        .k_rect
+        .unwrap_or_else(|| average_intrinsics(&left.k, &right.k));
+
+    let h_left = k_rect * r_rect * h_tilt0_inv * k0_inv;
+    let h_right = k_rect * (r_rect * r.transpose()) * h_tilt1_inv * k1_inv;
+
+    Ok(StereoRectification {
+        h_left,
+        h_right,
+        k_rect,
+        r_rect,
+        baseline,
+    })
+}
+
+/// Inverse of a Scheimpflug sensor homography, with a range guard so we never
+/// trip [`ScheimpflugParams::compile`]'s internal panic on a singular tilt.
+fn tilt_inverse(p: &ScheimpflugParams) -> Result<Mat3> {
+    if p.tilt_x.abs() >= MAX_TILT_RAD || p.tilt_y.abs() >= MAX_TILT_RAD {
+        return Err(MvgError::degenerate(format!(
+            "Scheimpflug tilt out of range: (tilt_x={}, tilt_y={})",
+            p.tilt_x, p.tilt_y
+        )));
+    }
+    Ok(p.compile().h_inv)
+}
+
+/// Average two intrinsic matrices (focal lengths + principal points), forcing
+/// the structural zeros and `K[2,2] = 1`.
+fn average_intrinsics(a: &Mat3, b: &Mat3) -> Mat3 {
+    Matrix3::new(
+        0.5 * (a[(0, 0)] + b[(0, 0)]),
+        0.0,
+        0.5 * (a[(0, 2)] + b[(0, 2)]),
+        0.0,
+        0.5 * (a[(1, 1)] + b[(1, 1)]),
+        0.5 * (a[(1, 2)] + b[(1, 2)]),
+        0.0,
+        0.0,
+        1.0,
+    )
+}
+
+/// Apply a homography to a pixel and dehomogenize.
+fn apply_homography(h: &Mat3, px: &Pt2) -> Pt2 {
+    let v = h * Vector3::new(px.x, px.y, 1.0);
+    Pt2::new(v.x / v.z, v.y / v.z)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Rotation3, Translation3, UnitQuaternion};
+    use vision_calibration_core::{
+        BrownConrady5, Camera, FxFyCxCySkew, IdentitySensor, Pinhole, Pt3,
+    };
+
+    type ScheimpflugCamera = Camera<
+        Real,
+        Pinhole,
+        BrownConrady5<Real>,
+        vision_calibration_core::HomographySensor<Real>,
+        FxFyCxCySkew<Real>,
+    >;
+
+    fn no_distortion() -> BrownConrady5<Real> {
+        BrownConrady5 {
+            k1: 0.0,
+            k2: 0.0,
+            k3: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+            iters: 5,
+        }
+    }
+
+    fn intr(fx: Real, fy: Real, cx: Real, cy: Real) -> FxFyCxCySkew<Real> {
+        FxFyCxCySkew {
+            fx,
+            fy,
+            cx,
+            cy,
+            skew: 0.0,
+        }
+    }
+
+    /// Build the full Scheimpflug projection camera (zero distortion) used to
+    /// generate synthetic observations through the *real* core model.
+    fn scheimpflug_camera(k: &FxFyCxCySkew<Real>, tilt: ScheimpflugParams) -> ScheimpflugCamera {
+        Camera::new(Pinhole, no_distortion(), tilt.compile(), *k)
+    }
+
+    /// A frontal pinhole projection camera (identity sensor).
+    fn pinhole_camera(
+        k: &FxFyCxCySkew<Real>,
+    ) -> Camera<Real, Pinhole, BrownConrady5<Real>, IdentitySensor, FxFyCxCySkew<Real>> {
+        Camera::new(Pinhole, no_distortion(), IdentitySensor, *k)
+    }
+
+    fn relative_pose(euler: (Real, Real, Real), t: (Real, Real, Real)) -> Iso3 {
+        let rot = Rotation3::from_euler_angles(euler.0, euler.1, euler.2);
+        Iso3::from_parts(Translation3::new(t.0, t.1, t.2), UnitQuaternion::from(rot))
+    }
+
+    /// A spread of 3D points, all comfortably in front of both cameras.
+    fn scene_points() -> Vec<Pt3> {
+        let mut pts = Vec::new();
+        for i in 0..5 {
+            for j in 0..5 {
+                let x = -0.5 + 0.25 * i as Real;
+                let y = -0.5 + 0.25 * j as Real;
+                let z = 4.0 + 0.4 * ((i * 3 + j) % 4) as Real;
+                pts.push(Pt3::new(x, y, z));
+            }
+        }
+        pts
+    }
+
+    /// Project every point into both cameras (camera 1 sees `R·p + t`), keeping
+    /// only points in front of both. Returns the rectified-row check inputs.
+    fn project_pair<C0, C1>(cam0: &C0, cam1: &C1, pose: &Iso3, pts: &[Pt3]) -> Vec<(Pt2, Pt2)>
+    where
+        C0: ProjectLike,
+        C1: ProjectLike,
+    {
+        let r = *pose.rotation.to_rotation_matrix().matrix();
+        let t = pose.translation.vector;
+        let mut out = Vec::new();
+        for p in pts {
+            let p0 = Vector3::new(p.x, p.y, p.z);
+            let p1 = r * p0 + t;
+            if let (Some(a), Some(b)) = (cam0.project(&p0), cam1.project(&p1)) {
+                out.push((a, b));
+            }
+        }
+        out
+    }
+
+    /// Minimal projection abstraction so the two concrete `Camera<...>` types can
+    /// share `project_pair`.
+    trait ProjectLike {
+        fn project(&self, p_c: &Vector3<Real>) -> Option<Pt2>;
+    }
+    impl<Sm> ProjectLike for Camera<Real, Pinhole, BrownConrady5<Real>, Sm, FxFyCxCySkew<Real>>
+    where
+        Sm: vision_calibration_core::SensorModel<Real>,
+    {
+        fn project(&self, p_c: &Vector3<Real>) -> Option<Pt2> {
+            self.project_point_c(p_c)
+        }
+    }
+
+    fn max_row_disagreement(pairs: &[(Pt2, Pt2)], rect: &StereoRectification) -> Real {
+        pairs
+            .iter()
+            .map(|(a, b)| {
+                let ra = rect.rectify_left(a);
+                let rb = rect.rectify_right(b);
+                (ra.y - rb.y).abs()
+            })
+            .fold(0.0, Real::max)
+    }
+
+    #[test]
+    fn scheimpflug_pair_rows_align() {
+        let k0 = intr(800.0, 810.0, 320.0, 240.0);
+        let k1 = intr(790.0, 805.0, 318.0, 242.0);
+        let tilt0 = ScheimpflugParams {
+            tilt_x: 0.09,
+            tilt_y: -0.04,
+        };
+        let tilt1 = ScheimpflugParams {
+            tilt_x: -0.06,
+            tilt_y: 0.05,
+        };
+        let pose = relative_pose((0.02, 0.04, -0.01), (-1.0, 0.05, 0.1));
+
+        let cam0 = scheimpflug_camera(&k0, tilt0);
+        let cam1 = scheimpflug_camera(&k1, tilt1);
+        let pairs = project_pair(&cam0, &cam1, &pose, &scene_points());
+        assert!(pairs.len() >= 20, "too few visible points: {}", pairs.len());
+
+        let rect = rectify_stereo_pair(
+            &RectifyCamera::scheimpflug(k0.k_matrix(), tilt0),
+            &RectifyCamera::scheimpflug(k1.k_matrix(), tilt1),
+            &pose,
+            &RectifyOptions::default(),
+        )
+        .unwrap();
+
+        let max_dv = max_row_disagreement(&pairs, &rect);
+        assert!(max_dv < 1e-6, "rows not aligned: max |Δv| = {max_dv}");
+    }
+
+    #[test]
+    fn zero_tilt_matches_standard_rectification() {
+        // With zero tilt the Scheimpflug path must coincide with plain pinhole
+        // rectification (H_tilt⁻¹ = I) and still row-align.
+        let k0 = intr(800.0, 800.0, 320.0, 240.0);
+        let k1 = intr(800.0, 800.0, 320.0, 240.0);
+        let pose = relative_pose((0.0, 0.03, 0.0), (-1.2, 0.0, 0.0));
+
+        let cam0 = pinhole_camera(&k0);
+        let cam1 = pinhole_camera(&k1);
+        let pairs = project_pair(&cam0, &cam1, &pose, &scene_points());
+
+        let rect = rectify_stereo_pair(
+            &RectifyCamera::pinhole(k0.k_matrix()),
+            &RectifyCamera::pinhole(k1.k_matrix()),
+            &pose,
+            &RectifyOptions::default(),
+        )
+        .unwrap();
+
+        // A pinhole RectifyCamera and a zero-tilt Scheimpflug one must produce
+        // identical maps.
+        let rect_via_tilt = rectify_stereo_pair(
+            &RectifyCamera::scheimpflug(k0.k_matrix(), ScheimpflugParams::default()),
+            &RectifyCamera::scheimpflug(k1.k_matrix(), ScheimpflugParams::default()),
+            &pose,
+            &RectifyOptions::default(),
+        )
+        .unwrap();
+        assert!((rect.h_left - rect_via_tilt.h_left).abs().max() < 1e-12);
+        assert!((rect.h_right - rect_via_tilt.h_right).abs().max() < 1e-12);
+
+        let max_dv = max_row_disagreement(&pairs, &rect);
+        assert!(max_dv < 1e-6, "rows not aligned: max |Δv| = {max_dv}");
+    }
+
+    #[test]
+    fn baseline_is_recovered() {
+        let k = intr(800.0, 800.0, 320.0, 240.0);
+        let pose = relative_pose((0.01, 0.0, 0.0), (-0.8, 0.3, 0.2));
+        let rect = rectify_stereo_pair(
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &pose,
+            &RectifyOptions::default(),
+        )
+        .unwrap();
+        let expected = (0.8f64 * 0.8 + 0.3 * 0.3 + 0.2 * 0.2).sqrt();
+        assert!((rect.baseline - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn explicit_k_rect_is_used() {
+        let k = intr(800.0, 800.0, 320.0, 240.0);
+        let pose = relative_pose((0.0, 0.0, 0.0), (-1.0, 0.0, 0.0));
+        let k_rect = intr(1000.0, 1000.0, 256.0, 256.0).k_matrix();
+        let rect = rectify_stereo_pair(
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &pose,
+            &RectifyOptions {
+                k_rect: Some(k_rect),
+            },
+        )
+        .unwrap();
+        assert!((rect.k_rect - k_rect).abs().max() < 1e-15);
+    }
+
+    #[test]
+    fn rejects_zero_baseline() {
+        let k = intr(800.0, 800.0, 320.0, 240.0);
+        let pose = relative_pose((0.05, 0.0, 0.0), (0.0, 0.0, 0.0));
+        let err = rectify_stereo_pair(
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &pose,
+            &RectifyOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, MvgError::Degenerate { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_extreme_tilt() {
+        let k = intr(800.0, 800.0, 320.0, 240.0);
+        let pose = relative_pose((0.0, 0.0, 0.0), (-1.0, 0.0, 0.0));
+        let err = rectify_stereo_pair(
+            &RectifyCamera::scheimpflug(
+                k.k_matrix(),
+                ScheimpflugParams {
+                    tilt_x: 1.5,
+                    tilt_y: 0.0,
+                },
+            ),
+            &RectifyCamera::pinhole(k.k_matrix()),
+            &pose,
+            &RectifyOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, MvgError::Degenerate { .. }), "got {err:?}");
+    }
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -300,6 +300,21 @@ Systemic causes:
   unobserved cameras/points pass through. 9 synthetic-GT tests (recovery up to
   scale, perfect-init, pixel-noise, no-gauge-fix, unobserved-camera-0 anchor,
   three input-validation guards).
+- [x] C4-RECTIFY - Scheimpflug-aware stereo rectification (the D4 gate).
+  **Done 2026-06-21** (PR #74). New `vision-mvg::rectification`:
+  `rectify_stereo_pair(left, right, cam1_se3_cam0, opts) -> StereoRectification`.
+  Because a pixel is `K·H_tilt·x_n`, the sensor tilt is a homography on the
+  normalized plane; pre-multiplying each camera's unprojection by `H_tilt⁻¹`
+  collapses a Scheimpflug camera to a frontal pinhole, after which standard
+  Fusiello/Bouguet applies (`H_left = K_rect·R_rect·H_tilt0⁻¹·K0⁻¹`,
+  `H_right = K_rect·(R_rect·Rᵀ)·H_tilt1⁻¹·K1⁻¹`). Zero tilt reduces exactly to
+  pinhole rectification; inputs are undistorted pixels (distortion handled
+  separately, as OpenCV splits `initUndistortRectifyMap`). 6 synthetic tests
+  through the real core Scheimpflug model (rows align <1e-6). D4 gate closed by
+  the `rtv3d_ref_rectify` example: worst rectified row disagreement 3.4e-13 px
+  across all oracle camera pairs (real K, asymmetric per-cam ~-5° tilts, ring
+  extrinsics). Also repointed a pre-existing #72 regression in examples-private
+  (`rtv3d_ref_reproj` imported the removed `linear::homography`).
 
 ## B — app (extend; sequencing serves V-track)
 


### PR DESCRIPTION
## Branch 3 / C4 — Scheimpflug-aware stereo rectification (the D4/v1.0 gate)

New `vision-mvg::rectification` module producing rectifying homographies for a calibrated stereo pair so corresponding points share an image row — the precondition for 1-D disparity search — **including Scheimpflug cameras** with a tilted sensor (standard rectification assumes a frontal sensor).

### API
```rust
rectify_stereo_pair(
    left:  &RectifyCamera,   // K + ScheimpflugParams (default = pinhole)
    right: &RectifyCamera,
    cam1_se3_cam0: &Iso3,    // relative pose T_C1_C0
    opts:  &RectifyOptions,  // optional explicit K_rect, else averaged
) -> Result<StereoRectification>  // h_left, h_right, k_rect, r_rect, baseline
```

### The idea (why the tilt is "free")
In this project's camera model a pixel is `K · H_tilt · x_n`, so the Scheimpflug tilt is just a homography on the normalized plane. Pre-multiplying each camera's unprojection by `H_tilt⁻¹` collapses a Scheimpflug camera to an **equivalent frontal pinhole** in `x_n`; standard Fusiello/Bouguet rectification then applies:
```
H_left  = K_rect · R_rect        · H_tilt0⁻¹ · K0⁻¹
H_right = K_rect · (R_rect · Rᵀ) · H_tilt1⁻¹ · K1⁻¹
```
With zero tilt `H_tilt⁻¹ = I` and it reduces **exactly** to pinhole rectification. The rectified x-axis is the baseline; `K_rect` is shared so rows align. Inputs are **undistorted** pixels — distortion is the caller's concern, matching how OpenCV splits `initUndistortRectifyMap`. Degenerate baselines / out-of-range tilts return typed `MvgError`s.

### Tests (synthetic, through the *real* core Scheimpflug model)
- `scheimpflug_pair_rows_align` — exact row alignment (max |Δv| < 1e-6) at ~5° tilts, projecting through `Camera<…HomographySensor…>`;
- `zero_tilt_matches_standard_rectification` — pinhole equivalence + identical maps for a zero-tilt Scheimpflug camera;
- baseline recovery, explicit `K_rect`, zero-baseline + extreme-tilt error paths.

### D4 / v1.0 gate — validated on the real `rtv3d_ref` Scheimpflug oracle
New `rtv3d_ref_rectify` example builds the rectification from the device's **real** K, asymmetric per-camera tilts (`τx ≈ −5°`), and ring extrinsics, then checks row alignment of a 3-D cloud projected through both cameras:
```
pair       baseline   points   mean|Δv|px    max|Δv|px
0–1            0.066m      301     8.97e-14     3.41e-13
0–2            0.110m      117     1.39e-13     3.41e-13
0–3            0.132m       45     6.06e-14     1.56e-13
0–4            0.110m      109     6.51e-14     2.49e-13
0–5            0.066m      274     6.50e-14     2.84e-13
VERDICT: VALIDATED (worst row disagreement 3.4e-13 px over all pairs)
```

### Also in this PR
- **`fix(examples-private)`** (separate commit): repoint `rtv3d_ref_reproj` to `geometry::homography::dlt_homography` — a pre-existing compile break from PR #72's dedup that never propagated to the examples-private workspace (which is **not** wired into CI). Surfaced because this PR's new example makes that workspace build again.
- examples-private gains a `vision-mvg` path dep.

### Note / follow-up
The facade (`vision-calibration`) does **not** re-export `vision-mvg` at all — so the whole MVG surface (pose recovery, robust estimation, C3 `bundle_adjust`, and this rectification) is only reachable by depending on `vision-mvg` directly. That's a pre-existing gap worth a dedicated decision (e.g. a `vision_calibration::mvg` module); flagged here, not folded in.

### Gates
- `cargo fmt --all -- --check` ✓ · `clippy --workspace --all-targets --all-features -D warnings` ✓ · `test --workspace --all-features` ✓ · `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` ✓
- examples-private: all examples build ✓; `rtv3d_ref_rectify` clippy `-D warnings` ✓ + runs green on the oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)