### PR TITLE
feat(planar): selectable distortion model (M-WIRE vertical slice)

### DIFF
--- a/crates/vision-calibration-bench/src/run.rs
+++ b/crates/vision-calibration-bench/src/run.rs
@@ -3312,7 +3312,14 @@ pub mod tier_b {
         let mut artifacts = CalibrationArtifacts {
             spatial_unit: "mm".to_string(),
             angle_unit: "deg".to_string(),
-            cameras: vec![camera_artifact(camera_id, &export.params.camera, None)],
+            cameras: vec![camera_artifact(
+                camera_id,
+                &export
+                    .params
+                    .pinhole_camera()
+                    .expect("planar export pinhole camera"),
+                None,
+            )],
             transforms: Vec::new(),
         };
         for (view_idx, pose) in export.params.camera_se3_target.iter().enumerate() {

--- a/crates/vision-calibration-core/src/lib.rs
+++ b/crates/vision-calibration-core/src/lib.rs
@@ -155,11 +155,14 @@ pub struct TargetPose {
 ///
 /// The transform chain is `p_cam = T_C_T * p_target`.
 ///
+/// Accepts any camera implementing [`CameraProject`] (e.g. [`PinholeCamera`] or
+/// the model-agnostic [`CameraModel`]).
+///
 /// # Errors
 ///
 /// Returns [`Error::InvalidInput`] if no points could be projected.
-pub fn compute_mean_reproj_error(
-    camera: &PinholeCamera,
+pub fn compute_mean_reproj_error<C: CameraProject>(
+    camera: &C,
     views: &[View<TargetPose>],
 ) -> Result<Real, Error> {
     let mut total_error = 0.0;
@@ -168,7 +171,7 @@ pub fn compute_mean_reproj_error(
     for view in views {
         for (p3d, p2d) in view.obs.points_3d.iter().zip(view.obs.points_2d.iter()) {
             let p_cam = view.meta.camera_se3_target * p3d;
-            if let Some(projected) = camera.project_point_c(&p_cam.coords) {
+            if let Some(projected) = camera.project_camera_point(&p_cam.coords) {
                 let error = (projected - *p2d).norm();
                 total_error += error;
                 total_points += 1;

--- a/crates/vision-calibration-optim/benches/ba_iter.rs
+++ b/crates/vision-calibration-optim/benches/ba_iter.rs
@@ -94,7 +94,8 @@ fn planar_intrinsics_ba(c: &mut Criterion) {
     let (dataset, cam_init, poses_gt) = synthetic_problem();
     c.bench_function("planar_intrinsics_ba_10views_70pts", |b| {
         b.iter(|| {
-            let init = PlanarIntrinsicsParams::new(cam_init.clone(), poses_gt.clone()).unwrap();
+            let init =
+                PlanarIntrinsicsParams::from_pinhole(cam_init.clone(), poses_gt.clone()).unwrap();
             optimize_planar_intrinsics(
                 black_box(&dataset),
                 black_box(&init),

--- a/crates/vision-calibration-optim/src/ir/types.rs
+++ b/crates/vision-calibration-optim/src/ir/types.rs
@@ -161,7 +161,9 @@ impl ProjectionKind {
 /// Distortion slot of a [`CameraModelDesc`].
 ///
 /// `dim() == 0` means the factor takes no distortion parameter block.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
 pub enum DistortionKind {
     /// No distortion; no parameter block.
     None,

--- a/crates/vision-calibration-optim/src/lib.rs
+++ b/crates/vision-calibration-optim/src/lib.rs
@@ -158,7 +158,9 @@ pub use crate::ir::{
     ParamSlotSpec, ProblemIR, ProjectionKind, ReprojChain, ResidualBlock, RobustLoss, SensorKind,
 };
 
-pub use crate::params::distortion::{DISTORTION_DIM, pack_distortion};
+pub use crate::params::distortion::{
+    DISTORTION_DIM, pack_distortion, pack_distortion_params, unpack_distortion_params,
+};
 pub use crate::params::intrinsics::{INTRINSICS_DIM, pack_intrinsics};
 pub use crate::params::laser_plane::LaserPlane;
 pub use crate::params::pose_se3::{iso3_to_se3_dvec, se3_dvec_to_iso3};

--- a/crates/vision-calibration-optim/src/params/distortion.rs
+++ b/crates/vision-calibration-optim/src/params/distortion.rs
@@ -1,8 +1,11 @@
 //! Distortion parameter packing for optimization.
 
 use crate::Error;
+use crate::ir::DistortionKind;
 use nalgebra::{DVector, DVectorView};
-use vision_calibration_core::{BrownConrady5, Real};
+use vision_calibration_core::{
+    BrownConrady5, DistortionParams, RationalPolynomial, Real, ThinPrism,
+};
 
 /// Dimension of the Brown-Conrady distortion vector [k1, k2, k3, p1, p2].
 pub const DISTORTION_DIM: usize = 5;
@@ -38,6 +41,97 @@ pub fn unpack_distortion(v: DVectorView<'_, f64>) -> Result<BrownConrady5<Real>,
     })
 }
 
+/// Pack a [`DistortionParams`] into the IR-ordered distortion vector for the
+/// active variant.
+///
+/// - `None`           → empty `DVector` (length 0)
+/// - `BrownConrady5`  → `[k1, k2, k3, p1, p2]`
+/// - `Rational`       → `[k1, k2, k3, k4, k5, k6, p1, p2]`
+/// - `ThinPrism`      → `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`
+/// - `Division`       → `[lambda]`
+pub fn pack_distortion_params(d: &DistortionParams) -> DVector<f64> {
+    match d {
+        DistortionParams::None => DVector::zeros(0),
+        DistortionParams::BrownConrady5 { params: p } => {
+            nalgebra::dvector![p.k1, p.k2, p.k3, p.p1, p.p2]
+        }
+        DistortionParams::Rational { params: p } => {
+            nalgebra::dvector![p.k1, p.k2, p.k3, p.k4, p.k5, p.k6, p.p1, p.p2]
+        }
+        DistortionParams::ThinPrism { params: p } => {
+            nalgebra::dvector![p.k1, p.k2, p.k3, p.p1, p.p2, p.s1, p.s2, p.s3, p.s4]
+        }
+        DistortionParams::Division { lambda } => {
+            nalgebra::dvector![*lambda]
+        }
+    }
+}
+
+/// Unpack a [`DistortionParams`] from an IR-ordered distortion vector.
+///
+/// `kind` selects the expected length and layout; returns
+/// [`Error::InvalidInput`] if `v.len() != kind.dim()`.
+///
+/// The `iters` field (where present on the underlying struct) is set to 8.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidInput`] if `v.len() != kind.dim()`.
+pub fn unpack_distortion_params(
+    kind: DistortionKind,
+    v: DVectorView<'_, f64>,
+) -> Result<DistortionParams, Error> {
+    if v.len() != kind.dim() {
+        return Err(Error::invalid_input(format!(
+            "expected distortion vector of length {} for {:?}, got {}",
+            kind.dim(),
+            kind,
+            v.len()
+        )));
+    }
+    match kind {
+        DistortionKind::None => Ok(DistortionParams::None),
+        DistortionKind::BrownConrady5 => Ok(DistortionParams::BrownConrady5 {
+            params: BrownConrady5 {
+                k1: v[0],
+                k2: v[1],
+                k3: v[2],
+                p1: v[3],
+                p2: v[4],
+                iters: 8,
+            },
+        }),
+        DistortionKind::Rational8 => Ok(DistortionParams::Rational {
+            params: RationalPolynomial {
+                k1: v[0],
+                k2: v[1],
+                k3: v[2],
+                k4: v[3],
+                k5: v[4],
+                k6: v[5],
+                p1: v[6],
+                p2: v[7],
+                iters: 8,
+            },
+        }),
+        DistortionKind::ThinPrism9 => Ok(DistortionParams::ThinPrism {
+            params: ThinPrism {
+                k1: v[0],
+                k2: v[1],
+                k3: v[2],
+                p1: v[3],
+                p2: v[4],
+                s1: v[5],
+                s2: v[6],
+                s3: v[7],
+                s4: v[8],
+                iters: 8,
+            },
+        }),
+        DistortionKind::Division1 => Ok(DistortionParams::Division { lambda: v[0] }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,5 +154,121 @@ mod tests {
         assert_eq!(restored.p1, dist.p1);
         assert_eq!(restored.p2, dist.p2);
         assert_eq!(restored.iters, 8);
+    }
+
+    // ── Model-aware pack/unpack roundtrips ──────────────────────────────────
+
+    #[test]
+    fn pack_unpack_params_none() {
+        let d = DistortionParams::None;
+        let v = pack_distortion_params(&d);
+        assert_eq!(v.len(), 0);
+        let restored = unpack_distortion_params(DistortionKind::None, v.as_view()).unwrap();
+        assert!(matches!(restored, DistortionParams::None));
+    }
+
+    #[test]
+    fn pack_unpack_params_brown_conrady5() {
+        let d = DistortionParams::BrownConrady5 {
+            params: BrownConrady5 {
+                k1: -0.1,
+                k2: 0.02,
+                k3: 0.003,
+                p1: 0.001,
+                p2: -0.002,
+                iters: 9,
+            },
+        };
+        let v = pack_distortion_params(&d);
+        assert_eq!(v.len(), 5);
+        let restored =
+            unpack_distortion_params(DistortionKind::BrownConrady5, v.as_view()).unwrap();
+        let DistortionParams::BrownConrady5 { params: p } = restored else {
+            panic!("wrong variant");
+        };
+        assert!((p.k1 - (-0.1)).abs() < 1e-15);
+        assert!((p.k2 - 0.02).abs() < 1e-15);
+        assert!((p.k3 - 0.003).abs() < 1e-15);
+        assert!((p.p1 - 0.001).abs() < 1e-15);
+        assert!((p.p2 - (-0.002)).abs() < 1e-15);
+        assert_eq!(p.iters, 8);
+    }
+
+    #[test]
+    fn pack_unpack_params_rational8() {
+        use vision_calibration_core::RationalPolynomial;
+        let d = DistortionParams::Rational {
+            params: RationalPolynomial {
+                k1: 0.1,
+                k2: -0.05,
+                k3: 0.001,
+                k4: 0.01,
+                k5: -0.005,
+                k6: 0.002,
+                p1: 0.003,
+                p2: -0.001,
+                iters: 10,
+            },
+        };
+        let v = pack_distortion_params(&d);
+        assert_eq!(v.len(), 8);
+        let restored = unpack_distortion_params(DistortionKind::Rational8, v.as_view()).unwrap();
+        let DistortionParams::Rational { params: p } = restored else {
+            panic!("wrong variant");
+        };
+        assert!((p.k1 - 0.1).abs() < 1e-15);
+        assert!((p.k4 - 0.01).abs() < 1e-15);
+        assert!((p.p2 - (-0.001)).abs() < 1e-15);
+        assert_eq!(p.iters, 8);
+    }
+
+    #[test]
+    fn pack_unpack_params_thinprism9() {
+        use vision_calibration_core::ThinPrism;
+        let d = DistortionParams::ThinPrism {
+            params: ThinPrism {
+                k1: -0.2,
+                k2: 0.05,
+                k3: 0.0,
+                p1: 0.001,
+                p2: -0.001,
+                s1: 0.002,
+                s2: -0.001,
+                s3: 0.003,
+                s4: -0.002,
+                iters: 10,
+            },
+        };
+        let v = pack_distortion_params(&d);
+        assert_eq!(v.len(), 9);
+        let restored = unpack_distortion_params(DistortionKind::ThinPrism9, v.as_view()).unwrap();
+        let DistortionParams::ThinPrism { params: p } = restored else {
+            panic!("wrong variant");
+        };
+        assert!((p.s1 - 0.002).abs() < 1e-15);
+        assert!((p.s4 - (-0.002)).abs() < 1e-15);
+        assert_eq!(p.iters, 8);
+    }
+
+    #[test]
+    fn pack_unpack_params_division1() {
+        let d = DistortionParams::Division { lambda: -0.15 };
+        let v = pack_distortion_params(&d);
+        assert_eq!(v.len(), 1);
+        let restored = unpack_distortion_params(DistortionKind::Division1, v.as_view()).unwrap();
+        let DistortionParams::Division { lambda } = restored else {
+            panic!("wrong variant");
+        };
+        assert!((lambda - (-0.15)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn unpack_params_rejects_wrong_length() {
+        let v = nalgebra::dvector![1.0, 2.0]; // len 2
+        let err = unpack_distortion_params(DistortionKind::BrownConrady5, v.as_view()).unwrap_err();
+        assert!(
+            err.to_string().contains("5"),
+            "error should mention expected length 5: {err}"
+        );
     }
 }

--- a/crates/vision-calibration-optim/src/problems/planar_intrinsics.rs
+++ b/crates/vision-calibration-optim/src/problems/planar_intrinsics.rs
@@ -218,6 +218,42 @@ fn build_planar_intrinsics_ir(
     let kind = distortion_params_to_kind(&initial.camera.distortion);
     let model = camera_model_desc_for_kind(kind);
 
+    // Planar intrinsics is a pinhole, identity-sensor model. The IR builder
+    // selects the camera model from the distortion kind ALONE, so a non-pinhole
+    // projection or a non-identity sensor (Scheimpflug/Homography) on the input
+    // `CameraParams` would be silently dropped and a *different* model optimized
+    // (the result is also rebuilt with an identity sensor). Reject up front.
+    if !matches!(initial.camera.projection, ProjectionParams::Pinhole) {
+        return Err(Error::invalid_input(
+            "planar intrinsics supports only the pinhole projection",
+        ));
+    }
+    if !matches!(initial.camera.sensor, SensorParams::Identity) {
+        return Err(Error::invalid_input(
+            "planar intrinsics supports only the identity sensor; use a \
+             Scheimpflug problem type for tilted sensors",
+        ));
+    }
+
+    // Exactly one initial pose per view: too few panics on `pose_ids[view_idx]`
+    // below, too many are silently unused. Reject the mismatch.
+    if initial.camera_se3_target.len() != dataset.num_views() {
+        return Err(Error::invalid_input(format!(
+            "initial pose count {} != view count {}",
+            initial.camera_se3_target.len(),
+            dataset.num_views()
+        )));
+    }
+
+    // `fix_poses` indices must reference real views.
+    if let Some(&bad) = opts.fix_poses.iter().find(|&&i| i >= dataset.num_views()) {
+        return Err(Error::invalid_input(format!(
+            "fix_poses index {} out of range for {} views",
+            bad,
+            dataset.num_views()
+        )));
+    }
+
     // For BC5 the existing `fix_distortion` indices apply; for other models
     // all distortion params are free (the mask is BC5-shaped and doesn't
     // translate to other orderings).

--- a/crates/vision-calibration-optim/src/problems/planar_intrinsics.rs
+++ b/crates/vision-calibration-optim/src/problems/planar_intrinsics.rs
@@ -5,35 +5,37 @@
 
 use crate::Error;
 use crate::backend::{BackendKind, BackendSolveOptions, SolveReport, solve_with_backend};
-use crate::ir::RobustLoss;
-use crate::params::distortion::unpack_distortion;
-use crate::params::intrinsics::unpack_intrinsics;
-use crate::params::pose_se3::se3_dvec_to_iso3;
-use crate::problems::planar_family_shared::{
-    PlanarReprojectionIrOptions, build_planar_reprojection_ir,
+use crate::ir::{
+    CameraModelDesc, DistortionKind, FactorKind, FixedMask, ManifoldKind, ProblemIR, ReprojChain,
+    ResidualBlock, RobustLoss,
 };
+use crate::params::distortion::{pack_distortion_params, unpack_distortion_params};
+use crate::params::intrinsics::{INTRINSICS_DIM, pack_intrinsics, unpack_intrinsics};
+use crate::params::pose_se3::{iso3_to_se3_dvec, se3_dvec_to_iso3};
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    BrownConrady5, DistortionFixMask, FxFyCxCySkew, IntrinsicsFixMask, Iso3, PinholeCamera,
-    PlanarDataset, Real, TargetPose, View, compute_mean_reproj_error, make_pinhole_camera,
+    BrownConrady5, CameraModel, CameraParams, DistortionFixMask, DistortionParams, FxFyCxCySkew,
+    IntrinsicsFixMask, IntrinsicsParams, Iso3, PinholeCamera, PlanarDataset, ProjectionParams,
+    Real, SensorParams, TargetPose, View, compute_mean_reproj_error, make_pinhole_camera,
+    pinhole_camera_params,
 };
 
 /// Optimization result for planar intrinsics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanarIntrinsicsParams {
-    /// Refined camera with intrinsics and distortion.
-    pub camera: PinholeCamera,
+    /// Refined camera model (model-agnostic serializable parameters).
+    pub camera: CameraParams,
     /// Refined target-to-camera poses.
     pub camera_se3_target: Vec<Iso3>,
 }
 
 impl PlanarIntrinsicsParams {
-    /// Construct parameter pack with non-empty pose validation.
+    /// Construct parameter pack from model-agnostic [`CameraParams`].
     ///
     /// # Errors
     ///
     /// Returns [`Error::InsufficientData`] if `camera_se3_target` is empty.
-    pub fn new(camera: PinholeCamera, camera_se3_target: Vec<Iso3>) -> Result<Self, Error> {
+    pub fn new(camera: CameraParams, camera_se3_target: Vec<Iso3>) -> Result<Self, Error> {
         if camera_se3_target.is_empty() {
             return Err(Error::InsufficientData { need: 1, got: 0 });
         }
@@ -43,7 +45,55 @@ impl PlanarIntrinsicsParams {
         })
     }
 
-    /// Create from individual components.
+    /// Construct from a concrete [`PinholeCamera`] (Brown-Conrady) and poses.
+    ///
+    /// Convenience back-compat wrapper used by rig calibration and tests that
+    /// operate with the concrete `PinholeCamera` type.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InsufficientData`] if `camera_se3_target` is empty.
+    pub fn from_pinhole(
+        camera: PinholeCamera,
+        camera_se3_target: Vec<Iso3>,
+    ) -> Result<Self, Error> {
+        Self::new(pinhole_camera_params(&camera), camera_se3_target)
+    }
+
+    /// Reconstruct a [`PinholeCamera`] (Brown-Conrady) from the stored params.
+    ///
+    /// Only valid when the stored distortion is `BrownConrady5` or `None`.
+    /// Rig calibration always uses Brown-Conrady, so this path is always safe
+    /// for rig consumers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidInput`] if the stored distortion is not a
+    /// Brown-Conrady or `None` variant, or if intrinsics are unavailable.
+    pub fn pinhole_camera(&self) -> Result<PinholeCamera, Error> {
+        let k = self.intrinsics();
+        let dist = match &self.camera.distortion {
+            DistortionParams::None => BrownConrady5::default(),
+            DistortionParams::BrownConrady5 { params } => *params,
+            other => {
+                return Err(Error::invalid_input(format!(
+                    "pinhole_camera() requires BrownConrady5 or None distortion, got {:?}",
+                    std::mem::discriminant(other)
+                )));
+            }
+        };
+        Ok(make_pinhole_camera(k, dist))
+    }
+
+    /// Build the runtime [`CameraModel`] for residual computation.
+    ///
+    /// Panics only if a stored homography sensor is not invertible (cannot
+    /// arise from the standard planar calibration path).
+    pub fn build_camera(&self) -> CameraModel {
+        self.camera.build()
+    }
+
+    /// Create from individual components (Brown-Conrady).
     ///
     /// # Errors
     ///
@@ -53,7 +103,7 @@ impl PlanarIntrinsicsParams {
         distortion: BrownConrady5<Real>,
         poses: Vec<Iso3>,
     ) -> Result<Self, Error> {
-        Self::new(make_pinhole_camera(intrinsics, distortion), poses)
+        Self::from_pinhole(make_pinhole_camera(intrinsics, distortion), poses)
     }
 
     /// Create with zero distortion (pinhole model only).
@@ -61,7 +111,7 @@ impl PlanarIntrinsicsParams {
         intrinsics: FxFyCxCySkew<Real>,
         camera_se3_target: Vec<Iso3>,
     ) -> Result<Self, Error> {
-        Self::new(
+        Self::from_pinhole(
             make_pinhole_camera(intrinsics, BrownConrady5::default()),
             camera_se3_target,
         )
@@ -69,12 +119,20 @@ impl PlanarIntrinsicsParams {
 
     /// Get intrinsics.
     pub fn intrinsics(&self) -> FxFyCxCySkew<Real> {
-        self.camera.k
+        match self.camera.intrinsics {
+            IntrinsicsParams::FxFyCxCySkew { params } => params,
+        }
     }
 
-    /// Get distortion.
-    pub fn distortion(&self) -> BrownConrady5<Real> {
-        self.camera.dist
+    /// Get distortion as Brown-Conrady (for BC-only consumers).
+    ///
+    /// Returns `None` when the active model is not Brown-Conrady or None.
+    pub fn distortion(&self) -> Option<BrownConrady5<Real>> {
+        match &self.camera.distortion {
+            DistortionParams::None => Some(BrownConrady5::default()),
+            DistortionParams::BrownConrady5 { params } => Some(*params),
+            _ => None,
+        }
     }
 
     /// Get poses.
@@ -102,6 +160,9 @@ pub struct PlanarIntrinsicsSolveOptions {
     /// Mask for fixing intrinsics parameters.
     pub fix_intrinsics: IntrinsicsFixMask,
     /// Mask for fixing distortion parameters (k3 fixed by default).
+    ///
+    /// This mask is applied only when the distortion model is BrownConrady5.
+    /// For other models all distortion coefficients are free by default.
     pub fix_distortion: DistortionFixMask,
     /// Indices of poses to keep fixed.
     pub fix_poses: Vec<usize>,
@@ -115,6 +176,28 @@ impl Default for PlanarIntrinsicsSolveOptions {
             fix_distortion: DistortionFixMask::default(), // k3 fixed by default
             fix_poses: Vec::new(),
         }
+    }
+}
+
+/// Map a [`DistortionParams`] variant to the corresponding [`DistortionKind`].
+fn distortion_params_to_kind(d: &DistortionParams) -> DistortionKind {
+    match d {
+        DistortionParams::None => DistortionKind::None,
+        DistortionParams::BrownConrady5 { .. } => DistortionKind::BrownConrady5,
+        DistortionParams::Rational { .. } => DistortionKind::Rational8,
+        DistortionParams::ThinPrism { .. } => DistortionKind::ThinPrism9,
+        DistortionParams::Division { .. } => DistortionKind::Division1,
+    }
+}
+
+/// Select the [`CameraModelDesc`] matching the distortion kind.
+fn camera_model_desc_for_kind(kind: DistortionKind) -> CameraModelDesc {
+    match kind {
+        DistortionKind::None => CameraModelDesc::PINHOLE4,
+        DistortionKind::BrownConrady5 => CameraModelDesc::PINHOLE4_DIST5,
+        DistortionKind::Rational8 => CameraModelDesc::PINHOLE4_RATIONAL8,
+        DistortionKind::ThinPrism9 => CameraModelDesc::PINHOLE4_THINPRISM9,
+        DistortionKind::Division1 => CameraModelDesc::PINHOLE4_DIVISION1,
     }
 }
 
@@ -132,22 +215,99 @@ fn build_planar_intrinsics_ir(
     ),
     Error,
 > {
-    build_planar_reprojection_ir(
-        dataset,
-        &initial.camera.k,
-        &initial.camera.dist,
-        &initial.camera_se3_target,
-        &PlanarReprojectionIrOptions {
-            robust_loss: opts.robust_loss,
-            fix_intrinsics_indices: opts.fix_intrinsics.to_indices(),
-            fix_distortion_indices: opts.fix_distortion.to_indices(),
-            fix_pose_indices: opts.fix_poses.clone(),
-            sensor: None,
-            model: crate::ir::CameraModelDesc::PINHOLE4_DIST5,
-            intrinsics_bounds: None,
-            sensor_bounds: None,
-        },
-    )
+    let kind = distortion_params_to_kind(&initial.camera.distortion);
+    let model = camera_model_desc_for_kind(kind);
+
+    // For BC5 the existing `fix_distortion` indices apply; for other models
+    // all distortion params are free (the mask is BC5-shaped and doesn't
+    // translate to other orderings).
+    let fix_dist_indices = if kind == DistortionKind::BrownConrady5 {
+        opts.fix_distortion.to_indices()
+    } else {
+        vec![]
+    };
+
+    use std::collections::{HashMap, HashSet};
+
+    let intrinsics = initial.intrinsics();
+    let dist_vec = pack_distortion_params(&initial.camera.distortion);
+
+    let poses = &initial.camera_se3_target;
+
+    let fixed_pose_set: HashSet<usize> = opts.fix_poses.iter().copied().collect();
+
+    let mut ir = ProblemIR::new();
+    let mut initial_map: HashMap<String, nalgebra::DVector<f64>> = HashMap::new();
+
+    let cam_id = ir.add_param_block(
+        "cam",
+        INTRINSICS_DIM,
+        ManifoldKind::Euclidean,
+        FixedMask::fix_indices(&opts.fix_intrinsics.to_indices()),
+        None,
+    );
+    initial_map.insert("cam".to_string(), pack_intrinsics(&intrinsics)?);
+
+    // Only add a distortion block when the model has one.
+    let dist_id = if kind != DistortionKind::None {
+        let id = ir.add_param_block(
+            "dist",
+            kind.dim(),
+            ManifoldKind::Euclidean,
+            FixedMask::fix_indices(&fix_dist_indices),
+            None,
+        );
+        initial_map.insert("dist".to_string(), dist_vec);
+        Some(id)
+    } else {
+        None
+    };
+
+    let mut pose_ids = Vec::with_capacity(poses.len());
+    for (view_idx, pose) in poses.iter().enumerate() {
+        let fixed = if fixed_pose_set.contains(&view_idx) {
+            FixedMask::all_fixed(7)
+        } else {
+            FixedMask::all_free()
+        };
+        let pose_key = format!("pose/{view_idx}");
+        let pose_id = ir.add_param_block(&pose_key, 7, ManifoldKind::SE3, fixed, None);
+        initial_map.insert(pose_key, iso3_to_se3_dvec(pose));
+        pose_ids.push(pose_id);
+    }
+
+    for (view_idx, view) in dataset.views.iter().enumerate() {
+        let pose_id = pose_ids[view_idx];
+        for (point_idx, (pw, uv)) in view
+            .obs
+            .points_3d
+            .iter()
+            .zip(view.obs.points_2d.iter())
+            .enumerate()
+        {
+            let mut params = vec![cam_id];
+            if let Some(did) = dist_id {
+                params.push(did);
+            }
+            params.push(pose_id);
+            let factor = FactorKind::ReprojPoint {
+                model,
+                chain: ReprojChain::SinglePose,
+                pw: [pw.x, pw.y, pw.z],
+                uv: [uv.x, uv.y],
+                w: view.obs.weight(point_idx),
+            };
+            ir.add_residual_block(ResidualBlock {
+                params,
+                loss: opts.robust_loss,
+                factor,
+                residual_dim: 2,
+            });
+        }
+    }
+
+    ir.validate()?;
+    Ok((ir, initial_map))
 }
 
 /// Optimize planar intrinsics using the default tiny-solver backend.
@@ -182,6 +342,8 @@ pub fn optimize_planar_intrinsics_with_backend(
     backend: BackendKind,
     backend_opts: BackendSolveOptions,
 ) -> Result<PlanarIntrinsicsEstimate, Error> {
+    let kind = distortion_params_to_kind(&initial.camera.distortion);
+
     let (ir, initial_map) = build_planar_intrinsics_ir(dataset, initial, &opts)?;
     let solution = solve_with_backend(backend, &ir, &initial_map, &backend_opts)?;
 
@@ -191,11 +353,16 @@ pub fn optimize_planar_intrinsics_with_backend(
         .ok_or_else(|| Error::numerical("missing camera parameters in solution"))?;
     let intrinsics = unpack_intrinsics(cam_vec.as_view())?;
 
-    let dist_vec = solution
-        .params
-        .get("dist")
-        .ok_or_else(|| Error::numerical("missing distortion parameters in solution"))?;
-    let distortion = unpack_distortion(dist_vec.as_view())?;
+    // Unpack distortion (may be empty for DistortionKind::None).
+    let distortion = if kind != DistortionKind::None {
+        let dist_vec = solution
+            .params
+            .get("dist")
+            .ok_or_else(|| Error::numerical("missing distortion parameters in solution"))?;
+        unpack_distortion_params(kind, dist_vec.as_view())?
+    } else {
+        DistortionParams::None
+    };
 
     let mut poses = Vec::with_capacity(dataset.num_views());
     for i in 0..dataset.num_views() {
@@ -207,7 +374,14 @@ pub fn optimize_planar_intrinsics_with_backend(
         poses.push(se3_dvec_to_iso3(pose_vec.as_view())?);
     }
 
-    let camera = make_pinhole_camera(intrinsics, distortion);
+    let camera_params = CameraParams {
+        projection: ProjectionParams::Pinhole,
+        distortion,
+        sensor: SensorParams::Identity,
+        intrinsics: IntrinsicsParams::FxFyCxCySkew { params: intrinsics },
+    };
+    let camera_model = camera_params.build();
+
     let views_with_poses: Vec<View<TargetPose>> = dataset
         .views
         .iter()
@@ -216,10 +390,10 @@ pub fn optimize_planar_intrinsics_with_backend(
             View::new(view.obs.clone(), TargetPose { camera_se3_target })
         })
         .collect();
-    let mean_reproj_error = compute_mean_reproj_error(&camera, &views_with_poses)?;
+    let mean_reproj_error = compute_mean_reproj_error(&camera_model, &views_with_poses)?;
 
     Ok(PlanarIntrinsicsEstimate {
-        params: PlanarIntrinsicsParams::new(camera, poses)?,
+        params: PlanarIntrinsicsParams::new(camera_params, poses)?,
         report: solution.solve_report,
         mean_reproj_error,
     })

--- a/crates/vision-calibration-optim/tests/planar_intrinsics.rs
+++ b/crates/vision-calibration-optim/tests/planar_intrinsics.rs
@@ -2,8 +2,9 @@
 
 use nalgebra::{UnitQuaternion, Vector3};
 use vision_calibration_core::{
-    BrownConrady5, CorrespondenceView, DistortionFixMask, FxFyCxCySkew, IntrinsicsFixMask, Iso3,
-    PinholeCamera, PlanarDataset, Pt2, Pt3, Real, View, make_pinhole_camera,
+    BrownConrady5, CameraParams, CorrespondenceView, DistortionFixMask, DistortionParams,
+    FxFyCxCySkew, IntrinsicsFixMask, IntrinsicsParams, Iso3, PinholeCamera, PlanarDataset,
+    ProjectionParams, Pt2, Pt3, Real, SensorParams, View, make_pinhole_camera,
 };
 use vision_calibration_optim::{
     BackendSolveOptions, PlanarIntrinsicsParams, PlanarIntrinsicsSolveOptions, RobustLoss,
@@ -527,5 +528,72 @@ fn distortion_parameter_masking_works() {
         (dist_res.k2 - dist_gt.k2).abs() < 0.01,
         "k2 should converge, off by {}",
         dist_res.k2 - dist_gt.k2
+    );
+}
+
+#[test]
+fn rejects_pose_count_mismatch_instead_of_panicking() {
+    // A caller supplying fewer poses than views must get a typed error, not a
+    // panic on `pose_ids[view_idx]` (codex P2 regression guard).
+    let SyntheticScenario {
+        dataset,
+        mut poses_gt,
+        cam_init,
+        ..
+    } = build_synthetic_scenario(0.0);
+    assert!(poses_gt.len() == dataset.num_views() && poses_gt.len() > 1);
+    poses_gt.pop(); // one fewer pose than views
+
+    let init = PlanarIntrinsicsParams::from_pinhole(cam_init, poses_gt).unwrap();
+    let err = optimize_planar_intrinsics(
+        &dataset,
+        &init,
+        PlanarIntrinsicsSolveOptions::default(),
+        BackendSolveOptions::default(),
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("pose count"),
+        "expected pose-count mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn rejects_non_identity_sensor() {
+    // Planar intrinsics selects the camera model from the distortion kind only;
+    // a non-identity sensor would be silently dropped. It must be rejected
+    // up front (codex P2 regression guard).
+    let SyntheticScenario {
+        dataset, poses_gt, ..
+    } = build_synthetic_scenario(0.0);
+
+    let bad_camera = CameraParams {
+        projection: ProjectionParams::Pinhole,
+        distortion: DistortionParams::None,
+        // identity-valued homography, but still a non-Identity sensor variant
+        sensor: SensorParams::Homography {
+            h: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        },
+        intrinsics: IntrinsicsParams::FxFyCxCySkew {
+            params: FxFyCxCySkew {
+                fx: 800.0,
+                fy: 800.0,
+                cx: 320.0,
+                cy: 240.0,
+                skew: 0.0,
+            },
+        },
+    };
+    let init = PlanarIntrinsicsParams::new(bad_camera, poses_gt).unwrap();
+    let err = optimize_planar_intrinsics(
+        &dataset,
+        &init,
+        PlanarIntrinsicsSolveOptions::default(),
+        BackendSolveOptions::default(),
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("identity sensor"),
+        "expected non-identity-sensor rejection, got: {err}"
     );
 }

--- a/crates/vision-calibration-optim/tests/planar_intrinsics.rs
+++ b/crates/vision-calibration-optim/tests/planar_intrinsics.rs
@@ -122,16 +122,17 @@ fn synthetic_planar_intrinsics_refinement_converges() {
     } = build_synthetic_scenario(0.0);
     let k_gt = cam_gt.k;
 
-    let init = PlanarIntrinsicsParams::new(cam_init, poses_gt).unwrap();
+    let init = PlanarIntrinsicsParams::from_pinhole(cam_init, poses_gt).unwrap();
     let opts = PlanarIntrinsicsSolveOptions::default();
     let solver = BackendSolveOptions::default();
 
     let result = optimize_planar_intrinsics(&dataset, &init, opts, solver).unwrap();
+    let k = result.params.intrinsics();
 
-    assert!((result.params.camera.k.fx - k_gt.fx).abs() < 5.0);
-    assert!((result.params.camera.k.fy - k_gt.fy).abs() < 5.0);
-    assert!((result.params.camera.k.cx - k_gt.cx).abs() < 5.0);
-    assert!((result.params.camera.k.cy - k_gt.cy).abs() < 5.0);
+    assert!((k.fx - k_gt.fx).abs() < 5.0);
+    assert!((k.fy - k_gt.fy).abs() < 5.0);
+    assert!((k.cx - k_gt.cx).abs() < 5.0);
+    assert!((k.cy - k_gt.cy).abs() < 5.0);
 }
 
 #[test]
@@ -215,7 +216,7 @@ fn synthetic_planar_intrinsics_with_outliers_robust_better_than_l2() {
         },
     );
 
-    let init = PlanarIntrinsicsParams::new(cam_init, poses_gt).unwrap();
+    let init = PlanarIntrinsicsParams::from_pinhole(cam_init, poses_gt).unwrap();
     let solver = BackendSolveOptions::default();
 
     let l2_opts = PlanarIntrinsicsSolveOptions::default();
@@ -227,15 +228,15 @@ fn synthetic_planar_intrinsics_with_outliers_robust_better_than_l2() {
     let l2 = optimize_planar_intrinsics(&dataset, &init, l2_opts, solver.clone()).unwrap();
     let robust = optimize_planar_intrinsics(&dataset, &init, robust_opts, solver).unwrap();
 
-    let err_total = |cam: &PinholeCamera| -> Real {
-        (cam.k.fx - k_gt.fx).abs()
-            + (cam.k.fy - k_gt.fy).abs()
-            + (cam.k.cx - k_gt.cx).abs()
-            + (cam.k.cy - k_gt.cy).abs()
+    let err_total = |k: vision_calibration_core::FxFyCxCySkew<Real>| -> Real {
+        (k.fx - k_gt.fx).abs()
+            + (k.fy - k_gt.fy).abs()
+            + (k.cx - k_gt.cx).abs()
+            + (k.cy - k_gt.cy).abs()
     };
 
-    let err_l2 = err_total(&l2.params.camera);
-    let err_robust = err_total(&robust.params.camera);
+    let err_l2 = err_total(l2.params.intrinsics());
+    let err_robust = err_total(robust.params.intrinsics());
 
     assert!(
         err_robust < err_l2,
@@ -254,7 +255,7 @@ fn intrinsics_masking_keeps_fixed_params() {
         ..
     } = build_synthetic_scenario(0.0);
 
-    let init = PlanarIntrinsicsParams::new(cam_init, poses_gt).unwrap();
+    let init = PlanarIntrinsicsParams::from_pinhole(cam_init, poses_gt).unwrap();
     let opts = PlanarIntrinsicsSolveOptions {
         fix_intrinsics: IntrinsicsFixMask {
             fx: true,
@@ -266,13 +267,15 @@ fn intrinsics_masking_keeps_fixed_params() {
     let solver = BackendSolveOptions::default();
 
     let result = optimize_planar_intrinsics(&dataset, &init, opts, solver).unwrap();
+    let k_init = init.intrinsics();
+    let k_result = result.params.intrinsics();
 
     assert!(
-        (result.params.camera.k.fx - init.camera.k.fx).abs() < 1e-12,
+        (k_result.fx - k_init.fx).abs() < 1e-12,
         "fx should remain fixed"
     );
     assert!(
-        (result.params.camera.k.fy - init.camera.k.fy).abs() < 1e-12,
+        (k_result.fy - k_init.fy).abs() < 1e-12,
         "fy should remain fixed"
     );
 }
@@ -353,7 +356,7 @@ fn synthetic_planar_with_distortion_converges() {
             iters: 8,
         },
     );
-    let init = PlanarIntrinsicsParams::new(cam_init, poses_gt.clone()).unwrap();
+    let init = PlanarIntrinsicsParams::from_pinhole(cam_init, poses_gt.clone()).unwrap();
 
     let opts = PlanarIntrinsicsSolveOptions {
         robust_loss: RobustLoss::None,
@@ -363,63 +366,59 @@ fn synthetic_planar_with_distortion_converges() {
     let backend_opts = BackendSolveOptions::default();
     let result = optimize_planar_intrinsics(&dataset, &init, opts, backend_opts).unwrap();
 
+    let k_res = result.params.intrinsics();
+    let dist_res = result.params.distortion().expect("BC5 distortion expected");
+
     // Verify convergence to ground truth
     println!(
         "Final camera: fx={}, fy={}, cx={}, cy={}",
-        result.params.camera.k.fx,
-        result.params.camera.k.fy,
-        result.params.camera.k.cx,
-        result.params.camera.k.cy
+        k_res.fx, k_res.fy, k_res.cx, k_res.cy
     );
     println!(
         "Final distortion: k1={}, k2={}, k3={}, p1={}, p2={}",
-        result.params.camera.dist.k1,
-        result.params.camera.dist.k2,
-        result.params.camera.dist.k3,
-        result.params.camera.dist.p1,
-        result.params.camera.dist.p2
+        dist_res.k1, dist_res.k2, dist_res.k3, dist_res.p1, dist_res.p2
     );
 
     assert!(
-        (result.params.camera.k.fx - k_gt.fx).abs() < 5.0,
+        (k_res.fx - k_gt.fx).abs() < 5.0,
         "fx off by {}",
-        result.params.camera.k.fx - k_gt.fx
+        k_res.fx - k_gt.fx
     );
     assert!(
-        (result.params.camera.k.fy - k_gt.fy).abs() < 5.0,
+        (k_res.fy - k_gt.fy).abs() < 5.0,
         "fy off by {}",
-        result.params.camera.k.fy - k_gt.fy
+        k_res.fy - k_gt.fy
     );
     assert!(
-        (result.params.camera.k.cx - k_gt.cx).abs() < 3.0,
+        (k_res.cx - k_gt.cx).abs() < 3.0,
         "cx off by {}",
-        result.params.camera.k.cx - k_gt.cx
+        k_res.cx - k_gt.cx
     );
     assert!(
-        (result.params.camera.k.cy - k_gt.cy).abs() < 3.0,
+        (k_res.cy - k_gt.cy).abs() < 3.0,
         "cy off by {}",
-        result.params.camera.k.cy - k_gt.cy
+        k_res.cy - k_gt.cy
     );
 
     assert!(
-        (result.params.camera.dist.k1 - dist_gt.k1).abs() < 0.01,
+        (dist_res.k1 - dist_gt.k1).abs() < 0.01,
         "k1 off by {}",
-        result.params.camera.dist.k1 - dist_gt.k1
+        dist_res.k1 - dist_gt.k1
     );
     assert!(
-        (result.params.camera.dist.k2 - dist_gt.k2).abs() < 0.01,
+        (dist_res.k2 - dist_gt.k2).abs() < 0.01,
         "k2 off by {}",
-        result.params.camera.dist.k2 - dist_gt.k2
+        dist_res.k2 - dist_gt.k2
     );
     assert!(
-        (result.params.camera.dist.p1 - dist_gt.p1).abs() < 0.001,
+        (dist_res.p1 - dist_gt.p1).abs() < 0.001,
         "p1 off by {}",
-        result.params.camera.dist.p1 - dist_gt.p1
+        dist_res.p1 - dist_gt.p1
     );
     assert!(
-        (result.params.camera.dist.p2 - dist_gt.p2).abs() < 0.001,
+        (dist_res.p2 - dist_gt.p2).abs() < 0.001,
         "p2 off by {}",
-        result.params.camera.dist.p2 - dist_gt.p2
+        dist_res.p2 - dist_gt.p2
     );
 }
 
@@ -495,7 +494,7 @@ fn distortion_parameter_masking_works() {
             iters: 8,
         },
     );
-    let init = PlanarIntrinsicsParams::new(cam_init, poses_gt).unwrap();
+    let init = PlanarIntrinsicsParams::from_pinhole(cam_init, poses_gt).unwrap();
 
     // Fix k3, p1, p2 (they are zero in ground truth)
     let opts = PlanarIntrinsicsSolveOptions {
@@ -511,29 +510,22 @@ fn distortion_parameter_masking_works() {
     let result =
         optimize_planar_intrinsics(&dataset, &init, opts, BackendSolveOptions::default()).unwrap();
 
+    let dist_res = result.params.distortion().expect("BC5 distortion expected");
+
     // Fixed params should stay at initial values
-    assert_eq!(
-        result.params.camera.dist.k3, 0.0,
-        "k3 should stay fixed at 0"
-    );
-    assert_eq!(
-        result.params.camera.dist.p1, 0.0,
-        "p1 should stay fixed at 0"
-    );
-    assert_eq!(
-        result.params.camera.dist.p2, 0.0,
-        "p2 should stay fixed at 0"
-    );
+    assert_eq!(dist_res.k3, 0.0, "k3 should stay fixed at 0");
+    assert_eq!(dist_res.p1, 0.0, "p1 should stay fixed at 0");
+    assert_eq!(dist_res.p2, 0.0, "p2 should stay fixed at 0");
 
     // k1, k2 should converge
     assert!(
-        (result.params.camera.dist.k1 - dist_gt.k1).abs() < 0.01,
+        (dist_res.k1 - dist_gt.k1).abs() < 0.01,
         "k1 should converge, off by {}",
-        result.params.camera.dist.k1 - dist_gt.k1
+        dist_res.k1 - dist_gt.k1
     );
     assert!(
-        (result.params.camera.dist.k2 - dist_gt.k2).abs() < 0.01,
+        (dist_res.k2 - dist_gt.k2).abs() < 0.01,
         "k2 should converge, off by {}",
-        result.params.camera.dist.k2 - dist_gt.k2
+        dist_res.k2 - dist_gt.k2
     );
 }

--- a/crates/vision-calibration-optim/tests/planar_intrinsics_real_data.rs
+++ b/crates/vision-calibration-optim/tests/planar_intrinsics_real_data.rs
@@ -256,8 +256,12 @@ fn planar_intrinsics_real_data_improves_reprojection() {
         .unwrap();
 
         // Compute initial reprojection error
-        let (init_mean, init_max) =
-            compute_reprojection_error(&nl_views, &init.camera.k, &init.camera.dist, &init_poses);
+        let (init_mean, init_max) = compute_reprojection_error(
+            &nl_views,
+            &init.intrinsics(),
+            &init.distortion().expect("BC5"),
+            &init_poses,
+        );
         println!(
             "Initial reprojection error: mean={:.3} px, max={:.3} px",
             init_mean, init_max
@@ -278,30 +282,23 @@ fn planar_intrinsics_real_data_improves_reprojection() {
         let result = optimize_planar_intrinsics(&dataset, &init, opts, backend_opts)
             .expect("optimization failed");
 
+        let opt_k = result.params.intrinsics();
+        let opt_dist = result.params.distortion().expect("BC5");
+
         println!(
             "Optimized: fx={:.2}, fy={:.2}, cx={:.2}, cy={:.2}",
-            result.params.camera.k.fx,
-            result.params.camera.k.fy,
-            result.params.camera.k.cx,
-            result.params.camera.k.cy
+            opt_k.fx, opt_k.fy, opt_k.cx, opt_k.cy
         );
         println!(
             "Distortion: k1={:.6}, k2={:.6}, k3={:.6}, p1={:.6}, p2={:.6}",
-            result.params.camera.dist.k1,
-            result.params.camera.dist.k2,
-            result.params.camera.dist.k3,
-            result.params.camera.dist.p1,
-            result.params.camera.dist.p2
+            opt_dist.k1, opt_dist.k2, opt_dist.k3, opt_dist.p1, opt_dist.p2
         );
 
         // Compute final reprojection error
-        let opt_intrinsics = result.params.camera.k;
-        let opt_distortion = result.params.camera.dist;
-
         let (final_mean, final_max) = compute_reprojection_error(
             &nl_views,
-            &opt_intrinsics,
-            &opt_distortion,
+            &opt_k,
+            &opt_dist,
             &result.params.camera_se3_target,
         );
         println!(
@@ -443,27 +440,22 @@ fn planar_intrinsics_parameter_fixing_works() {
     let result = optimize_planar_intrinsics(&dataset, &init, opts, BackendSolveOptions::default())
         .expect("optimization with fixed p1, p2");
 
-    assert_eq!(
-        result.params.camera.dist.p1, 0.0,
-        "p1 should remain fixed at 0.0"
-    );
-    assert_eq!(
-        result.params.camera.dist.p2, 0.0,
-        "p2 should remain fixed at 0.0"
-    );
+    let dist_res = result.params.distortion().expect("BC5");
+    assert_eq!(dist_res.p1, 0.0, "p1 should remain fixed at 0.0");
+    assert_eq!(dist_res.p2, 0.0, "p2 should remain fixed at 0.0");
     println!(
         "✓ Tangential distortion stayed fixed: p1={}, p2={}",
-        result.params.camera.dist.p1, result.params.camera.dist.p2
+        dist_res.p1, dist_res.p2
     );
 
     // Radial should have changed
     assert!(
-        result.params.camera.dist.k1.abs() > 1e-6 || result.params.camera.dist.k2.abs() > 1e-6,
+        dist_res.k1.abs() > 1e-6 || dist_res.k2.abs() > 1e-6,
         "Radial distortion should be optimized"
     );
     println!(
         "✓ Radial distortion optimized: k1={:.6}, k2={:.6}",
-        result.params.camera.dist.k1, result.params.camera.dist.k2
+        dist_res.k1, dist_res.k2
     );
 
     // Test 2: Fix k3 (default behavior)
@@ -495,14 +487,9 @@ fn planar_intrinsics_parameter_fixing_works() {
         optimize_planar_intrinsics(&dataset, &init2, opts2, BackendSolveOptions::default())
             .expect("optimization with default k3 fixed");
 
-    assert_eq!(
-        result2.params.camera.dist.k3, 0.0,
-        "k3 should be fixed by default"
-    );
-    println!(
-        "✓ k3 stayed fixed at default: k3={}",
-        result2.params.camera.dist.k3
-    );
+    let dist_res2 = result2.params.distortion().expect("BC5");
+    assert_eq!(dist_res2.k3, 0.0, "k3 should be fixed by default");
+    println!("✓ k3 stayed fixed at default: k3={}", dist_res2.k3);
 
     // Test 3: Fix intrinsics, optimize only distortion
     println!("\nTest 3: Fixing intrinsics (fx, fy), optimizing distortion");
@@ -541,21 +528,18 @@ fn planar_intrinsics_parameter_fixing_works() {
         optimize_planar_intrinsics(&dataset, &init3, opts3, BackendSolveOptions::default())
             .expect("optimization with fixed fx, fy");
 
-    assert!(
-        (result3.params.camera.k.fx - init3.camera.k.fx).abs() < 1e-6,
-        "fx should remain fixed"
-    );
-    assert!(
-        (result3.params.camera.k.fy - init3.camera.k.fy).abs() < 1e-6,
-        "fy should remain fixed"
-    );
+    let k3 = result3.params.intrinsics();
+    let k_init3 = init3.intrinsics();
+    let dist_res3 = result3.params.distortion().expect("BC5");
+    assert!((k3.fx - k_init3.fx).abs() < 1e-6, "fx should remain fixed");
+    assert!((k3.fy - k_init3.fy).abs() < 1e-6, "fy should remain fixed");
     println!(
         "✓ Intrinsics stayed fixed: fx={:.2}, fy={:.2}",
-        result3.params.camera.k.fx, result3.params.camera.k.fy
+        k3.fx, k3.fy
     );
     println!(
         "✓ Distortion optimized: k1={:.6}, k2={:.6}",
-        result3.params.camera.dist.k1, result3.params.camera.dist.k2
+        dist_res3.k1, dist_res3.k2
     );
 
     println!("\n✓ All parameter fixing tests passed\n");
@@ -713,28 +697,23 @@ fn planar_intrinsics_with_iterative_linear_init() {
         let result = optimize_planar_intrinsics(&dataset, &init, optim_opts, backend_opts)
             .expect("optimization");
 
+        let opt_k = result.params.intrinsics();
+        let opt_dist = result.params.distortion().expect("BC5");
+
         println!(
             "  Final K: fx={:.1}, fy={:.1}, cx={:.1}, cy={:.1}",
-            result.params.camera.k.fx,
-            result.params.camera.k.fy,
-            result.params.camera.k.cx,
-            result.params.camera.k.cy
+            opt_k.fx, opt_k.fy, opt_k.cx, opt_k.cy
         );
         println!(
             "  Final distortion: k1={:.4}, k2={:.4}, p1={:.4}, p2={:.4}",
-            result.params.camera.dist.k1,
-            result.params.camera.dist.k2,
-            result.params.camera.dist.p1,
-            result.params.camera.dist.p2
+            opt_dist.k1, opt_dist.k2, opt_dist.p1, opt_dist.p2
         );
 
         // Step 3: Compute reprojection error
-        let opt_intrinsics = result.params.camera.k;
-        let opt_distortion_params = result.params.camera.dist;
         let (mean_err, max_err) = compute_reprojection_error(
             &views_optim,
-            &opt_intrinsics,
-            &opt_distortion_params,
+            &opt_k,
+            &opt_dist,
             &result.params.camera_se3_target,
         );
 
@@ -749,10 +728,10 @@ fn planar_intrinsics_with_iterative_linear_init() {
         let cx_gt = k_gt[(0, 2)];
         let cy_gt = k_gt[(1, 2)];
 
-        let fx_err_pct = (result.params.camera.k.fx - fx_gt).abs() / fx_gt * 100.0;
-        let fy_err_pct = (result.params.camera.k.fy - fy_gt).abs() / fy_gt * 100.0;
-        let cx_err = (result.params.camera.k.cx - cx_gt).abs();
-        let cy_err = (result.params.camera.k.cy - cy_gt).abs();
+        let fx_err_pct = (opt_k.fx - fx_gt).abs() / fx_gt * 100.0;
+        let fy_err_pct = (opt_k.fy - fy_gt).abs() / fy_gt * 100.0;
+        let cx_err = (opt_k.cx - cx_gt).abs();
+        let cy_err = (opt_k.cy - cy_gt).abs();
 
         println!(
             "  Final errors: fx={:.2}%, fy={:.2}%, cx={:.2}px, cy={:.2}px",
@@ -783,7 +762,7 @@ fn planar_intrinsics_with_iterative_linear_init() {
 
         // Distortion signs should match
         assert!(
-            result.params.camera.dist.k1.signum() == dist_gt.k1.signum(),
+            opt_dist.k1.signum() == dist_gt.k1.signum(),
             "{side}: k1 sign mismatch"
         );
 

--- a/crates/vision-calibration-pipeline/src/analysis/mod.rs
+++ b/crates/vision-calibration-pipeline/src/analysis/mod.rs
@@ -291,12 +291,12 @@ pub fn planar_intrinsics_report<M>(
     export: &PlanarIntrinsicsExport,
     views: &[View<M>],
 ) -> Result<ReprojReport, Error> {
-    let cam = &export.params.camera;
-    let k = cam.k;
+    let cam = export.params.build_camera();
+    let k = export.params.intrinsics();
     let residuals = if !export.per_feature_residuals.target.is_empty() {
         export.per_feature_residuals.target.clone()
     } else {
-        intrinsic_floor_single_cam(cam, &k, views, 0)
+        intrinsic_floor_single_cam(&cam, &k, views, 0)
     };
     let num_views = views.len().max(max_pose(&residuals) + 1);
     let level = LevelReport::from_residuals(ReprojLevel::Intrinsic, residuals, 1, num_views);

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/problem.rs
@@ -11,7 +11,7 @@ use vision_calibration_core::{
 };
 use vision_calibration_linear::prelude::*;
 use vision_calibration_optim::{
-    BackendSolveOptions, PlanarIntrinsicsEstimate, PlanarIntrinsicsParams,
+    BackendSolveOptions, DistortionKind, PlanarIntrinsicsEstimate, PlanarIntrinsicsParams,
     PlanarIntrinsicsSolveOptions, SolveReport,
 };
 
@@ -97,6 +97,21 @@ pub struct PlanarIntrinsicsConfig {
 
     /// Indices of poses to fix during optimization (e.g., \[0\] to fix first pose).
     pub fix_poses: Vec<usize>,
+
+    /// Distortion model to use for optimization.
+    ///
+    /// Selects which distortion model is built during initialization and
+    /// handed to the optimizer. Brown-Conrady5 is the default and is
+    /// compatible with all existing downstream rig consumers. Extended
+    /// models (Rational8, ThinPrism9, Division1) are PlanarIntrinsics-only;
+    /// they cannot be passed into `RigExtrinsics` / `RigHandeye` pipelines
+    /// which still expect a `PinholeCamera`.
+    #[serde(default = "default_distortion_kind")]
+    pub distortion_model: DistortionKind,
+}
+
+fn default_distortion_kind() -> DistortionKind {
+    DistortionKind::BrownConrady5
 }
 
 impl Default for PlanarIntrinsicsConfig {
@@ -114,6 +129,7 @@ impl Default for PlanarIntrinsicsConfig {
             fix_intrinsics: Default::default(),
             fix_distortion: Default::default(),
             fix_poses: Vec::new(),
+            distortion_model: DistortionKind::BrownConrady5,
         }
     }
 }
@@ -244,11 +260,9 @@ impl ProblemType for PlanarIntrinsicsProblem {
         // Length-mismatch is a logic error inside the pipeline (output came
         // out of an optimizer that ran on `input`); surface it as a typed
         // error rather than panicking.
-        let target = compute_planar_target_residuals(
-            &output.params.camera,
-            input,
-            &output.params.camera_se3_target,
-        )?;
+        let cam = output.params.build_camera();
+        let target =
+            compute_planar_target_residuals(&cam, input, &output.params.camera_se3_target)?;
         let target_hist = build_feature_histogram(target.iter().filter_map(|r| r.error_px));
         let mut per_feature_residuals = PerFeatureResiduals::default();
         per_feature_residuals.target = target;
@@ -442,9 +456,11 @@ mod tests {
             },
             vision_calibration_core::BrownConrady5::default(),
         );
-        let params =
-            PlanarIntrinsicsParams::new(camera, vec![vision_calibration_core::Iso3::identity()])
-                .expect("valid params");
+        let params = PlanarIntrinsicsParams::from_pinhole(
+            camera,
+            vec![vision_calibration_core::Iso3::identity()],
+        )
+        .expect("valid params");
         let output = PlanarIntrinsicsEstimate {
             params,
             report: SolveReport {
@@ -537,8 +553,8 @@ mod tests {
         ])
         .unwrap();
 
-        let params =
-            PlanarIntrinsicsParams::new(camera, vec![pose, pose, pose]).expect("valid params");
+        let params = PlanarIntrinsicsParams::from_pinhole(camera, vec![pose, pose, pose])
+            .expect("valid params");
         let output = PlanarIntrinsicsEstimate {
             params,
             report: SolveReport {
@@ -605,7 +621,8 @@ mod tests {
             .unwrap(),
         );
         let dataset = vision_calibration_core::PlanarDataset::new(vec![view]).unwrap();
-        let params = PlanarIntrinsicsParams::new(camera, vec![pose]).expect("valid params");
+        let params =
+            PlanarIntrinsicsParams::from_pinhole(camera, vec![pose]).expect("valid params");
         let output = PlanarIntrinsicsEstimate {
             params,
             report: SolveReport {
@@ -656,9 +673,11 @@ mod tests {
             },
             vision_calibration_core::BrownConrady5::default(),
         );
-        let params =
-            PlanarIntrinsicsParams::new(camera, vec![vision_calibration_core::Iso3::identity()])
-                .expect("valid params");
+        let params = PlanarIntrinsicsParams::from_pinhole(
+            camera,
+            vec![vision_calibration_core::Iso3::identity()],
+        )
+        .expect("valid params");
         let mut export = PlanarIntrinsicsExport {
             params,
             report: SolveReport {

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/state.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/state.rs
@@ -4,7 +4,9 @@
 //! computed during the calibration pipeline (homographies, initial estimates, etc.).
 
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{BrownConrady5, FxFyCxCySkew, Iso3, Mat3, Real, make_pinhole_camera};
+use vision_calibration_core::{
+    BrownConrady5, CameraParams, FxFyCxCySkew, Iso3, Mat3, Real, make_pinhole_camera,
+};
 use vision_calibration_optim::PlanarIntrinsicsParams;
 
 /// Intermediate state for planar intrinsics calibration.
@@ -34,6 +36,12 @@ pub(crate) struct PlanarState {
 
     /// Initial pose estimates for each view (camera_T_target).
     pub initial_poses: Option<Vec<Iso3>>,
+
+    /// Full camera params for extended distortion models (Rational8, ThinPrism9,
+    /// Division1). When set, `initial_params()` uses this directly instead of
+    /// building a Brown-Conrady5 `PinholeCamera`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_camera_params: Option<CameraParams>,
 
     // ─────────────────────────────────────────────────────────────────────────
     // From optimization
@@ -66,16 +74,24 @@ impl PlanarState {
 
     /// Get initial parameters for optimization.
     ///
-    /// Constructs `PlanarIntrinsicsParams` from the initial estimates.
+    /// When `initial_camera_params` is set (extended distortion model), uses it
+    /// directly. Otherwise constructs a Brown-Conrady5 `PinholeCamera` from
+    /// `initial_intrinsics` + `initial_distortion`.
+    ///
     /// Returns `None` if initialization hasn't been run.
     pub fn initial_params(&self) -> Option<PlanarIntrinsicsParams> {
+        let poses = self.initial_poses.clone()?;
+
+        if let Some(camera_params) = &self.initial_camera_params {
+            return PlanarIntrinsicsParams::new(camera_params.clone(), poses).ok();
+        }
+
         let intrinsics = self.initial_intrinsics?;
         let distortion = self.initial_distortion.unwrap_or_default();
-        let poses = self.initial_poses.clone()?;
 
         // Construct camera from intrinsics and distortion
         let camera = make_pinhole_camera(intrinsics, distortion);
-        PlanarIntrinsicsParams::new(camera, poses).ok()
+        PlanarIntrinsicsParams::from_pinhole(camera, poses).ok()
     }
 
     /// Clear optimization results, keeping initialization.

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/steps.rs
@@ -36,8 +36,12 @@
 
 use crate::Error;
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, Real, View};
-use vision_calibration_optim::optimize_planar_intrinsics;
+use vision_calibration_core::{
+    BrownConrady5, CameraParams, CameraProject, CorrespondenceView, DistortionParams, FxFyCxCySkew,
+    IntrinsicsParams, Iso3, ProjectionParams, RationalPolynomial, Real, SensorParams, ThinPrism,
+    View,
+};
+use vision_calibration_optim::{DistortionKind, optimize_planar_intrinsics};
 
 use crate::planar_family::{
     bootstrap_planar_intrinsics, estimate_view_homographies, recover_planar_poses_from_homographies,
@@ -284,10 +288,17 @@ pub fn step_init_with_seed(
         (bootstrap.camera.k, dist, bootstrap.homographies, poses)
     };
 
+    // Build extended-model CameraParams when the config requests a model other
+    // than BrownConrady5.  The linear init always produces BC5 coefficients;
+    // we embed them into the target model and zero any extra degrees of freedom.
+    let extended_camera_params =
+        build_initial_camera_params(intrinsics, &distortion, session.config.distortion_model);
+
     session.state.homographies = Some(homographies);
     session.state.initial_intrinsics = Some(intrinsics);
     session.state.initial_distortion = Some(distortion);
     session.state.initial_poses = Some(poses.clone());
+    session.state.initial_camera_params = extended_camera_params;
     session.state.clear_optimization();
 
     let source = format_init_source(&manual_fields, &auto_fields);
@@ -313,6 +324,57 @@ fn format_init_source(manual: &[&str], auto: &[&str]) -> String {
         (true, false) => format!("(auto: {})", auto.join(", ")),
         (true, true) => "(empty)".to_string(),
     }
+}
+
+/// Build `CameraParams` for an extended distortion model by embedding the
+/// BC5 linear-init coefficients as starting values and zeroing extra DOF.
+///
+/// Returns `None` for `BrownConrady5` — the BC5 path uses `initial_distortion`
+/// directly via `PlanarState::initial_params()`.
+fn build_initial_camera_params(
+    intrinsics: FxFyCxCySkew<Real>,
+    bc5: &BrownConrady5<Real>,
+    model: DistortionKind,
+) -> Option<CameraParams> {
+    let distortion = match model {
+        DistortionKind::BrownConrady5 => return None,
+        DistortionKind::None => DistortionParams::None,
+        DistortionKind::Rational8 => DistortionParams::Rational {
+            params: RationalPolynomial {
+                k1: bc5.k1,
+                k2: bc5.k2,
+                k3: bc5.k3,
+                k4: 0.0,
+                k5: 0.0,
+                k6: 0.0,
+                p1: bc5.p1,
+                p2: bc5.p2,
+                iters: 8,
+            },
+        },
+        DistortionKind::ThinPrism9 => DistortionParams::ThinPrism {
+            params: ThinPrism {
+                k1: bc5.k1,
+                k2: bc5.k2,
+                k3: bc5.k3,
+                p1: bc5.p1,
+                p2: bc5.p2,
+                s1: 0.0,
+                s2: 0.0,
+                s3: 0.0,
+                s4: 0.0,
+                iters: 8,
+            },
+        },
+        DistortionKind::Division1 => DistortionParams::Division { lambda: 0.0 },
+    };
+
+    Some(CameraParams {
+        projection: ProjectionParams::Pinhole,
+        distortion,
+        sensor: SensorParams::Identity,
+        intrinsics: IntrinsicsParams::FxFyCxCySkew { params: intrinsics },
+    })
 }
 
 /// Initialize intrinsics and poses from observations using full auto-init.
@@ -457,7 +519,7 @@ pub fn step_filter(
         )));
     }
 
-    let camera = &output.params.camera;
+    let camera = output.params.build_camera();
 
     let mut filtered_views = Vec::new();
     let mut total_removed = 0usize;
@@ -476,7 +538,7 @@ pub fn step_filter(
             .enumerate()
         {
             let p_cam = pose.transform_point(p3d);
-            let Some(projected) = camera.project_point_c(&p_cam.coords) else {
+            let Some(projected) = camera.project_camera_point(&p_cam.coords) else {
                 total_removed += 1;
                 continue;
             };

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
@@ -345,13 +345,13 @@ pub fn step_intrinsics_optimize_all(
 
         match &config.sensor {
             SensorMode::Pinhole => {
-                let initial_params =
-                    PlanarIntrinsicsParams::new(per_cam_intrinsics[cam_idx].clone(), initial_poses)
-                        .map_err(|e| {
-                            Error::numerical(format!(
-                                "failed to build params for camera {cam_idx}: {e}"
-                            ))
-                        })?;
+                let initial_params = PlanarIntrinsicsParams::from_pinhole(
+                    per_cam_intrinsics[cam_idx].clone(),
+                    initial_poses,
+                )
+                .map_err(|e| {
+                    Error::numerical(format!("failed to build params for camera {cam_idx}: {e}"))
+                })?;
 
                 let solve_opts = PlanarIntrinsicsSolveOptions {
                     robust_loss: config.robust_loss,
@@ -381,7 +381,11 @@ pub fn step_intrinsics_optimize_all(
                         Some(result.params.poses()[local_idx]);
                 }
 
-                optimized_cameras.push(result.params.camera.clone());
+                optimized_cameras.push(result.params.pinhole_camera().map_err(|e| {
+                    Error::numerical(format!(
+                        "camera {cam_idx} result not pinhole-compatible: {e}"
+                    ))
+                })?);
                 per_cam_reproj_errors.push(result.mean_reproj_error);
             }
             SensorMode::Scheimpflug {

--- a/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
@@ -398,13 +398,13 @@ pub fn step_intrinsics_optimize_all(
 
         match &config.sensor {
             SensorMode::Pinhole => {
-                let initial_params =
-                    PlanarIntrinsicsParams::new(per_cam_intrinsics[cam_idx].clone(), initial_poses)
-                        .map_err(|e| {
-                            Error::numerical(format!(
-                                "failed to build params for camera {cam_idx}: {e}"
-                            ))
-                        })?;
+                let initial_params = PlanarIntrinsicsParams::from_pinhole(
+                    per_cam_intrinsics[cam_idx].clone(),
+                    initial_poses,
+                )
+                .map_err(|e| {
+                    Error::numerical(format!("failed to build params for camera {cam_idx}: {e}"))
+                })?;
 
                 let solve_opts = PlanarIntrinsicsSolveOptions {
                     robust_loss: config.solver.robust_loss,
@@ -434,7 +434,11 @@ pub fn step_intrinsics_optimize_all(
                         Some(result.params.poses()[local_idx]);
                 }
 
-                optimized_cameras.push(result.params.camera.clone());
+                optimized_cameras.push(result.params.pinhole_camera().map_err(|e| {
+                    Error::numerical(format!(
+                        "camera {cam_idx} result not pinhole-compatible: {e}"
+                    ))
+                })?);
                 per_cam_reproj_errors.push(result.mean_reproj_error);
             }
             SensorMode::Scheimpflug {

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/steps.rs
@@ -380,7 +380,7 @@ pub fn step_intrinsics_optimize(
         .ok_or_else(|| Error::not_available("initial poses"))?;
 
     // Build initial params
-    let initial_params = PlanarIntrinsicsParams::new(initial_camera, initial_poses)
+    let initial_params = PlanarIntrinsicsParams::from_pinhole(initial_camera, initial_poses)
         .map_err(|e| Error::numerical(format!("failed to build params: {e}")))?;
 
     // Convert to PlanarDataset
@@ -415,7 +415,10 @@ pub fn step_intrinsics_optimize(
     };
 
     // Update state
-    let camera = result.params.camera.clone();
+    let camera = result
+        .params
+        .pinhole_camera()
+        .map_err(|e| Error::numerical(format!("intrinsics result not pinhole-compatible: {e}")))?;
     let target_poses = result.params.poses().to_vec();
     let mean_reproj_error = result.mean_reproj_error;
     session.state.optimized_camera = Some(camera.clone());

--- a/crates/vision-calibration-pipeline/tests/planar_distortion_models.rs
+++ b/crates/vision-calibration-pipeline/tests/planar_distortion_models.rs
@@ -1,0 +1,423 @@
+//! End-to-end synthetic GT round-trip tests for extended distortion models
+//! (Rational8, ThinPrism9, Division1) wired through the full pipeline:
+//!
+//!   config.distortion_model = X  →  step_init  →  step_optimize  →  export
+//!
+//! All scenarios use noiseless synthetic data so reprojection RMS must be
+//! below 1e-2 px (tight tolerance).  Brown-Conrady5 regression is also
+//! included to guard the default path.
+//!
+//! Division1 notes: lambda=0 is a valid seed (rationalized formula has
+//! non-zero Jacobian at λ=0), but the model absorbs barrel distortion only.
+//! GT lambda is chosen large enough to be observable but small enough that
+//! all board points remain inside the image at the test pose distances.
+
+#![allow(missing_docs)]
+
+use nalgebra::{Rotation3, Translation3};
+use vision_calibration_core::{
+    Camera, CameraProject, CorrespondenceView, Division, FxFyCxCySkew, IdentitySensor, Iso3,
+    Pinhole, PlanarDataset, Pt2, Pt3, RationalPolynomial, ThinPrism, View, make_pinhole_camera,
+};
+use vision_calibration_optim::DistortionKind;
+use vision_calibration_pipeline::{
+    planar_intrinsics::{
+        PlanarIntrinsicsConfig, PlanarIntrinsicsProblem, step_init, step_optimize,
+    },
+    session::CalibrationSession,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared test infrastructure
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NX: usize = 7;
+const NY: usize = 5;
+const SPACING: f64 = 0.04;
+
+fn board_points() -> Vec<Pt3> {
+    let mut pts = Vec::new();
+    for j in 0..NY {
+        for i in 0..NX {
+            pts.push(Pt3::new(i as f64 * SPACING, j as f64 * SPACING, 0.0));
+        }
+    }
+    pts
+}
+
+fn gt_poses() -> Vec<Iso3> {
+    (0..6)
+        .map(|i| {
+            let angle_y = 0.08 * (i as f64 - 2.5);
+            let angle_x = 0.05 * (i % 3) as f64 - 0.05;
+            let rot = Rotation3::from_euler_angles(angle_x, angle_y, 0.0);
+            let tz = 0.5 + 0.07 * i as f64;
+            Iso3::from_parts(Translation3::new(0.0, 0.0, tz), rot.into())
+        })
+        .collect()
+}
+
+fn gt_intrinsics() -> FxFyCxCySkew<f64> {
+    FxFyCxCySkew {
+        fx: 820.0,
+        fy: 800.0,
+        cx: 640.0,
+        cy: 360.0,
+        skew: 0.0,
+    }
+}
+
+/// Synthesize a noiseless `PlanarDataset` from a generic camera model.
+fn make_dataset<C: CameraProject>(camera: &C, poses: &[Iso3]) -> PlanarDataset {
+    let pts3d = board_points();
+    let views: Vec<_> = poses
+        .iter()
+        .map(|pose| {
+            // Collect (3D, 2D) pairs for points that project into the image.
+            let (pts3d_valid, pts2d): (Vec<Pt3>, Vec<Pt2>) = pts3d
+                .iter()
+                .filter_map(|pw| {
+                    let pc = pose.transform_point(pw);
+                    camera
+                        .project_camera_point(&pc.coords)
+                        .map(|proj| (*pw, proj))
+                })
+                .unzip();
+            View::without_meta(CorrespondenceView::new(pts3d_valid, pts2d).expect("non-empty view"))
+        })
+        .collect();
+    PlanarDataset::new(views).expect("valid dataset")
+}
+
+/// Mean reprojection RMS for a built camera over the dataset.
+fn reproj_rms<C: CameraProject>(camera: &C, dataset: &PlanarDataset, poses: &[Iso3]) -> f64 {
+    let mut sum_sq = 0.0;
+    let mut n = 0usize;
+    for (view, pose) in dataset.views.iter().zip(poses.iter()) {
+        for (p3, p2) in view.obs.points_3d.iter().zip(view.obs.points_2d.iter()) {
+            let pc = pose.transform_point(p3);
+            if let Some(proj) = camera.project_camera_point(&pc.coords) {
+                let err = (proj - *p2).norm_squared();
+                sum_sq += err;
+                n += 1;
+            }
+        }
+    }
+    if n == 0 {
+        return f64::INFINITY;
+    }
+    (sum_sq / n as f64).sqrt()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers to run the full pipeline and return reprojection RMS
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn run_pipeline(
+    dataset: PlanarDataset,
+    model: DistortionKind,
+) -> (
+    vision_calibration_pipeline::planar_intrinsics::PlanarIntrinsicsExport,
+    f64,
+) {
+    let mut config = PlanarIntrinsicsConfig::default();
+    config.distortion_model = model;
+    // Allow k3 for the extended models; it doesn't affect them but keeps
+    // BC5 test consistent.
+    config.fix_k3_in_init = false;
+    config.max_iters = 100;
+
+    let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+    session.set_config(config).unwrap();
+    session.set_input(dataset.clone()).unwrap();
+
+    step_init(&mut session, None).expect("step_init must succeed");
+    let opt_result = step_optimize(&mut session, None).expect("step_optimize must succeed");
+    let export = session.export().expect("export must succeed");
+
+    (export, opt_result.mean_reproj_error)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Brown-Conrady 5  (default path — regression guard)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bc5_pipeline_noiseless_round_trip() {
+    let k_gt = gt_intrinsics();
+    // Use mild distortion so Zhang's linear init yields a good-enough starting
+    // point for the non-linear optimizer to reach near-zero residual in a
+    // fresh pipeline run (no seeded GT poses).
+    let dist_gt = vision_calibration_core::BrownConrady5 {
+        k1: -0.05,
+        k2: 0.02,
+        k3: 0.0,
+        p1: 0.0003,
+        p2: -0.0002,
+        iters: 8,
+    };
+    let cam_gt = make_pinhole_camera(k_gt, dist_gt);
+    let poses = gt_poses();
+    let dataset = make_dataset(&cam_gt, &poses);
+
+    let (export, rms) = run_pipeline(dataset, DistortionKind::BrownConrady5);
+
+    println!("[BC5 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "BC5 pipeline: reprojection RMS too large: {rms:.4e} px"
+    );
+
+    // Verify coefficients converge close to GT.
+    let k_out = export.params.intrinsics();
+    let d_out = export
+        .params
+        .distortion()
+        .expect("BC5 must produce BC5 distortion");
+    println!(
+        "[BC5] fx_err={:.3} fy_err={:.3} k1_err={:.4e} k2_err={:.4e}",
+        (k_out.fx - k_gt.fx).abs(),
+        (k_out.fy - k_gt.fy).abs(),
+        (d_out.k1 - dist_gt.k1).abs(),
+        (d_out.k2 - dist_gt.k2).abs(),
+    );
+    assert!((k_out.fx - k_gt.fx).abs() < 5.0, "fx not converged");
+    assert!((k_out.fy - k_gt.fy).abs() < 5.0, "fy not converged");
+    // Pipeline-path coefficient accuracy: ~50% relative (loose — linear init
+    // introduces mild bias that the NL optimizer absorbs into intrinsics).
+    assert!((d_out.k1 - dist_gt.k1).abs() < 0.05, "k1 not converged");
+    assert!((d_out.k2 - dist_gt.k2).abs() < 0.05, "k2 not converged");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rational-8  (6 radial + 2 tangential)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rational8_pipeline_noiseless_round_trip() {
+    let k_gt = gt_intrinsics();
+    let dist_gt = RationalPolynomial {
+        k1: -0.20,
+        k2: 0.06,
+        k3: 0.0,
+        k4: 0.01,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.001,
+        p2: -0.0005,
+        iters: 10,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, IdentitySensor, k_gt);
+    let poses = gt_poses();
+    let dataset = make_dataset(&cam_gt, &poses);
+
+    let (export, rms) = run_pipeline(dataset.clone(), DistortionKind::Rational8);
+
+    println!("[Rational8 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Rational8 pipeline: reprojection RMS too large: {rms:.4e} px"
+    );
+
+    let k_out = export.params.intrinsics();
+    println!(
+        "[Rational8] fx_err={:.3} fy_err={:.3}",
+        (k_out.fx - k_gt.fx).abs(),
+        (k_out.fy - k_gt.fy).abs(),
+    );
+    assert!((k_out.fx - k_gt.fx).abs() < 5.0, "fx not converged");
+    assert!((k_out.fy - k_gt.fy).abs() < 5.0, "fy not converged");
+
+    // Verify reprojection with the exported camera model.
+    let cam_out = export.params.build_camera();
+    let rms_check = reproj_rms(&cam_out, &dataset, &export.params.camera_se3_target);
+    println!("[Rational8] direct reproj rms={rms_check:.4e}");
+    assert!(
+        rms_check < 1e-2,
+        "Rational8 direct reproj RMS: {rms_check:.4e}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ThinPrism-9  (BC5 + thin-prism s1..s4)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn thinprism9_pipeline_noiseless_round_trip() {
+    let k_gt = gt_intrinsics();
+    let dist_gt = ThinPrism {
+        k1: -0.15,
+        k2: 0.05,
+        k3: 0.0,
+        p1: 0.0008,
+        p2: -0.0005,
+        s1: 0.0002,
+        s2: -0.0001,
+        s3: 0.0001,
+        s4: 0.0,
+        iters: 8,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, IdentitySensor, k_gt);
+    let poses = gt_poses();
+    let dataset = make_dataset(&cam_gt, &poses);
+
+    let (export, rms) = run_pipeline(dataset.clone(), DistortionKind::ThinPrism9);
+
+    println!("[ThinPrism9 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "ThinPrism9 pipeline: reprojection RMS too large: {rms:.4e} px"
+    );
+
+    let k_out = export.params.intrinsics();
+    println!(
+        "[ThinPrism9] fx_err={:.3} fy_err={:.3}",
+        (k_out.fx - k_gt.fx).abs(),
+        (k_out.fy - k_gt.fy).abs(),
+    );
+    assert!((k_out.fx - k_gt.fx).abs() < 5.0, "fx not converged");
+    assert!((k_out.fy - k_gt.fy).abs() < 5.0, "fy not converged");
+
+    let cam_out = export.params.build_camera();
+    let rms_check = reproj_rms(&cam_out, &dataset, &export.params.camera_se3_target);
+    println!("[ThinPrism9] direct reproj rms={rms_check:.4e}");
+    assert!(
+        rms_check < 1e-2,
+        "ThinPrism9 direct reproj RMS: {rms_check:.4e}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Division-1  (Fitzgibbon single-parameter division model)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn division1_pipeline_noiseless_round_trip() {
+    let k_gt = gt_intrinsics();
+    // lambda < 0 produces barrel distortion (the typical case).
+    // |lambda| is kept moderate so all board points stay in-frame.
+    let lambda_gt = -0.25_f64;
+    let dist_gt = Division { lambda: lambda_gt };
+    let cam_gt = Camera::new(Pinhole, dist_gt, IdentitySensor, k_gt);
+    let poses = gt_poses();
+    let dataset = make_dataset(&cam_gt, &poses);
+
+    let (export, rms) = run_pipeline(dataset.clone(), DistortionKind::Division1);
+
+    println!("[Division1 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Division1 pipeline: reprojection RMS too large: {rms:.4e} px"
+    );
+
+    let k_out = export.params.intrinsics();
+    println!(
+        "[Division1] fx_err={:.3} fy_err={:.3}",
+        (k_out.fx - k_gt.fx).abs(),
+        (k_out.fy - k_gt.fy).abs(),
+    );
+    assert!((k_out.fx - k_gt.fx).abs() < 5.0, "fx not converged");
+    assert!((k_out.fy - k_gt.fy).abs() < 5.0, "fy not converged");
+
+    let cam_out = export.params.build_camera();
+    let rms_check = reproj_rms(&cam_out, &dataset, &export.params.camera_se3_target);
+    println!("[Division1] direct reproj rms={rms_check:.4e}");
+    assert!(
+        rms_check < 1e-2,
+        "Division1 direct reproj RMS: {rms_check:.4e}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// JSON roundtrip of PlanarIntrinsicsExport for an extended model
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rational8_export_json_roundtrip() {
+    let k_gt = gt_intrinsics();
+    let dist_gt = RationalPolynomial {
+        k1: -0.20,
+        k2: 0.06,
+        k3: 0.0,
+        k4: 0.01,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.001,
+        p2: -0.0005,
+        iters: 10,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, IdentitySensor, k_gt);
+    let poses = gt_poses();
+    let dataset = make_dataset(&cam_gt, &poses);
+
+    let (export, _rms) = run_pipeline(dataset, DistortionKind::Rational8);
+
+    let json = serde_json::to_string_pretty(&export).expect("serialize export");
+    let restored: vision_calibration_pipeline::planar_intrinsics::PlanarIntrinsicsExport =
+        serde_json::from_str(&json).expect("deserialize export");
+
+    // Intrinsics survive the roundtrip.
+    let k_orig = export.params.intrinsics();
+    let k_rest = restored.params.intrinsics();
+    assert!((k_orig.fx - k_rest.fx).abs() < 1e-9);
+    assert!((k_orig.fy - k_rest.fy).abs() < 1e-9);
+    assert!((k_orig.cx - k_rest.cx).abs() < 1e-9);
+    assert!((k_orig.cy - k_rest.cy).abs() < 1e-9);
+
+    // Metrics survive.
+    assert!((export.mean_reproj_error - restored.mean_reproj_error).abs() < 1e-12);
+
+    // Distortion kind survives (DistortionParams::Rational round-trips).
+    let json_str = json.as_str();
+    assert!(
+        json_str.contains("rational") || json_str.contains("Rational"),
+        "export JSON must contain 'rational' distortion kind"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config JSON roundtrip with distortion_model field
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn planar_config_distortion_model_json_roundtrip() {
+    for model in [
+        DistortionKind::BrownConrady5,
+        DistortionKind::Rational8,
+        DistortionKind::ThinPrism9,
+        DistortionKind::Division1,
+        DistortionKind::None,
+    ] {
+        let mut config = PlanarIntrinsicsConfig::default();
+        config.distortion_model = model;
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: PlanarIntrinsicsConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.distortion_model, model,
+            "distortion_model roundtrip failed for {model:?}"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backward compat: config without distortion_model field defaults to BC5
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn planar_config_missing_distortion_model_defaults_to_bc5() {
+    // Simulate a pre-M-WIRE config JSON that has no `distortion_model` field.
+    // Serialize the default config, strip the distortion_model key, and verify
+    // deserialization still produces BrownConrady5 (via #[serde(default=...)]).
+    let default_config = PlanarIntrinsicsConfig::default();
+    let mut json_val: serde_json::Value =
+        serde_json::to_value(&default_config).expect("serialize default config");
+    json_val.as_object_mut().unwrap().remove("distortion_model");
+    let json_without_field = serde_json::to_string(&json_val).unwrap();
+
+    let config: PlanarIntrinsicsConfig = serde_json::from_str(&json_without_field).unwrap();
+    assert_eq!(
+        config.distortion_model,
+        DistortionKind::BrownConrady5,
+        "missing field must default to BrownConrady5"
+    );
+}

--- a/crates/vision-calibration/examples/planar_real.rs
+++ b/crates/vision-calibration/examples/planar_real.rs
@@ -96,12 +96,16 @@ fn main() -> Result<()> {
     println!("    fy = {:.2}", final_k.fy);
     println!("    cx = {:.2}", final_k.cx);
     println!("    cy = {:.2}", final_k.cy);
-    println!("  Distortion:");
-    println!("    k1 = {:.6}", final_dist.k1);
-    println!("    k2 = {:.6}", final_dist.k2);
-    println!("    k3 = {:.6}", final_dist.k3);
-    println!("    p1 = {:.6}", final_dist.p1);
-    println!("    p2 = {:.6}", final_dist.p2);
+    println!("  Distortion (Brown-Conrady5):");
+    if let Some(d) = final_dist {
+        println!("    k1 = {:.6}", d.k1);
+        println!("    k2 = {:.6}", d.k2);
+        println!("    k3 = {:.6}", d.k3);
+        println!("    p1 = {:.6}", d.p1);
+        println!("    p2 = {:.6}", d.p2);
+    } else {
+        println!("    (no Brown-Conrady5 distortion)");
+    }
     println!(
         "  Mean reprojection error: {:.4} px\n",
         export.mean_reproj_error

--- a/crates/vision-calibration/examples/planar_synthetic.rs
+++ b/crates/vision-calibration/examples/planar_synthetic.rs
@@ -107,10 +107,14 @@ fn main() -> Result<()> {
         "  Intrinsics: fx={:.1}, fy={:.1}, cx={:.1}, cy={:.1}",
         final_k.fx, final_k.fy, final_k.cx, final_k.cy
     );
-    println!(
-        "  Distortion: k1={:.4}, k2={:.4}, k3={:.4}, p1={:.4}, p2={:.4}",
-        final_dist.k1, final_dist.k2, final_dist.k3, final_dist.p1, final_dist.p2
-    );
+    if let Some(d) = &final_dist {
+        println!(
+            "  Distortion: k1={:.4}, k2={:.4}, k3={:.4}, p1={:.4}, p2={:.4}",
+            d.k1, d.k2, d.k3, d.p1, d.p2
+        );
+    } else {
+        println!("  Distortion: (no Brown-Conrady5 coefficients)");
+    }
     println!(
         "  Error vs GT: fx={:.2}%, fy={:.2}%",
         100.0 * (final_k.fx - k_gt.fx).abs() / k_gt.fx,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -217,14 +217,29 @@ Systemic causes:
   tests. **Strictly additive** — no pipeline/builder/export change, BC5
   production paths byte-identical. Usable via `CameraParams` and hand-built
   `ProblemIR`.
-- [ ] M-WIRE - Pipeline-selection plumbing for the new distortion models:
-  user-facing distortion-model choice through `PlanarIntrinsicsConfig` /
-  `ScheimpflugIntrinsicsConfig` into the problem builders (which hardcode
-  `CameraModelDesc::PINHOLE4_DIST5*`). Requires: generalize the BC5-hardwired
-  `DistortionFixMask`, model-aware init seeds (note Division's `lambda=0`
-  degeneracy + Rational k1↔k4 correlation), variable-dim pack/unpack, export
-  reconstruction per model, schema regen, app selector. Touches validated
-  calibration paths — do supervised, not in an autonomous batch.
+- [~] M-WIRE - Pipeline-selection plumbing for the new distortion models.
+  **PlanarIntrinsics vertical slice DONE 2026-06-21** (user-supervised; chose
+  vertical slice + "Zhang shared terms, zero extras, refine" init + a
+  model-agnostic export contract). `PlanarIntrinsicsConfig.distortion_model:
+  DistortionKind` (Serde, `#[serde(default)]` → BC5) selects BC5 / Rational8 /
+  ThinPrism9 / Division1. `PlanarIntrinsicsParams.camera` is now the serializable
+  `CameraParams` (was the concrete `PinholeCamera`) — `build_camera()` →
+  `CameraModel` for residuals (generic via `CameraProject`), `from_pinhole()` /
+  `pinhole_camera()` (Result; `Err` for extended models) bridge the rig family
+  which stays BC5. Model-aware `pack/unpack_distortion_params` (variable-dim,
+  IR-order-exact); the IR builder maps the kind → `CameraModelDesc::PINHOLE4_*`;
+  init embeds the BC5 linear seed into the target model and zeros the extras.
+  7 new E2E tests (per-model noiseless round-trip — Rational8 4.2e-6 px,
+  ThinPrism9 2.9e-4 px, Division1 3.2e-6 px from λ=0, BC5 3.0e-3 px regression
+  + JSON roundtrip + back-compat default). The export `params.camera` JSON shape
+  changed to the tagged `CameraParams` form (app/diagnose deserialization updates
+  when the app selector lands).
+  - [ ] **Remaining (supervised):** the other intrinsics-bearing problem types
+    (`ScheimpflugIntrinsics`, rig family), the app Run-form model selector +
+    Diagnose display, Python binding, and manual-init seeding of extended models
+    (`PlanarManualInit::distortion` is still `Option<BrownConrady5>`). Also: the
+    BC5-shaped `DistortionFixMask` is currently ignored for non-BC5 models (no
+    user-visible error) — generalize or warn.
   - **Robust wide-FOV inverse** (sub-item): the rational/thin-prism runtime +
     kernel `undistort` use a radial-division fixed point that is contracting
     only within the calibrated FOV (radius ≲ ~1.2), matching OpenCV


### PR DESCRIPTION
## What

Wires the already-implemented **Rational8 / ThinPrism9 / Division1** distortion models (complete at the core + optim IR layers since M1–M3, but dead code) through the **PlanarIntrinsics** calibration pipeline. Brown-Conrady5 stays the default; the model is chosen via `PlanarIntrinsicsConfig.distortion_model: DistortionKind` (`#[serde(default)]` → BC5, so existing configs/JSON are unaffected).

Supervised vertical slice (user-approved scope): **PlanarIntrinsics only, Rust-core only**, init = "Zhang shared terms, zero extras, refine", model-agnostic export contract.

## Design

The calibrated camera becomes **model-agnostic**: `PlanarIntrinsicsParams.camera` is now the serializable `CameraParams` (was the concrete Brown-Conrady `PinholeCamera`). `build_camera() → CameraModel` drives residuals (generic via `CameraProject`); `from_pinhole()` / `pinhole_camera()` (`Result`; `Err` for extended models) bridge the rig family, which stays Brown-Conrady.

- **optim:** model-aware `pack/unpack_distortion_params` (variable-dim, IR-order-exact); the planar IR builder maps `DistortionKind` → `CameraModelDesc::PINHOLE4_{DIST5,RATIONAL8,THINPRISM9,DIVISION1}`; `DistortionKind` gains Serde.
- **init:** linear init stays Brown-Conrady; its `(k1,k2,k3,p1,p2)` seed is embedded into the selected model's layout and the extra coefficients zeroed; nonlinear optimization refines them.
- **export:** `PlanarIntrinsicsExport.params.camera` is now the tagged `CameraParams` JSON. **Contract change** — the diagnose viewer's deserialization updates when the app selector lands (Rust-core-only slice per scope).
- **rig_extrinsics / rig_handeye / single_cam_handeye:** adapted via `from_pinhole`/`pinhole_camera` (behaviour unchanged, still BC5).

## Tests

7 new E2E tests in `planar_distortion_models.rs` — per-model noiseless round-trip (**Rational8 4.2e-6 px, ThinPrism9 2.9e-4 px, Division1 3.2e-6 px from λ=0, BC5 3.0e-3 px** regression) + JSON roundtrip + back-compat default. Full workspace `build`/`clippy -D warnings`/`test --all-features`/`doc` green; all rig regressions pass.

## Follow-ups (tracked in backlog, supervised)

Other problem types (Scheimpflug, rig family), app Run-form selector + Diagnose display, Python binding, manual-init seeding of extended models, and generalizing the BC5-shaped `DistortionFixMask` (currently ignored for non-BC5 models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)