### PR TITLE
docs: MVG tutorial + runnable example (C-MVG-TUTORIAL)

### DIFF
--- a/crates/vision-calibration/examples/mvg_two_view.rs
+++ b/crates/vision-calibration/examples/mvg_two_view.rs
@@ -1,0 +1,192 @@
+//! Two-view multiple-view geometry through the facade `mvg` module.
+//!
+//! Companion runnable example for
+//! [`docs/tutorials/multiple-view-geometry.md`]. It walks the
+//! facade-exposed MVG surface end-to-end on a synthetic calibrated stereo pair
+//! with known ground truth:
+//!
+//! 1. relative pose recovery (5-point + cheirality) — `mvg::pose_recovery`
+//! 2. two-view triangulation (returned by step 1)   — `mvg::types`
+//! 3. bundle adjustment (with `--features refine`)   — `mvg::bundle_adjust`
+//! 4. Scheimpflug-aware stereo rectification         — `mvg::rectification`
+//!
+//! Run:
+//! ```bash
+//! cargo run -p vision-calibration --example mvg_two_view --features refine
+//! ```
+
+use nalgebra::{Matrix3, Rotation3, Translation3, UnitQuaternion, Vector3};
+use vision_calibration::core::{Iso3, Pt2, Pt3};
+use vision_calibration::mvg::{
+    pose_recovery::recover_relative_pose,
+    rectification::{RectifyCamera, RectifyOptions, rectify_stereo_pair},
+    types::Correspondence2D,
+};
+
+/// Shared pinhole intrinsics for both cameras.
+fn intrinsics() -> Matrix3<f64> {
+    Matrix3::new(800.0, 0.0, 320.0, 0.0, 800.0, 240.0, 0.0, 0.0, 1.0)
+}
+
+/// Ground-truth relative pose `T_C1_C0` (maps a point from camera 0 to camera 1).
+fn ground_truth_pose() -> Iso3 {
+    let r = Rotation3::from_euler_angles(0.02, 0.06, -0.01);
+    Iso3::from_parts(Translation3::new(-0.6, 0.04, 0.10), UnitQuaternion::from(r))
+}
+
+/// A genuinely 3-D point cloud in front of both cameras (world == camera-0
+/// frame). Depth is decorrelated from `(x, y)` and spans a wide range so the
+/// scene is non-planar — a near-planar cloud is degenerate for the 5-point
+/// essential-matrix estimator.
+fn scene() -> Vec<Pt3> {
+    let mut pts = Vec::new();
+    for i in 0..6 {
+        for j in 0..6 {
+            let x = -0.6 + 0.24 * i as f64;
+            let y = -0.6 + 0.24 * j as f64;
+            let h = ((i * 5 + j * 11 + 7) % 17) as f64 / 16.0; // pseudo-random in [0, 1]
+            let z = 3.5 + 3.0 * h; // depth in [3.5, 6.5], decorrelated from x/y
+            pts.push(Pt3::new(x, y, z));
+        }
+    }
+    pts
+}
+
+/// Normalized image coordinates of a camera-frame point.
+fn normalize(p: &Vector3<f64>) -> Pt2 {
+    Pt2::new(p.x / p.z, p.y / p.z)
+}
+
+/// Apply (zero-skew) pinhole intrinsics to a normalized point → pixel.
+fn to_pixel(k: &Matrix3<f64>, n: &Pt2) -> Pt2 {
+    Pt2::new(k[(0, 0)] * n.x + k[(0, 2)], k[(1, 1)] * n.y + k[(1, 2)])
+}
+
+fn main() {
+    let k = intrinsics();
+    let gt = ground_truth_pose();
+    let points = scene();
+
+    // Project the scene into both cameras. Camera 0 is the world frame; a point
+    // in camera 1 is `gt * p`. Pose recovery wants normalized coordinates;
+    // rectification wants pixels.
+    let mut corrs = Vec::new();
+    let mut px0 = Vec::new();
+    let mut px1 = Vec::new();
+    for p in &points {
+        let c0 = p.coords;
+        let c1 = (gt * p).coords;
+        if c0.z <= 0.0 || c1.z <= 0.0 {
+            continue;
+        }
+        let (n0, n1) = (normalize(&c0), normalize(&c1));
+        corrs.push(Correspondence2D::new(n0, n1));
+        px0.push(to_pixel(&k, &n0));
+        px1.push(to_pixel(&k, &n1));
+    }
+    println!(
+        "scene: {} correspondences visible in both views",
+        corrs.len()
+    );
+
+    // 1 + 2. Relative pose recovery (5-point + cheirality) also triangulates the
+    // inlier correspondences. Translation is recovered up to scale (unit length).
+    let rel = recover_relative_pose(&corrs).expect("recover relative pose");
+    let rot_err = (rel.r - gt.rotation.to_rotation_matrix().into_inner()).norm();
+    let t_dot = rel.t.dot(&gt.translation.vector.normalize()).abs();
+    println!(
+        "1. pose recovery : rotation Δ = {rot_err:.2e}, |t·t_gt| = {t_dot:.6}, \
+         {} points triangulated",
+        rel.points.len()
+    );
+    assert!(rot_err < 1e-3, "rotation not recovered: {rot_err}");
+    assert!(
+        t_dot > 0.9999,
+        "translation direction not recovered: {t_dot}"
+    );
+
+    // 3. Bundle adjustment jointly refines poses + structure (frozen intrinsics).
+    #[cfg(feature = "refine")]
+    bundle_adjust_demo(&k, &gt, &points);
+    #[cfg(not(feature = "refine"))]
+    println!("3. bundle adjust : skipped — re-run with `--features refine`");
+
+    // 4. Rectify the calibrated pair so corresponding points share an image row.
+    let rect = rectify_stereo_pair(
+        &RectifyCamera::pinhole(k),
+        &RectifyCamera::pinhole(k),
+        &gt,
+        &RectifyOptions::default(),
+    )
+    .expect("rectify stereo pair");
+    let max_dv = px0
+        .iter()
+        .zip(&px1)
+        .map(|(a, b)| (rect.rectify_left(a).y - rect.rectify_right(b).y).abs())
+        .fold(0.0_f64, f64::max);
+    println!(
+        "4. rectification : baseline = {:.3}, max row disagreement = {max_dv:.2e} px",
+        rect.baseline
+    );
+    assert!(max_dv < 1e-9, "rectified rows not aligned: {max_dv}");
+
+    println!("\nAll stages recovered ground truth. ✔");
+}
+
+/// Perturb the second camera + the structure, then bundle-adjust back to ground
+/// truth. Camera 0 (the reference) anchors the rigid gauge.
+#[cfg(feature = "refine")]
+fn bundle_adjust_demo(k: &Matrix3<f64>, gt: &Iso3, points: &[Pt3]) {
+    use vision_calibration::mvg::bundle_adjust::{
+        BundleAdjustmentOptions, BundleObservation, bundle_adjust,
+    };
+
+    let poses_gt = [Iso3::identity(), *gt];
+    let intr = [*k, *k];
+
+    // Every point seen by both cameras (pixel observations).
+    let mut obs = Vec::new();
+    for (j, p) in points.iter().enumerate() {
+        for (cam, pose) in poses_gt.iter().enumerate() {
+            let c = (pose * p).coords;
+            if c.z > 0.0 {
+                obs.push(BundleObservation::new(cam, j, to_pixel(k, &normalize(&c))));
+            }
+        }
+    }
+
+    // Perturb camera 1 and the points; camera 0 stays at ground truth as the anchor.
+    let mut init_poses = poses_gt;
+    init_poses[1] = *gt
+        * Iso3::from_parts(
+            Translation3::new(0.05, -0.03, 0.04),
+            UnitQuaternion::from(Rotation3::from_euler_angles(0.01, -0.015, 0.008)),
+        );
+    let init_points: Vec<Pt3> = points
+        .iter()
+        .enumerate()
+        .map(|(i, p)| p + 0.1 * Vector3::new((i % 3) as f64 - 1.0, (i % 2) as f64 - 0.5, 0.2))
+        .collect();
+
+    let res = bundle_adjust(
+        &intr,
+        &obs,
+        &init_poses,
+        &init_points,
+        &BundleAdjustmentOptions::default(),
+    )
+    .expect("bundle adjust");
+    println!(
+        "3. bundle adjust : RMS {:.4} → {:.4} px over {} cameras, {} points",
+        res.initial_rms,
+        res.final_rms,
+        res.poses.len(),
+        res.points.len()
+    );
+    assert!(
+        res.final_rms < 0.1 && res.final_rms < res.initial_rms,
+        "bundle adjustment did not converge: {} → {}",
+        res.initial_rms,
+        res.final_rms
+    );
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -326,6 +326,15 @@ Systemic causes:
   reachable only via a direct `vision-mvg` dependency; also unblocks future
   Python parity for the MVG surface. Surface locked by
   `tests/facade_compile_surface.rs` (default + `refine`).
+- [x] C-MVG-TUTORIAL - Tutorial + runnable example for the MVG surface.
+  **Done 2026-06-21**. `docs/tutorials/multiple-view-geometry.md` (pose recovery
+  → triangulation → bundle adjustment → Scheimpflug-aware rectification via the
+  facade `mvg` module) with the runnable companion
+  `crates/vision-calibration/examples/mvg_two_view.rs` — a synthetic-GT
+  end-to-end demo (pose recovery exact, BA 18→0.03 px, rectification rows align
+  to ~1e-13 px). BA section is `#[cfg(feature = "refine")]`-gated so the example
+  builds in both configs. Tutorials README index updated. Closes the
+  ship-a-tutorial-with-new-features gap for C2/C3/C4.
 
 ## B — app (extend; sequencing serves V-track)
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -14,6 +14,7 @@ authoritative reference and stays green in CI.
 | Drill into per-corner reprojection errors (diagnose mode) | [Per-feature residuals](./per-feature-residuals.md) | [`manual_init_proof.rs`](../../crates/vision-calibration/examples/manual_init_proof.rs) (Run A printout) |
 | Calibrate a Scheimpflug rig + laser device end-to-end on real data | [Puzzle 130×130 walkthrough](./puzzle-130x130-walkthrough.md) | [`puzzle_130x130_rig.rs`](../../crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs) (private dataset) |
 | Describe a laser dataset in `dataset.toml` and run it through the app | [Laser dataset manifest](./laser-dataset-manifest.md) | `rtv3d_laser_end_to_end` test in [`app/src-tauri/src/run.rs`](../../app/src-tauri/src/run.rs) (private dataset) |
+| Recover relative pose, triangulate, bundle-adjust, and rectify a calibrated stereo pair | [Multiple-view geometry](./multiple-view-geometry.md) | [`mvg_two_view.rs`](../../crates/vision-calibration/examples/mvg_two_view.rs) |
 
 ## Target detectors
 

--- a/docs/tutorials/multiple-view-geometry.md
+++ b/docs/tutorials/multiple-view-geometry.md
@@ -1,0 +1,137 @@
+# Multiple-view geometry
+
+> Onboarding tutorial. Runnable companion:
+> [`mvg_two_view.rs`](../../crates/vision-calibration/examples/mvg_two_view.rs).
+> Run it with `cargo run -p vision-calibration --example mvg_two_view --features refine`.
+
+## Why
+
+Calibration tells you *what each camera is* (intrinsics, distortion, pose).
+**Multiple-view geometry (MVG)** is what you do *with* a calibrated rig:
+recover the relative pose between two views, triangulate 3-D structure, refine
+both with bundle adjustment, and rectify a stereo pair for dense matching. This
+tutorial is the tour of that surface, now reachable through the facade as
+`vision_calibration::mvg`.
+
+It is aimed at someone who already has calibrated cameras (e.g. from the
+[five-minute calibration](./five-minute-calibration.md)) and wants to reconstruct
+or rectify.
+
+## Mental model
+
+Everything in `mvg` operates on **calibrated** observations. Two coordinate
+conventions matter:
+
+- **Normalized image coordinates** — pixels after applying `K⁻¹`. Relative-pose
+  recovery and triangulation work here, so geometry is independent of the
+  specific intrinsics.
+- **Pixel coordinates** — what rectification consumes (it folds `K` back in).
+
+Poses follow the project convention (ADR 0009): `T_C1_C0` maps a point from
+camera 0's frame into camera 1's frame (`p_c1 = R · p_c0 + t`).
+
+The surface, in dependency order:
+
+```
+mvg::pose_recovery   recover_relative_pose  ← 5-point + cheirality (also triangulates)
+mvg::triangulation   triangulate_nview      ← N-view DLT + refinement
+mvg::bundle_adjust   bundle_adjust          ← joint poses + structure (feature `refine`)
+mvg::rectification   rectify_stereo_pair    ← rectifying homographies (Scheimpflug-aware)
+mvg::robust          *_robust               ← RANSAC wrappers for outlier-laden data
+```
+
+## Walkthrough
+
+The companion example builds a synthetic calibrated stereo pair with known
+ground truth and runs the whole pipeline. The key steps:
+
+### 1. Recover the relative pose (and triangulate)
+
+Given calibrated correspondences in **normalized** coordinates,
+`recover_relative_pose` runs the 5-point algorithm, disambiguates the four
+essential-matrix decompositions by cheirality (positive depth), and triangulates
+the inliers:
+
+```rust
+use vision_calibration::mvg::pose_recovery::recover_relative_pose;
+use vision_calibration::mvg::types::Correspondence2D;
+
+let corrs: Vec<Correspondence2D> = /* (normalized pt in cam0, normalized pt in cam1) */;
+let rel = recover_relative_pose(&corrs)?;
+// rel.r : rotation cam0 → cam1
+// rel.t : unit translation direction (absolute scale is unobservable from two views)
+// rel.points : triangulated 3-D points with reprojection + parallax diagnostics
+```
+
+Two-view translation is recovered only **up to scale** — there is no metric
+anchor in two bare views. Fix scale with a known baseline or a known 3-D point.
+
+For outlier-contaminated correspondences, reach for
+`mvg::robust::recover_relative_pose_robust` (RANSAC) instead.
+
+### 2. Bundle adjustment (feature `refine`)
+
+`bundle_adjust` jointly refines all camera **poses** and the 3-D **structure**
+to minimize reprojection error, holding per-camera intrinsics frozen. It is
+behind the `refine` feature (it pulls in `tiny-solver`):
+
+```rust
+use vision_calibration::mvg::bundle_adjust::{bundle_adjust, BundleAdjustmentOptions, BundleObservation};
+
+let res = bundle_adjust(&intrinsics, &observations, &init_poses, &init_points,
+                        &BundleAdjustmentOptions::default())?;
+println!("RMS {:.3} → {:.3} px", res.initial_rms, res.final_rms);
+```
+
+By default the **first observed camera** is held fixed to remove the rigid gauge
+freedom; global scale remains a gauge that reprojection cannot observe with free
+structure (documented on `BundleAdjustmentOptions::fix_first_camera`). In the
+example a ~18 px initial reprojection error collapses to ~0.03 px.
+
+### 3. Stereo rectification
+
+`rectify_stereo_pair` returns rectifying homographies that put corresponding
+points on the **same image row** — the precondition for 1-D disparity search.
+It handles **Scheimpflug** (tilted-sensor) cameras as well as plain pinholes:
+
+```rust
+use vision_calibration::mvg::rectification::{rectify_stereo_pair, RectifyCamera, RectifyOptions};
+
+let rect = rectify_stereo_pair(
+    &RectifyCamera::pinhole(k0),            // or RectifyCamera::scheimpflug(k0, tilt0)
+    &RectifyCamera::pinhole(k1),
+    &cam1_se3_cam0,                          // the calibrated relative pose
+    &RectifyOptions::default(),
+)?;
+let p_left  = rect.rectify_left(&undistorted_pixel0);
+let p_right = rect.rectify_right(&undistorted_pixel1);
+// p_left.y == p_right.y for a corresponding pair
+```
+
+Inputs are **undistorted** pixels — remove lens distortion first (the rectifying
+homography is the rotation part of rectification, exactly as OpenCV splits
+`initUndistortRectifyMap`). See [ADR 0015](../adrs/0015-mvg-ceiling.md) for the
+crate's scope boundary.
+
+## Common variations
+
+- **Outliers in the matches** → `mvg::robust::recover_relative_pose_robust` /
+  `estimate_essential` / `estimate_homography` (RANSAC).
+- **More than two views** → `mvg::triangulation::triangulate_nview` for a single
+  point across N cameras; `bundle_adjust` already takes any number of cameras.
+- **A Scheimpflug rig** → pass `RectifyCamera::scheimpflug(k, tilt)` per camera;
+  the tilt is absorbed into the rectifying homography automatically.
+- **Getting the inputs from a calibration** → a `RigExtrinsicsExport`'s
+  `cameras[i].k.k_matrix()`, `sensors[i]`, and `cam_se3_rig[i]` feed
+  `RectifyCamera` and the relative pose directly.
+
+## What to read next
+
+- [ADR 0015](../adrs/0015-mvg-ceiling.md) — the MVG crate's scope ceiling
+  (no SfM / pose-graph / loop closure).
+- [ADR 0009](../adrs/0009-coordinate-and-pose-conventions.md) — pose and frame
+  conventions (`frame_se3_frame`, `T_C_W`).
+- Crate docs for `vision_calibration::mvg::{pose_recovery, triangulation,
+  bundle_adjust, rectification, robust}`.
+- The low-level solvers underneath: `vision_calibration::geometry`
+  (epipolar, homography, triangulation, camera-matrix).

--- a/docs/tutorials/multiple-view-geometry.md
+++ b/docs/tutorials/multiple-view-geometry.md
@@ -121,9 +121,18 @@ crate's scope boundary.
   point across N cameras; `bundle_adjust` already takes any number of cameras.
 - **A Scheimpflug rig** → pass `RectifyCamera::scheimpflug(k, tilt)` per camera;
   the tilt is absorbed into the rectifying homography automatically.
-- **Getting the inputs from a calibration** → a `RigExtrinsicsExport`'s
-  `cameras[i].k.k_matrix()`, `sensors[i]`, and `cam_se3_rig[i]` feed
-  `RectifyCamera` and the relative pose directly.
+- **Getting the inputs from a calibration** → from a `RigExtrinsicsExport`,
+  `cameras[i].k.k_matrix()` and `sensors[i]` build each `RectifyCamera`. The
+  relative pose is **composed** from the two cameras' extrinsics:
+
+  ```rust
+  // cam_se3_rig[i] is T_Ci_R (camera i ← rig), so:
+  let cam1_se3_cam0 = export.cam_se3_rig[right] * export.cam_se3_rig[left].inverse();
+  ```
+
+  A single `cam_se3_rig[i]` equals the relative pose only in the special case
+  where the left camera is the reference frame (`cam_se3_rig[left] = Identity`);
+  compose explicitly for any other pair or `reference_camera_idx`.
 
 ## What to read next
 


### PR DESCRIPTION
## C-MVG-TUTORIAL — tutorial + runnable example for the MVG surface

C2 (triangulation), C3 (bundle adjustment), and C4 (rectification) all shipped without the tutorial that `CLAUDE.md` asks every new feature to carry. This closes that gap for the whole MVG arc, now that the surface is facade-exposed (`vision_calibration::mvg`, #75).

### What's here
- **`docs/tutorials/multiple-view-geometry.md`** — narrative walkthrough: coordinate conventions, then relative pose recovery → triangulation → bundle adjustment → Scheimpflug-aware rectification, with "common variations" and pointers to ADR 0015 / 0009.
- **`crates/vision-calibration/examples/mvg_two_view.rs`** — the runnable, self-validating companion (the authoritative reference, per the tutorials README). Builds a synthetic calibrated stereo pair with known ground truth and runs the full pipeline:
  ```
  scene: 36 correspondences visible in both views
  1. pose recovery : rotation Δ = 2.43e-15, |t·t_gt| = 1.000000, 36 points triangulated
  3. bundle adjust : RMS 18.1423 → 0.0296 px over 2 cameras, 36 points
  4. rectification : baseline = 0.610, max row disagreement = 1.14e-13 px
  ```
- Tutorials README index row added; `C-MVG-TUTORIAL` recorded in the backlog.

### Notes
- The bundle-adjustment section is `#[cfg(feature = "refine")]`-gated, so the example builds **and runs** in both feature configs (`cargo run … --example mvg_two_view` with or without `--features refine`). CI covers it under `clippy --all-targets --all-features` and `cargo build --workspace --locked`.
- The synthetic scene uses a genuinely 3-D, depth-decorrelated point cloud — a near-planar cloud is degenerate for the 5-point essential-matrix estimator (caught while writing the example).

### Gates
`fmt --check` · `clippy --workspace --all-targets --all-features -D warnings` · `build --workspace --locked` · `RUSTDOCFLAGS="-D warnings" doc --workspace --all-features` — all green. Example runs green in both configs.

No `docs/report/` file (per the amended AGENTS.md §11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)