### PR TITLE
feat(facade): expose vision-mvg as vision_calibration::mvg (C-FACADE-MVG)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -237,12 +237,10 @@ re-implements what `cargo run --example` already gives a terminal user.
   triangulation) landed; PR #72 carried C1-FOLLOWUP solver dedup
   (`linear` → `vision-geometry`) plus the geometry/mvg typed-error migration.
   **C3 (frozen-intrinsics bundle adjustment, PR #73)** and **C4
-  (Scheimpflug-aware stereo rectification, the D4 gate, PR #74)** are done.
-  Next: **C5** dense matcher (opencv-rust SGBM, feature-flagged). Known gap:
-  `vision-mvg` is not yet re-exported by the `vision-calibration` facade, so its
-  surface (pose recovery, robust estimation, `bundle_adjust`, `rectification`)
-  is reachable only via a direct `vision-mvg` dependency — a candidate
-  `vision_calibration::mvg` follow-up.
+  (Scheimpflug-aware stereo rectification, the D4 gate, PR #74)** are done. The
+  MVG surface is now re-exported through the facade as `vision_calibration::mvg`
+  (`bundle_adjust` behind the facade `refine` feature). Next: **C5** dense
+  matcher (opencv-rust SGBM, feature-flagged).
 - **D — Earn v1.0** (continuous ratchet). Typed errors (geometry/mvg migrated in
   PR #72) → doc-warning-free → Python parity audit → v1.0 release.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,6 +3701,7 @@ dependencies = [
  "vision-calibration-optim",
  "vision-calibration-pipeline",
  "vision-geometry",
+ "vision-mvg",
 ]
 
 [[package]]

--- a/crates/vision-calibration/Cargo.toml
+++ b/crates/vision-calibration/Cargo.toml
@@ -14,10 +14,17 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+# Enable the nonlinear-refinement surface of the `mvg` module (tiny-solver):
+# `vision_calibration::mvg::bundle_adjust`.
+refine = ["vision-mvg/refine"]
+
 [dependencies]
 vision-calibration-core.workspace = true
 vision-calibration-linear.workspace = true
 vision-geometry.workspace = true
+vision-mvg.workspace = true
 vision-calibration-optim.workspace = true
 vision-calibration-pipeline.workspace = true
 anyhow.workspace = true

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -509,6 +509,25 @@ pub mod geometry {
     pub use vision_geometry::{camera_matrix, epipolar, homography, triangulation};
 }
 
+/// Multiple-view geometry pipelines over the [`geometry`] solvers, re-exported
+/// from `vision_mvg`: calibrated relative-pose recovery, robust (RANSAC)
+/// estimation, cheirality/degeneracy checks, N-view triangulation, homography
+/// decomposition, and Scheimpflug-aware stereo rectification — reached via the
+/// owning module, e.g.
+/// `vision_calibration::mvg::rectification::rectify_stereo_pair`.
+///
+/// With the `refine` feature, `vision_calibration::mvg::bundle_adjust` adds
+/// frozen-intrinsics bundle adjustment (tiny-solver).
+pub mod mvg {
+    pub use vision_mvg::{
+        MvgError, cheirality, degeneracy, error, homography, pose_recovery, rectification,
+        residuals, robust, triangulation, types,
+    };
+
+    #[cfg(feature = "refine")]
+    pub use vision_mvg::bundle_adjust;
+}
+
 /// Per-feature residual helpers from `vision-calibration-optim` re-exported
 /// for convenience: `handeye_observer_se3_target` (used by hand-eye exports)
 /// and `compute_*_feature_residuals` (used by laser exports).

--- a/crates/vision-calibration/tests/facade_compile_surface.rs
+++ b/crates/vision-calibration/tests/facade_compile_surface.rs
@@ -77,3 +77,49 @@ fn prelude_compiles_for_hello_world_surface() {
         &mut CalibrationSession<PlanarIntrinsicsProblem>,
     ) -> Result<(), vision_calibration::Error> = run_planar_intrinsics;
 }
+
+#[test]
+fn mvg_module_surface_compiles() {
+    use vision_calibration::mvg;
+
+    // Lock the key re-exported paths (multiple-view geometry pipelines).
+    let _ = mvg::pose_recovery::recover_relative_pose;
+    let _ = mvg::robust::recover_relative_pose_robust;
+    let _ = mvg::triangulation::triangulate_nview;
+    let _ = mvg::rectification::rectify_stereo_pair;
+    let _ = mvg::homography::decompose_homography;
+    let _: Option<mvg::rectification::StereoRectification> = None;
+    let _: Option<mvg::types::Correspondence2D> = None;
+    let _: Option<mvg::MvgError> = None;
+    let _: Option<mvg::error::Result<()>> = None;
+}
+
+#[test]
+fn mvg_rectification_runs_through_facade() {
+    use nalgebra::{Matrix3, Translation3, UnitQuaternion};
+    use vision_calibration::core::Iso3;
+    use vision_calibration::mvg::rectification::{
+        RectifyCamera, RectifyOptions, rectify_stereo_pair,
+    };
+
+    let k = Matrix3::new(800.0, 0.0, 320.0, 0.0, 800.0, 240.0, 0.0, 0.0, 1.0);
+    let pose = Iso3::from_parts(
+        Translation3::new(-1.0, 0.0, 0.0),
+        UnitQuaternion::identity(),
+    );
+    let rect = rectify_stereo_pair(
+        &RectifyCamera::pinhole(k),
+        &RectifyCamera::pinhole(k),
+        &pose,
+        &RectifyOptions::default(),
+    )
+    .expect("rectify a trivial pinhole pair");
+    assert!((rect.baseline - 1.0).abs() < 1e-12);
+}
+
+#[cfg(feature = "refine")]
+#[test]
+fn mvg_bundle_adjust_reachable_under_refine() {
+    // The `refine` facade feature surfaces frozen-intrinsics bundle adjustment.
+    let _ = vision_calibration::mvg::bundle_adjust::bundle_adjust;
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -315,6 +315,17 @@ Systemic causes:
   across all oracle camera pairs (real K, asymmetric per-cam ~-5° tilts, ring
   extrinsics). Also repointed a pre-existing #72 regression in examples-private
   (`rtv3d_ref_reproj` imported the removed `linear::homography`).
+- [x] C-FACADE-MVG - Re-export the `vision-mvg` surface through the
+  `vision-calibration` facade. **Done 2026-06-21**. New
+  `vision_calibration::mvg` module (mirrors the existing `geometry` module
+  style) re-exporting `pose_recovery`, `robust`, `cheirality`, `degeneracy`,
+  `triangulation`, `homography`, `rectification`, `residuals`, `types`, `error`
+  + `MvgError`. Frozen-intrinsics `bundle_adjust` is surfaced behind a new
+  facade `refine` feature (`refine = ["vision-mvg/refine"]`). Closes the gap
+  that the MVG pipelines (C2 triangulation, C3 BA, C4 rectification) were
+  reachable only via a direct `vision-mvg` dependency; also unblocks future
+  Python parity for the MVG surface. Surface locked by
+  `tests/facade_compile_surface.rs` (default + `refine`).
 
 ## B — app (extend; sequencing serves V-track)
 


### PR DESCRIPTION
## C-FACADE-MVG — expose the MVG surface through the facade

The MVG pipelines landed in the C-track (C2 N-view triangulation, C3 bundle adjustment, C4 Scheimpflug rectification) were reachable **only** by depending on `vision-mvg` directly — the `vision-calibration` facade re-exported the low-level `geometry` solvers but not the higher-level `mvg` surface. This closes that gap (flagged in #74).

### What changed
- New `vision_calibration::mvg` module (mirrors the existing `geometry` module style), re-exporting `pose_recovery`, `robust`, `cheirality`, `degeneracy`, `triangulation`, `homography`, `rectification`, `residuals`, `types`, `error`, and `MvgError`.
- Frozen-intrinsics `bundle_adjust` (which pulls in `tiny-solver`) is surfaced behind a **new facade `refine` feature** (`refine = ["vision-mvg/refine"]`), so the default build stays lean — symmetric with `vision-mvg`'s own `refine` gating.
- `vision-mvg` added as a facade dependency.

### Why
- Makes the whole MVG surface usable through the single facade entry point (e.g. `vision_calibration::mvg::rectification::rectify_stereo_pair`), consistent with how `linear`/`geometry`/the problem modules are already exposed.
- Unblocks future Python parity (D3) for the MVG surface — the bindings depend on the facade only.

### Tests
`tests/facade_compile_surface.rs` extended to lock the new surface:
- `mvg_module_surface_compiles` — names the key re-exported paths (default).
- `mvg_rectification_runs_through_facade` — a real `rectify_stereo_pair` call (asserts the recovered baseline).
- `mvg_bundle_adjust_reachable_under_refine` — `#[cfg(feature = "refine")]`, runs under `--all-features`.

### Gates
`fmt --check` · `clippy --workspace --all-targets --all-features -D warnings` · `test --workspace --all-features` · `RUSTDOCFLAGS="-D warnings" doc --workspace --all-features` — all green. Default-feature facade build confirmed lean (no tiny-solver).

Backlog: `C-FACADE-MVG` marked done. No `docs/report/` file (per the amended AGENTS.md §11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)