### PR TITLE
C5: pure-Rust dense stereo matcher (block-matching MVP) + visual evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,6 +3695,7 @@ dependencies = [
  "calib-targets",
  "image",
  "nalgebra",
+ "serde",
  "serde_json",
  "vision-calibration-core",
  "vision-calibration-linear",

--- a/crates/vision-calibration-bench/examples/dense_synth.rs
+++ b/crates/vision-calibration-bench/examples/dense_synth.rs
@@ -1,0 +1,247 @@
+//! Visual + quantitative evidence for the C5 pure-Rust dense matcher on
+//! synthetic ground truth.
+//!
+//! Runs [`BlockMatcher`] (and the [`OracleMatcher`] reference) on a deterministic
+//! slanted-plane rectified pair, scores both with the harness [`evaluate`], and
+//! writes a tiled PNG so the result can be eyeballed:
+//!
+//! ```text
+//!   left | right | GT disparity | estimated disparity | error
+//! ```
+//!
+//! The GT and estimate panels share one color scale, so a correct matcher's
+//! estimate panel should look like the GT ramp; the error panel should be near-
+//! uniformly low. Invalid pixels are rendered black (disparity) / dark grey
+//! (error) — never hidden.
+//!
+//! ```bash
+//! cargo run -p vision-calibration-bench --example dense_synth --features tier-b --release
+//! # → target/fixtures/dense_synth/composite.png  (+ per-panel PNGs)
+//! ```
+//!
+//! Requires `--features tier-b` (pulls in the `image` crate for PNG output).
+
+#[cfg(not(feature = "tier-b"))]
+fn main() {
+    eprintln!(
+        "dense_synth requires the `tier-b` feature for PNG output:\n  \
+         cargo run -p vision-calibration-bench --example dense_synth --features tier-b --release"
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "tier-b")]
+fn main() {
+    real::run();
+}
+
+#[cfg(feature = "tier-b")]
+mod real {
+    use std::path::{Path, PathBuf};
+
+    use vision_calibration_bench::dense::{
+        BlockMatcher, DenseMatchOptions, DenseMatcher, DenseMetrics, DisparityMap, GrayBuffer,
+        OracleMatcher, SlantedPlane, evaluate, synthetic_rectified_pair,
+    };
+
+    const W: usize = 480;
+    const H: usize = 320;
+    const SEP: usize = 6; // white separator between composite panels
+
+    pub fn run() {
+        // A gently slanted plane: enough disparity sweep for a clear colormap
+        // gradient, shallow enough that the fixture's forward-warp foreshortening
+        // (GT bias ≈ d·dx/(1+dx)) stays well under a tenth of a pixel.
+        let plane = SlantedPlane {
+            d0: 8.0,
+            dx: 0.012,
+            dy: 0.004,
+        };
+        let (left, right, gt) = synthetic_rectified_pair(W, H, &plane);
+
+        let opts = DenseMatchOptions {
+            min_disparity: 0,
+            num_disparities: 24,
+            block_size: 9,
+        };
+
+        let est = BlockMatcher.match_disparity(&left, &right, &opts);
+        let oracle = OracleMatcher { gt: gt.clone() }.match_disparity(&left, &right, &opts);
+
+        let m_block = evaluate(&est, &gt, 1.0);
+        let m_oracle = evaluate(&oracle, &gt, 1.0);
+
+        // Shared disparity color scale from the GT valid range.
+        let (lo, hi) = disp_range(&gt).unwrap_or((0.0, 1.0));
+
+        let panels = [
+            gray_to_rgb(&left),
+            gray_to_rgb(&right),
+            disp_to_rgb(&gt, lo, hi),
+            disp_to_rgb(&est, lo, hi),
+            error_to_rgb(&est, &gt),
+        ];
+        let out_dir = fixtures_dir();
+        std::fs::create_dir_all(&out_dir).expect("create output dir");
+
+        let names = ["left", "right", "gt", "est", "error"];
+        for (panel, name) in panels.iter().zip(names) {
+            save_rgb(&out_dir.join(format!("{name}.png")), W, H, panel);
+        }
+        let composite = tile_h(&panels, W, H, SEP);
+        let comp_w = W * panels.len() + SEP * (panels.len() - 1);
+        save_rgb(&out_dir.join("composite.png"), comp_w, H, &composite);
+
+        // ---- report ----
+        println!("C5 dense matcher — synthetic slanted-plane evidence");
+        println!(
+            "  image {W}x{H}, disparity range [{lo:.2}, {hi:.2}] px, block {}, search {}..{}",
+            opts.block_size,
+            opts.min_disparity,
+            opts.min_disparity + opts.num_disparities
+        );
+        println!();
+        println!(
+            "  {:<11} {:>9} {:>8} {:>8} {:>9}",
+            "matcher", "density", "rms_px", "mae_px", "bad%>1px"
+        );
+        report_row("block-zncc", &m_block);
+        report_row("oracle", &m_oracle);
+        println!();
+        println!("  panels: left | right | GT | estimate | error");
+        println!("  wrote  {}", out_dir.join("composite.png").display());
+
+        // Quality gate (mirrors the harness integration test): a real matcher
+        // must recover most pixels accurately.
+        let pass = m_block.density > 0.5 && m_block.rms_px < 1.0;
+        if pass {
+            println!(
+                "\n  PASS — density {:.1}% at RMS {:.3} px",
+                m_block.density * 100.0,
+                m_block.rms_px
+            );
+        } else {
+            eprintln!(
+                "\n  FAIL — density {:.3}, RMS {:.3} px (want density > 0.5, RMS < 1.0)",
+                m_block.density, m_block.rms_px
+            );
+            std::process::exit(1);
+        }
+    }
+
+    fn report_row(name: &str, m: &DenseMetrics) {
+        println!(
+            "  {:<11} {:>8.1}% {:>8.3} {:>8.3} {:>8.1}%",
+            name,
+            m.density * 100.0,
+            m.rms_px,
+            m.mae_px,
+            m.bad_pixel_rate * 100.0
+        );
+    }
+
+    // ---- color & layout helpers -------------------------------------------
+
+    /// Jet colormap, `t` in `[0, 1]` → `[r, g, b]`.
+    fn jet(t: f32) -> [u8; 3] {
+        let t = t.clamp(0.0, 1.0);
+        let r = ((1.5 - (4.0 * t - 3.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
+        let g = ((1.5 - (4.0 * t - 2.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
+        let b = ((1.5 - (4.0 * t - 1.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
+        [r, g, b]
+    }
+
+    /// Stepped error palette (teal → red), matching the app's `colorForError`
+    /// language but scaled to sub-pixel disparity error.
+    fn error_color(e: f32) -> [u8; 3] {
+        if e < 0.25 {
+            [26, 188, 156]
+        } else if e < 0.5 {
+            [46, 204, 113]
+        } else if e < 1.0 {
+            [241, 196, 15]
+        } else if e < 2.0 {
+            [230, 126, 34]
+        } else {
+            [231, 76, 60]
+        }
+    }
+
+    fn disp_range(d: &DisparityMap) -> Option<(f32, f32)> {
+        let mut lo = f32::INFINITY;
+        let mut hi = f32::NEG_INFINITY;
+        let mut any = false;
+        for &v in &d.data {
+            if v.is_finite() {
+                any = true;
+                lo = lo.min(v);
+                hi = hi.max(v);
+            }
+        }
+        any.then_some((lo, hi))
+    }
+
+    fn gray_to_rgb(buf: &GrayBuffer) -> Vec<[u8; 3]> {
+        buf.data.iter().map(|&v| [v, v, v]).collect()
+    }
+
+    fn disp_to_rgb(d: &DisparityMap, lo: f32, hi: f32) -> Vec<[u8; 3]> {
+        let span = (hi - lo).max(1e-6);
+        d.data
+            .iter()
+            .map(|&v| {
+                if v.is_finite() {
+                    jet((v - lo) / span)
+                } else {
+                    [0, 0, 0] // invalid → black
+                }
+            })
+            .collect()
+    }
+
+    fn error_to_rgb(est: &DisparityMap, gt: &DisparityMap) -> Vec<[u8; 3]> {
+        (0..est.data.len())
+            .map(|i| {
+                let e = est.data[i];
+                let g = gt.data[i];
+                if e.is_finite() && g.is_finite() {
+                    error_color((e - g).abs())
+                } else {
+                    [40, 40, 40] // not evaluated → dark grey
+                }
+            })
+            .collect()
+    }
+
+    /// Tile equal-size RGB panels horizontally with white separators.
+    fn tile_h(panels: &[Vec<[u8; 3]>], w: usize, h: usize, sep: usize) -> Vec<[u8; 3]> {
+        let n = panels.len();
+        let total_w = w * n + sep * (n - 1);
+        let mut out = vec![[255u8, 255, 255]; total_w * h];
+        for (p, panel) in panels.iter().enumerate() {
+            let x0 = p * (w + sep);
+            for y in 0..h {
+                for x in 0..w {
+                    out[y * total_w + x0 + x] = panel[y * w + x];
+                }
+            }
+        }
+        out
+    }
+
+    fn save_rgb(path: &Path, w: usize, h: usize, rgb: &[[u8; 3]]) {
+        let flat: Vec<u8> = rgb.iter().flat_map(|p| p.iter().copied()).collect();
+        let img = image::RgbImage::from_raw(w as u32, h as u32, flat).expect("rgb buffer size");
+        img.save(path).expect("write png");
+    }
+
+    fn fixtures_dir() -> PathBuf {
+        // CARGO_MANIFEST_DIR = <root>/crates/vision-calibration-bench
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let root = manifest
+            .ancestors()
+            .nth(2)
+            .expect("workspace root above crates/<crate>");
+        root.join("target/fixtures/dense_synth")
+    }
+}

--- a/crates/vision-calibration-bench/src/dense.rs
+++ b/crates/vision-calibration-bench/src/dense.rs
@@ -266,7 +266,8 @@ fn texture_u8(x: usize, y: usize) -> u8 {
 ///
 /// Returns `(left, right, gt_disparity)` where:
 ///
-/// * `left` has a deterministic high-entropy texture (see [`texture_u8`]).
+/// * `left` has a deterministic high-entropy texture (two sine gratings plus a
+///   hash term — no RNG).
 /// * `gt_disparity` is the left-frame slanted-plane disparity
 ///   `d(x, y) = d0 + dx*x + dy*y`, following the standard convention
 ///   `d = x_left − x_right` (so a left pixel `(x, y)` matches right pixel
@@ -448,6 +449,51 @@ impl DenseMatcher for OracleMatcher {
         _opts: &DenseMatchOptions,
     ) -> DisparityMap {
         self.gt.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure-Rust block-matcher adapter (Track C5 deliverable)
+// ---------------------------------------------------------------------------
+
+use vision_calibration::mvg::dense as mvgd;
+
+/// Adapter exposing the pure-Rust [`vision_calibration::mvg::dense::match_block`]
+/// matcher through the harness [`DenseMatcher`] trait.
+///
+/// The harness-level [`DenseMatchOptions`] (`min_disparity` / `num_disparities`
+/// / `block_size`) are forwarded verbatim; the matcher's additional controls
+/// (ZNCC min-correlation, uniqueness, left-right consistency, sub-pixel) keep
+/// their library defaults. This is the in-workspace counterpart to the external
+/// OpenCV SGBM baseline.
+#[derive(Debug, Clone, Default)]
+pub struct BlockMatcher;
+
+impl DenseMatcher for BlockMatcher {
+    fn name(&self) -> &str {
+        "block-zncc"
+    }
+
+    fn match_disparity(
+        &self,
+        left: &GrayBuffer,
+        right: &GrayBuffer,
+        opts: &DenseMatchOptions,
+    ) -> DisparityMap {
+        let l = mvgd::GrayImage::new(left.width, left.height, left.data.clone());
+        let r = mvgd::GrayImage::new(right.width, right.height, right.data.clone());
+        let mopts = mvgd::BlockMatchOptions {
+            min_disparity: opts.min_disparity,
+            num_disparities: opts.num_disparities,
+            block_size: opts.block_size,
+            ..Default::default()
+        };
+        match mvgd::match_block(&l, &r, &mopts) {
+            Ok(d) => DisparityMap::new(d.width, d.height, d.data),
+            // The matcher only errors on invalid configuration; surface that as
+            // an all-invalid map rather than panicking inside the harness.
+            Err(_) => DisparityMap::filled(left.width, left.height, f32::NAN),
+        }
     }
 }
 
@@ -671,5 +717,42 @@ mod tests {
         assert_eq!(opts.min_disparity, 0);
         assert_eq!(opts.num_disparities, 64);
         assert_eq!(opts.block_size, 5);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pure-Rust block matcher, scored through the harness
+    // -----------------------------------------------------------------------
+
+    /// The C5 matcher run through the full harness (synthetic GT + `evaluate`)
+    /// must recover the slanted plane densely and accurately. This is the
+    /// quantitative gate that mirrors what the visual `dense_synth` example
+    /// renders.
+    #[test]
+    fn block_matcher_recovers_synthetic_plane() {
+        let plane = sample_plane();
+        let (left, right, gt) = synthetic_rectified_pair(W, H, &plane);
+
+        let matcher = BlockMatcher;
+        assert_eq!(matcher.name(), "block-zncc");
+        let opts = DenseMatchOptions {
+            min_disparity: 0,
+            num_disparities: 16,
+            block_size: 7,
+        };
+        let est = matcher.match_disparity(&left, &right, &opts);
+        let metrics = evaluate(&est, &gt, 1.0);
+
+        assert!(
+            metrics.density > 0.7,
+            "block matcher density too low: {} ({} / {})",
+            metrics.density,
+            metrics.evaluated_px,
+            metrics.gt_valid_px
+        );
+        assert!(
+            metrics.rms_px < 0.5,
+            "block matcher RMS too high: {} px",
+            metrics.rms_px
+        );
     }
 }

--- a/crates/vision-calibration/Cargo.toml
+++ b/crates/vision-calibration/Cargo.toml
@@ -30,6 +30,7 @@ vision-calibration-pipeline.workspace = true
 
 [dev-dependencies]
 anyhow = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 calib-targets = { workspace = true }
 image = { workspace = true }

--- a/crates/vision-calibration/examples/dense_stereo_real.rs
+++ b/crates/vision-calibration/examples/dense_stereo_real.rs
@@ -1,0 +1,495 @@
+//! Real-data evidence for the C5 pure-Rust dense matcher.
+//!
+//! Runs the full pipeline on the committed `data/stereo` chessboard rig:
+//!
+//! 1. read the frozen `RigExtrinsics` calibration (`viewer_export.json`) — two
+//!    `K` matrices, Brown-Conrady distortion, and the inter-camera pose;
+//! 2. undistort + Scheimpflug-aware **rectify** one synchronized pair
+//!    (`Im_L_1` / `Im_R_1`) so rows align (Track C4);
+//! 3. **dense-match** the rectified pair ([`mvg::dense::match_block`]);
+//! 4. write inspectable PNGs and a planarity-fit metric.
+//!
+//! The target is a planar board, so the *true* disparity over it is an affine
+//! function of pixel position. The matcher knows nothing about that — so the
+//! residual of a least-squares plane fit to the recovered disparities is a
+//! ground-truth-free measure of correctness (a coherent, low-residual planar
+//! surface ⇒ the matcher works on real data).
+//!
+//! ```bash
+//! cargo run -p vision-calibration --example dense_stereo_real --release
+//! # → target/fixtures/dense_stereo_real/{rectified_pair,disparity,overlay}.png
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use nalgebra::{Matrix3, Quaternion, Translation3, UnitQuaternion};
+use serde::Deserialize;
+use vision_calibration::core::Iso3;
+use vision_calibration::mvg::dense::{BlockMatchOptions, DisparityMap, GrayImage, match_block};
+use vision_calibration::mvg::rectification::{RectifyCamera, RectifyOptions, rectify_stereo_pair};
+use vision_calibration_core::{
+    BrownConrady5, Mat3, Pt2, Vec3, distort_to_pixel, pixel_to_normalized,
+};
+
+/// Integer downscale factor: the board sits ~0.54 m away with a 0.19 m baseline,
+/// so full-res disparities run to ~250 px. Matching at a third of the resolution
+/// keeps the disparity search (and the cost volume) modest.
+const DOWNSCALE: usize = 3;
+
+fn main() {
+    let data_dir = workspace_root().join("data/stereo");
+    let export_path = data_dir.join("viewer_export.json");
+    if !export_path.exists() {
+        eprintln!(
+            "data/stereo/viewer_export.json not found at {} — skipping (committed dataset absent)",
+            export_path.display()
+        );
+        return;
+    }
+
+    let export: Export =
+        serde_json::from_reader(std::fs::File::open(&export_path).expect("open export"))
+            .expect("parse RigExtrinsics export");
+    assert!(
+        export.cameras.len() == 2 && export.cam_se3_rig.len() == 2,
+        "expected a two-camera rig export"
+    );
+
+    let s = DOWNSCALE as f64;
+    let k0 = export.cameras[0].k.matrix(s);
+    let k1 = export.cameras[1].k.matrix(s);
+    let d0 = export.cameras[0].dist.model();
+    let d1 = export.cameras[1].dist.model();
+    // cam0 is the rig reference (identity pose), so cam_se3_rig[1] = T_C1_C0.
+    let cam1_se3_cam0: Iso3 = export.cam_se3_rig[1].iso();
+    // Nominal board depth in cam0 from the first view's target pose.
+    let z_board = export.rig_se3_target[0].translation[2];
+
+    // --- load + downscale the synchronized pair ---
+    let left_src = load_gray_downscaled(&data_dir.join("imgs/leftcamera/Im_L_1.png"), DOWNSCALE);
+    let right_src = load_gray_downscaled(&data_dir.join("imgs/rightcamera/Im_R_1.png"), DOWNSCALE);
+    let (w, h) = (left_src.width, left_src.height);
+
+    // --- rectify (Track C4) ---
+    let rect = rectify_stereo_pair(
+        &RectifyCamera::pinhole(k0),
+        &RectifyCamera::pinhole(k1),
+        &cam1_se3_cam0,
+        &RectifyOptions::default(),
+    )
+    .expect("rectify stereo pair");
+
+    let rect_left = remap(&left_src, &rect.h_left, &k0, &d0, w, h);
+    let rect_right = remap(&right_src, &rect.h_right, &k1, &d1, w, h);
+
+    // --- disparity search window from geometry: d ≈ f_rect · B / Z ---
+    // The board is near fronto-parallel, so bracket the nominal disparity
+    // tightly: a window much wider than the surface only invites weakly-textured
+    // background to false-match at the search edges.
+    let f_rect = rect.k_rect[(0, 0)];
+    let disp_nominal = (f_rect * rect.baseline / z_board) as f32;
+    let min_d = (disp_nominal * 0.6).round().max(0.0) as i32;
+    let num_d = (disp_nominal * 0.85).round().max(16.0) as i32;
+
+    let opts = BlockMatchOptions {
+        min_disparity: min_d,
+        num_disparities: num_d,
+        block_size: 11,
+        // Real imagery: the high-contrast board boundaries correlate strongly;
+        // require a solid peak so low-texture background is rejected.
+        min_correlation: 0.5,
+        uniqueness_ratio: 0.05,
+        ..Default::default()
+    };
+    let disp = match_block(&rect_left, &rect_right, &opts).expect("dense match");
+
+    // --- metrics ---
+    let valid = disp.data.iter().filter(|v| v.is_finite()).count();
+    let density = valid as f64 / (w * h) as f64;
+    let (lo, hi) = valid_range(&disp).unwrap_or((0.0, 1.0));
+    // Robust planar fit: the board dominates, so refitting on inliers reports
+    // the board's own planarity, undistracted by any stray background match.
+    let (plane_rms, plane_n) = planarity_rms(&disp);
+
+    // --- outputs ---
+    let out_dir = workspace_root().join("target/fixtures/dense_stereo_real");
+    std::fs::create_dir_all(&out_dir).expect("create output dir");
+    save_pair_with_epilines(&out_dir.join("rectified_pair.png"), &rect_left, &rect_right);
+    save_disparity(&out_dir.join("disparity.png"), &disp, lo, hi);
+    save_overlay(&out_dir.join("overlay.png"), &rect_left, &disp, lo, hi);
+
+    println!("C5 dense matcher — real chessboard rig evidence (data/stereo)");
+    println!("  source 1024x576 → matched {w}x{h} (downscale {DOWNSCALE}x)");
+    println!(
+        "  baseline {:.3} m, board depth {:.3} m, f_rect {:.1} px",
+        rect.baseline, z_board, f_rect
+    );
+    println!("  disparity search {min_d}..{}", min_d + num_d);
+    println!(
+        "  recovered: {valid} valid px ({:.1}% density), disparity range [{lo:.1}, {hi:.1}] px",
+        density * 100.0
+    );
+    println!(
+        "  board plane: {plane_n} inlier px, planarity-fit RMS {plane_rms:.3} px \
+         (planar target ⇒ low = coherent surface)"
+    );
+    println!("  wrote {}", out_dir.display());
+
+    // Evidence the matcher works on real data: it recovers a large, coherent
+    // PLANAR surface (the board) — low planarity RMS over many inliers. The raw
+    // range legitimately extends below the board: textured background sits at a
+    // greater depth (smaller disparity). The board's NEAR edge (max disparity)
+    // must not be clipped by the search ceiling.
+    let near_edge_clipped = hi >= (min_d + num_d) as f32 - 0.5;
+    let pass = plane_n > 3000 && plane_rms < 1.0 && !near_edge_clipped;
+    if pass {
+        println!(
+            "\n  PASS — coherent board plane: {plane_n} inlier px at {plane_rms:.3} px planarity RMS"
+        );
+    } else {
+        eprintln!(
+            "\n  CHECK — planarity RMS {plane_rms:.3} px over {plane_n} px, near-edge clipped: {near_edge_clipped} \
+             (range [{lo:.1},{hi:.1}] vs search {min_d}..{})",
+            min_d + num_d
+        );
+        std::process::exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Export JSON (minimal view — serde ignores the rest)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct Export {
+    cameras: Vec<CamJson>,
+    cam_se3_rig: Vec<PoseJson>,
+    rig_se3_target: Vec<PoseJson>,
+}
+
+#[derive(Deserialize)]
+struct CamJson {
+    k: KJson,
+    dist: DistJson,
+}
+
+#[derive(Deserialize)]
+struct KJson {
+    fx: f64,
+    fy: f64,
+    cx: f64,
+    cy: f64,
+    #[serde(default)]
+    skew: f64,
+}
+
+impl KJson {
+    /// Intrinsic matrix scaled for a `scale`× image downscale.
+    fn matrix(&self, scale: f64) -> Mat3 {
+        Matrix3::new(
+            self.fx / scale,
+            self.skew / scale,
+            self.cx / scale,
+            0.0,
+            self.fy / scale,
+            self.cy / scale,
+            0.0,
+            0.0,
+            1.0,
+        )
+    }
+}
+
+#[derive(Deserialize)]
+struct DistJson {
+    k1: f64,
+    k2: f64,
+    k3: f64,
+    p1: f64,
+    p2: f64,
+    #[serde(default = "default_iters")]
+    iters: u32,
+}
+
+fn default_iters() -> u32 {
+    8
+}
+
+impl DistJson {
+    fn model(&self) -> BrownConrady5<f64> {
+        BrownConrady5 {
+            k1: self.k1,
+            k2: self.k2,
+            k3: self.k3,
+            p1: self.p1,
+            p2: self.p2,
+            iters: self.iters,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct PoseJson {
+    /// Quaternion `[x, y, z, w]`.
+    rotation: [f64; 4],
+    translation: [f64; 3],
+}
+
+impl PoseJson {
+    fn iso(&self) -> Iso3 {
+        let [x, y, z, w] = self.rotation;
+        let q = UnitQuaternion::from_quaternion(Quaternion::new(w, x, y, z));
+        let t = Translation3::new(
+            self.translation[0],
+            self.translation[1],
+            self.translation[2],
+        );
+        Iso3::from_parts(t, q)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Image loading / rectifying remap
+// ---------------------------------------------------------------------------
+
+/// Load a PNG as grayscale and box-average downscale by an integer `factor`.
+fn load_gray_downscaled(path: &Path, factor: usize) -> GrayImage {
+    let img = image::ImageReader::open(path)
+        .unwrap_or_else(|e| panic!("open {}: {e}", path.display()))
+        .decode()
+        .unwrap_or_else(|e| panic!("decode {}: {e}", path.display()))
+        .to_luma8();
+    let (fw, fh) = (img.width() as usize, img.height() as usize);
+    let (w, h) = (fw / factor, fh / factor);
+    let mut data = vec![0u8; w * h];
+    for oy in 0..h {
+        for ox in 0..w {
+            let mut acc = 0u32;
+            for dy in 0..factor {
+                for dx in 0..factor {
+                    acc += img
+                        .get_pixel((ox * factor + dx) as u32, (oy * factor + dy) as u32)
+                        .0[0] as u32;
+                }
+            }
+            data[oy * w + ox] = (acc / (factor * factor) as u32) as u8;
+        }
+    }
+    GrayImage::new(w, h, data)
+}
+
+/// Resample a source image into the rectified frame.
+///
+/// For each rectified output pixel: invert the rectifying homography to the
+/// undistorted source pixel, re-apply the lens distortion to find the true
+/// (distorted) source sample location, and bilinear-sample. This is the
+/// `initUndistortRectifyMap` + `remap` step OpenCV keeps separate from the
+/// rectifying rotation.
+fn remap(
+    src: &GrayImage,
+    h_rect: &Mat3,
+    k: &Mat3,
+    dist: &BrownConrady5<f64>,
+    out_w: usize,
+    out_h: usize,
+) -> GrayImage {
+    let h_inv = h_rect
+        .try_inverse()
+        .expect("rectifying homography invertible");
+    let mut data = vec![0u8; out_w * out_h];
+    for yr in 0..out_h {
+        for xr in 0..out_w {
+            // rectified → undistorted source pixel
+            let p = h_inv * Vec3::new(xr as f64, yr as f64, 1.0);
+            if p.z.abs() < 1e-12 {
+                continue;
+            }
+            let undist = Pt2::new(p.x / p.z, p.y / p.z);
+            // undistorted pixel → normalized → distorted source pixel
+            let n = pixel_to_normalized(undist, k);
+            let src_px = distort_to_pixel(n, k, dist);
+            data[yr * out_w + xr] = src_px_sample(src, src_px.x, src_px.y);
+        }
+    }
+    GrayImage::new(out_w, out_h, data)
+}
+
+/// Bilinear sample, returning 0 (black) for out-of-frame coordinates.
+fn src_px_sample(img: &GrayImage, x: f64, y: f64) -> u8 {
+    if x < 0.0 || y < 0.0 || x > (img.width - 1) as f64 || y > (img.height - 1) as f64 {
+        return 0;
+    }
+    img.bilinear(x, y).round().clamp(0.0, 255.0) as u8
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+fn valid_range(d: &DisparityMap) -> Option<(f32, f32)> {
+    let mut lo = f32::INFINITY;
+    let mut hi = f32::NEG_INFINITY;
+    let mut any = false;
+    for &v in &d.data {
+        if v.is_finite() {
+            any = true;
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+    }
+    any.then_some((lo, hi))
+}
+
+/// Robust least-squares fit `d ≈ a·x + b·y + c`.
+///
+/// Fits over all valid pixels, then refits once over the inliers (residual
+/// within 3 px) so a handful of stray background matches cannot distort the
+/// board's reported planarity. Returns `(inlier_rms_px, inlier_count)`.
+fn planarity_rms(d: &DisparityMap) -> (f64, usize) {
+    let samples: Vec<(f64, f64, f64)> = (0..d.height)
+        .flat_map(|y| (0..d.width).map(move |x| (x, y)))
+        .filter_map(|(x, y)| {
+            let v = d.get(x, y);
+            v.is_finite().then_some((x as f64, y as f64, v as f64))
+        })
+        .collect();
+    if samples.len() < 3 {
+        return (f64::INFINITY, samples.len());
+    }
+
+    let fit = |pts: &[(f64, f64, f64)]| -> Option<Vec3> {
+        let mut ata = Matrix3::<f64>::zeros();
+        let mut atb = Vec3::zeros();
+        for &(x, y, v) in pts {
+            let f = Vec3::new(x, y, 1.0);
+            ata += f * f.transpose();
+            atb += f * v;
+        }
+        ata.try_inverse().map(|inv| inv * atb)
+    };
+
+    let Some(coef) = fit(&samples) else {
+        return (f64::INFINITY, samples.len());
+    };
+    let resid = |c: &Vec3, x: f64, y: f64, v: f64| (v - (c.x * x + c.y * y + c.z)).abs();
+
+    // Refit on inliers (within 3 px of the first fit).
+    let inliers: Vec<(f64, f64, f64)> = samples
+        .iter()
+        .copied()
+        .filter(|&(x, y, v)| resid(&coef, x, y, v) < 3.0)
+        .collect();
+    let pts = if inliers.len() >= 3 {
+        &inliers
+    } else {
+        &samples
+    };
+    let Some(coef) = fit(pts) else {
+        return (f64::INFINITY, pts.len());
+    };
+
+    let sum_sq: f64 = pts
+        .iter()
+        .map(|&(x, y, v)| resid(&coef, x, y, v).powi(2))
+        .sum();
+    ((sum_sq / pts.len() as f64).sqrt(), pts.len())
+}
+
+// ---------------------------------------------------------------------------
+// Visualization
+// ---------------------------------------------------------------------------
+
+/// Jet colormap, `t` in `[0, 1]` → `[r, g, b]`.
+fn jet(t: f32) -> [u8; 3] {
+    let t = t.clamp(0.0, 1.0);
+    let r = ((1.5 - (4.0 * t - 3.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
+    let g = ((1.5 - (4.0 * t - 2.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
+    let b = ((1.5 - (4.0 * t - 1.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
+    [r, g, b]
+}
+
+/// Save the rectified pair side-by-side with shared horizontal epipolar lines:
+/// a feature at row `y` on the left must sit at row `y` on the right.
+fn save_pair_with_epilines(path: &Path, left: &GrayImage, right: &GrayImage) {
+    let (w, h) = (left.width, left.height);
+    let gap = 8usize;
+    let total_w = w * 2 + gap;
+    let mut rgb = vec![[255u8, 255, 255]; total_w * h];
+    for y in 0..h {
+        for x in 0..w {
+            let l = left.get(x, y);
+            rgb[y * total_w + x] = [l, l, l];
+            let r = right.get(x, y);
+            rgb[y * total_w + w + gap + x] = [r, r, r];
+        }
+    }
+    // Epipolar lines every ~h/12 rows.
+    let step = (h / 12).max(1);
+    let mut yy = step;
+    while yy < h {
+        for x in 0..total_w {
+            rgb[yy * total_w + x] = [40, 220, 90];
+        }
+        yy += step;
+    }
+    save_rgb(path, total_w, h, &rgb);
+}
+
+/// Save the disparity map as a jet colormap (invalid → black).
+fn save_disparity(path: &Path, d: &DisparityMap, lo: f32, hi: f32) {
+    let span = (hi - lo).max(1e-6);
+    let rgb: Vec<[u8; 3]> = d
+        .data
+        .iter()
+        .map(|&v| {
+            if v.is_finite() {
+                jet((v - lo) / span)
+            } else {
+                [0, 0, 0]
+            }
+        })
+        .collect();
+    save_rgb(path, d.width, d.height, &rgb);
+}
+
+/// Save the disparity colormap alpha-blended over the rectified left image.
+fn save_overlay(path: &Path, left: &GrayImage, d: &DisparityMap, lo: f32, hi: f32) {
+    let span = (hi - lo).max(1e-6);
+    let rgb: Vec<[u8; 3]> = left
+        .data
+        .iter()
+        .zip(&d.data)
+        .map(|(&g8, &v)| {
+            let g = g8 as f32;
+            if v.is_finite() {
+                let c = jet((v - lo) / span);
+                // 65% disparity color, 35% underlying grayscale.
+                [
+                    (0.65 * c[0] as f32 + 0.35 * g) as u8,
+                    (0.65 * c[1] as f32 + 0.35 * g) as u8,
+                    (0.65 * c[2] as f32 + 0.35 * g) as u8,
+                ]
+            } else {
+                [g8, g8, g8]
+            }
+        })
+        .collect();
+    save_rgb(path, left.width, left.height, &rgb);
+}
+
+fn save_rgb(path: &Path, w: usize, h: usize, rgb: &[[u8; 3]]) {
+    let flat: Vec<u8> = rgb.iter().flat_map(|p| p.iter().copied()).collect();
+    image::RgbImage::from_raw(w as u32, h as u32, flat)
+        .expect("rgb buffer size")
+        .save(path)
+        .expect("write png");
+}
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = <root>/crates/vision-calibration
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root above crates/<crate>")
+        .to_path_buf()
+}

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -512,15 +512,16 @@ pub mod geometry {
 /// Multiple-view geometry pipelines over the [`geometry`] solvers, re-exported
 /// from `vision_mvg`: calibrated relative-pose recovery, robust (RANSAC)
 /// estimation, cheirality/degeneracy checks, N-view triangulation, homography
-/// decomposition, and Scheimpflug-aware stereo rectification — reached via the
-/// owning module, e.g.
-/// `vision_calibration::mvg::rectification::rectify_stereo_pair`.
+/// decomposition, Scheimpflug-aware stereo rectification, and pure-Rust dense
+/// stereo matching — reached via the owning module, e.g.
+/// `vision_calibration::mvg::rectification::rectify_stereo_pair` or
+/// `vision_calibration::mvg::dense::match_block`.
 ///
 /// With the `refine` feature, `vision_calibration::mvg::bundle_adjust` adds
 /// frozen-intrinsics bundle adjustment (tiny-solver).
 pub mod mvg {
     pub use vision_mvg::{
-        MvgError, cheirality, degeneracy, error, homography, pose_recovery, rectification,
+        MvgError, cheirality, degeneracy, dense, error, homography, pose_recovery, rectification,
         residuals, robust, triangulation, types,
     };
 

--- a/crates/vision-calibration/tests/facade_compile_surface.rs
+++ b/crates/vision-calibration/tests/facade_compile_surface.rs
@@ -88,7 +88,10 @@ fn mvg_module_surface_compiles() {
     let _ = mvg::triangulation::triangulate_nview;
     let _ = mvg::rectification::rectify_stereo_pair;
     let _ = mvg::homography::decompose_homography;
+    let _ = mvg::dense::match_block;
     let _: Option<mvg::rectification::StereoRectification> = None;
+    let _: Option<mvg::dense::DisparityMap> = None;
+    let _: Option<mvg::dense::BlockMatchOptions> = None;
     let _: Option<mvg::types::Correspondence2D> = None;
     let _: Option<mvg::MvgError> = None;
     let _: Option<mvg::error::Result<()>> = None;

--- a/crates/vision-mvg/src/dense.rs
+++ b/crates/vision-mvg/src/dense.rs
@@ -1,0 +1,695 @@
+//! Pure-Rust dense stereo matching (Track C5, ADR 0015 amended 2026-06-21).
+//!
+//! [`match_block`] is a block-matching stereo correspondence search: for every
+//! pixel of the (rectified) left image it finds the horizontal shift that best
+//! aligns a local window with the right image, producing a per-pixel
+//! [`DisparityMap`].
+//!
+//! # Algorithm (MVP)
+//!
+//! * **Cost** — zero-mean normalized cross-correlation (ZNCC) over a square
+//!   window, so the matcher is invariant to per-camera gain/bias (important on
+//!   real two-camera pairs). Window statistics are computed in `O(1)` per pixel
+//!   from summed-area tables, so the whole search is `O(W·H·D)` regardless of
+//!   the block size.
+//! * **Selection** — winner-take-all over the disparity range, with optional
+//!   parabolic **sub-pixel** refinement of the correlation peak.
+//! * **Invalidation** — three independent filters mark a pixel `NaN`:
+//!   a minimum correlation gate (rejects textureless regions), a uniqueness
+//!   margin (rejects ambiguous matches), and a left-right consistency check
+//!   (rejects occlusions / mismatches).
+//!
+//! Semi-global aggregation (SGM) on top of this cost is the documented
+//! follow-up; this module is the block-matching MVP.
+//!
+//! # Conventions
+//!
+//! Both images must be **rectified** — corresponding points share the same row.
+//! Disparity follows the standard sign `d = x_left − x_right ≥ 0`, so a left
+//! pixel `(x, y)` matches right pixel `(x − d, y)`. The returned map has the
+//! same dimensions as the left image; invalid pixels are `f32::NAN`.
+//!
+//! # Memory
+//!
+//! The MVP materializes a full `W·H·num_disparities` cost volume (`f32`). This
+//! keeps the selection/sub-pixel/uniqueness logic simple and is fine for the
+//! demo and modest images; SGM (the follow-up) replaces it with bounded-memory
+//! path aggregation.
+
+use crate::{MvgError, Result};
+
+// ---------------------------------------------------------------------------
+// Buffer types
+// ---------------------------------------------------------------------------
+
+/// 8-bit grayscale image buffer, row-major (`x` is the fast axis).
+#[derive(Debug, Clone)]
+pub struct GrayImage {
+    /// Image width in pixels.
+    pub width: usize,
+    /// Image height in pixels.
+    pub height: usize,
+    /// Raw pixel data, `data[y * width + x]`.
+    pub data: Vec<u8>,
+}
+
+impl GrayImage {
+    /// Construct a new buffer.
+    ///
+    /// # Panics
+    /// Panics if `data.len() != width * height`.
+    pub fn new(width: usize, height: usize, data: Vec<u8>) -> Self {
+        assert_eq!(
+            data.len(),
+            width * height,
+            "GrayImage: data length mismatch (expected {}, got {})",
+            width * height,
+            data.len()
+        );
+        Self {
+            width,
+            height,
+            data,
+        }
+    }
+
+    /// Read one pixel.
+    ///
+    /// # Panics
+    /// Panics in debug builds if `(x, y)` is out of bounds.
+    #[inline]
+    pub fn get(&self, x: usize, y: usize) -> u8 {
+        debug_assert!(
+            x < self.width && y < self.height,
+            "GrayImage::get out of bounds"
+        );
+        self.data[y * self.width + x]
+    }
+
+    /// Bilinear interpolation at sub-pixel position `(xf, yf)`.
+    ///
+    /// Coordinates are clamped to the border (the last valid pixel is
+    /// replicated rather than extrapolated).
+    pub fn bilinear(&self, xf: f64, yf: f64) -> f64 {
+        let w = self.width as f64;
+        let h = self.height as f64;
+
+        let xf = xf.clamp(0.0, w - 1.0);
+        let yf = yf.clamp(0.0, h - 1.0);
+
+        let x0 = xf.floor() as usize;
+        let y0 = yf.floor() as usize;
+        let x1 = (x0 + 1).min(self.width - 1);
+        let y1 = (y0 + 1).min(self.height - 1);
+
+        let dx = xf - x0 as f64;
+        let dy = yf - y0 as f64;
+
+        let p00 = self.get(x0, y0) as f64;
+        let p10 = self.get(x1, y0) as f64;
+        let p01 = self.get(x0, y1) as f64;
+        let p11 = self.get(x1, y1) as f64;
+
+        p00 * (1.0 - dx) * (1.0 - dy)
+            + p10 * dx * (1.0 - dy)
+            + p01 * (1.0 - dx) * dy
+            + p11 * dx * dy
+    }
+}
+
+/// Per-pixel horizontal disparity (`x_left − x_right`), in pixels.
+///
+/// `f32::NAN` marks an invalid/unknown pixel. Use [`DisparityMap::is_valid`] to
+/// test validity; never compare disparity values with `!=` or `<` directly
+/// because those comparisons return `false` for `NaN`.
+#[derive(Debug, Clone)]
+pub struct DisparityMap {
+    /// Map width in pixels.
+    pub width: usize,
+    /// Map height in pixels.
+    pub height: usize,
+    /// Raw data, `data[y * width + x]`, `NaN` = invalid.
+    pub data: Vec<f32>,
+}
+
+impl DisparityMap {
+    /// Construct a new map.
+    ///
+    /// # Panics
+    /// Panics if `data.len() != width * height`.
+    pub fn new(width: usize, height: usize, data: Vec<f32>) -> Self {
+        assert_eq!(
+            data.len(),
+            width * height,
+            "DisparityMap: data length mismatch"
+        );
+        Self {
+            width,
+            height,
+            data,
+        }
+    }
+
+    /// Construct a map filled with a single value (use `f32::NAN` for all-invalid).
+    pub fn filled(width: usize, height: usize, value: f32) -> Self {
+        Self {
+            width,
+            height,
+            data: vec![value; width * height],
+        }
+    }
+
+    /// Read one disparity value.
+    #[inline]
+    pub fn get(&self, x: usize, y: usize) -> f32 {
+        self.data[y * self.width + x]
+    }
+
+    /// Write one disparity value.
+    #[inline]
+    pub fn set(&mut self, x: usize, y: usize, value: f32) {
+        self.data[y * self.width + x] = value;
+    }
+
+    /// Returns `true` if the pixel is valid (finite, not `NaN`).
+    #[inline]
+    pub fn is_valid(&self, x: usize, y: usize) -> bool {
+        self.get(x, y).is_finite()
+    }
+
+    /// Number of valid (finite) pixels.
+    pub fn valid_count(&self) -> usize {
+        self.data.iter().filter(|v| v.is_finite()).count()
+    }
+
+    /// Min and max over the valid pixels, or `None` if there are none.
+    pub fn valid_range(&self) -> Option<(f32, f32)> {
+        let mut lo = f32::INFINITY;
+        let mut hi = f32::NEG_INFINITY;
+        let mut any = false;
+        for &v in &self.data {
+            if v.is_finite() {
+                any = true;
+                lo = lo.min(v);
+                hi = hi.max(v);
+            }
+        }
+        any.then_some((lo, hi))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/// Options controlling [`match_block`].
+#[derive(Debug, Clone)]
+pub struct BlockMatchOptions {
+    /// Minimum disparity searched, in pixels (usually `0`).
+    pub min_disparity: i32,
+    /// Number of disparity levels searched, `[min_disparity, min_disparity + num_disparities)`.
+    pub num_disparities: i32,
+    /// Square matching-window side length, in pixels (must be odd and ≥ 1).
+    pub block_size: usize,
+    /// Reject a pixel whose best ZNCC is below this (textureless / poor match), in `[-1, 1]`.
+    pub min_correlation: f32,
+    /// Reject a pixel unless its best ZNCC exceeds the best non-adjacent
+    /// alternative by at least this margin (ambiguity rejection).
+    pub uniqueness_ratio: f32,
+    /// Enable the left-right consistency cross-check (occlusion / mismatch rejection).
+    pub lr_consistency: bool,
+    /// Maximum `|d_left − d_right|`, in pixels, tolerated by the LR check.
+    pub lr_max_diff: f32,
+    /// Enable parabolic sub-pixel refinement of the correlation peak.
+    pub subpixel: bool,
+}
+
+impl Default for BlockMatchOptions {
+    fn default() -> Self {
+        Self {
+            min_disparity: 0,
+            num_disparities: 64,
+            block_size: 7,
+            min_correlation: 0.5,
+            uniqueness_ratio: 0.03,
+            lr_consistency: true,
+            lr_max_diff: 1.0,
+            subpixel: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Summed-area table
+// ---------------------------------------------------------------------------
+
+/// A summed-area table (integral image) for `O(1)` windowed sums.
+struct SummedArea {
+    /// Image width (the table has `width + 1` columns).
+    width: usize,
+    /// `(width + 1) * (height + 1)` prefix sums; `sat[(y+1)*(w+1) + (x+1)]`
+    /// holds the sum of the source over `[0..=x] × [0..=y]`.
+    sat: Vec<f64>,
+}
+
+impl SummedArea {
+    /// Build the table from a per-pixel value function.
+    fn build(width: usize, height: usize, value: impl Fn(usize, usize) -> f64) -> Self {
+        let stride = width + 1;
+        let mut sat = vec![0.0f64; stride * (height + 1)];
+        for y in 0..height {
+            for x in 0..width {
+                sat[(y + 1) * stride + (x + 1)] =
+                    value(x, y) + sat[y * stride + (x + 1)] + sat[(y + 1) * stride + x]
+                        - sat[y * stride + x];
+            }
+        }
+        Self { width, sat }
+    }
+
+    /// Sum over the `(2r+1)×(2r+1)` window centred at `(cx, cy)`.
+    ///
+    /// The caller must guarantee the window lies fully inside the image
+    /// (`cx >= r`, `cx + r < width`, `cy >= r`, `cy + r < height`).
+    #[inline]
+    fn window_sum(&self, cx: usize, cy: usize, r: usize) -> f64 {
+        let stride = self.width + 1;
+        let x0 = cx - r;
+        let x1 = cx + r + 1;
+        let y0 = cy - r;
+        let y1 = cy + r + 1;
+        self.sat[y1 * stride + x1] - self.sat[y0 * stride + x1] - self.sat[y1 * stride + x0]
+            + self.sat[y0 * stride + x0]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/// Sentinel correlation for a window that cannot be evaluated (out of range or
+/// zero-variance). Stored in the cost volume; never selected as a peak.
+const INVALID_CORR: f32 = f32::NEG_INFINITY;
+
+/// Compute a dense disparity map for a rectified stereo pair by block matching.
+///
+/// See the [module documentation](self) for the algorithm and conventions.
+///
+/// # Errors
+///
+/// Returns [`MvgError::InvalidInput`] if the two images differ in size, if
+/// `block_size` is even or zero, if `num_disparities <= 0`, or if either image
+/// is smaller than the matching window.
+pub fn match_block(
+    left: &GrayImage,
+    right: &GrayImage,
+    opts: &BlockMatchOptions,
+) -> Result<DisparityMap> {
+    let (w, h) = (left.width, left.height);
+    if right.width != w || right.height != h {
+        return Err(MvgError::invalid_input(format!(
+            "left ({w}x{h}) and right ({}x{}) images must have equal dimensions",
+            right.width, right.height
+        )));
+    }
+    if opts.block_size == 0 || opts.block_size.is_multiple_of(2) {
+        return Err(MvgError::invalid_input(format!(
+            "block_size must be odd and >= 1, got {}",
+            opts.block_size
+        )));
+    }
+    if opts.num_disparities <= 0 {
+        return Err(MvgError::invalid_input(format!(
+            "num_disparities must be positive, got {}",
+            opts.num_disparities
+        )));
+    }
+    let r = opts.block_size / 2;
+    if w < opts.block_size || h < opts.block_size {
+        return Err(MvgError::invalid_input(format!(
+            "image {w}x{h} is smaller than the {0}x{0} matching window",
+            opts.block_size
+        )));
+    }
+
+    // Summed-area tables of the intensities and their squares, reused across
+    // disparities and across both matching directions.
+    let il = SummedArea::build(w, h, |x, y| left.get(x, y) as f64);
+    let ill = SummedArea::build(w, h, |x, y| {
+        let v = left.get(x, y) as f64;
+        v * v
+    });
+    let ir = SummedArea::build(w, h, |x, y| right.get(x, y) as f64);
+    let irr = SummedArea::build(w, h, |x, y| {
+        let v = right.get(x, y) as f64;
+        v * v
+    });
+
+    // Left-referenced disparity: a left pixel matches the right image at x - d.
+    let left_disp = solve_direction(left, right, &il, &ill, &ir, &irr, -1, r, opts);
+
+    if !opts.lr_consistency {
+        return Ok(DisparityMap::new(w, h, left_disp));
+    }
+
+    // Right-referenced disparity: a right pixel matches the left image at xr + d.
+    let right_disp = solve_direction(right, left, &ir, &irr, &il, &ill, 1, r, opts);
+
+    // Cross-check: keep a left disparity only if the right map agrees.
+    let mut out = left_disp;
+    for y in 0..h {
+        for x in 0..w {
+            let idx = y * w + x;
+            let d = out[idx];
+            if !d.is_finite() {
+                continue;
+            }
+            let xr = (x as f32 - d).round();
+            if xr < 0.0 || xr >= w as f32 {
+                out[idx] = f32::NAN;
+                continue;
+            }
+            let dr = right_disp[(y * w) + xr as usize];
+            if !dr.is_finite() || (d - dr).abs() > opts.lr_max_diff {
+                out[idx] = f32::NAN;
+            }
+        }
+    }
+    Ok(DisparityMap::new(w, h, out))
+}
+
+/// Compute a one-directional disparity map.
+///
+/// `a` is the reference image, `b` the target; for each `a` pixel the matcher
+/// searches `b` at `x + sign * d` for `d` in the configured range. `sign` is
+/// `-1` when `a` is the left image (match leftward) and `+1` when `a` is the
+/// right image (match rightward). Returns disparity magnitudes (`>= 0`) with
+/// `NaN` for rejected pixels.
+#[allow(clippy::too_many_arguments)]
+fn solve_direction(
+    a: &GrayImage,
+    b: &GrayImage,
+    ia: &SummedArea,
+    iaa: &SummedArea,
+    ib: &SummedArea,
+    ibb: &SummedArea,
+    sign: i32,
+    r: usize,
+    opts: &BlockMatchOptions,
+) -> Vec<f32> {
+    let (w, h) = (a.width, a.height);
+    let num_d = opts.num_disparities as usize;
+    let n = ((2 * r + 1) * (2 * r + 1)) as f64;
+    // Cost volume: cost[k * (w*h) + y*w + x] = ZNCC at disparity min+k.
+    let mut cost = vec![INVALID_CORR; num_d * w * h];
+
+    for k in 0..num_d {
+        let disp = opts.min_disparity + k as i32;
+        // Cross-correlation term a(x,y) * b(x + sign*disp, y), summed-area table
+        // rebuilt per disparity (it is the only disparity-dependent term).
+        let iab = SummedArea::build(w, h, |x, y| {
+            let tx = x as i32 + sign * disp;
+            if tx >= 0 && (tx as usize) < w {
+                a.get(x, y) as f64 * b.get(tx as usize, y) as f64
+            } else {
+                0.0
+            }
+        });
+
+        let plane = k * w * h;
+        for y in r..h - r {
+            for x in r..w - r {
+                let tx = x as i32 + sign * disp;
+                // The b-window must lie fully inside the image.
+                if tx - (r as i32) < 0 || tx + (r as i32) >= w as i32 {
+                    continue;
+                }
+                let cxb = tx as usize;
+
+                let s_a = ia.window_sum(x, y, r);
+                let s_aa = iaa.window_sum(x, y, r);
+                let s_b = ib.window_sum(cxb, y, r);
+                let s_bb = ibb.window_sum(cxb, y, r);
+                let s_ab = iab.window_sum(x, y, r);
+
+                let var_a = n * s_aa - s_a * s_a;
+                let var_b = n * s_bb - s_b * s_b;
+                if var_a <= 1e-6 || var_b <= 1e-6 {
+                    continue; // flat window: correlation undefined
+                }
+                let cov = n * s_ab - s_a * s_b;
+                let zncc = cov / (var_a.sqrt() * var_b.sqrt());
+                cost[plane + y * w + x] = zncc as f32;
+            }
+        }
+    }
+
+    // Per-pixel selection: winner-take-all + uniqueness + min-correlation +
+    // optional parabolic sub-pixel refinement.
+    let mut disp_map = vec![f32::NAN; w * h];
+    let area = w * h;
+    for y in r..h - r {
+        for x in r..w - r {
+            let base = y * w + x;
+            let mut best_k = usize::MAX;
+            let mut best = INVALID_CORR;
+            for k in 0..num_d {
+                let c = cost[k * area + base];
+                if c > best {
+                    best = c;
+                    best_k = k;
+                }
+            }
+            if best_k == usize::MAX || best < opts.min_correlation {
+                continue;
+            }
+            // Best non-adjacent competitor for the uniqueness test.
+            let mut second = INVALID_CORR;
+            for k in 0..num_d {
+                if k.abs_diff(best_k) <= 1 {
+                    continue;
+                }
+                let c = cost[k * area + base];
+                if c > second {
+                    second = c;
+                }
+            }
+            if second.is_finite() && best - second < opts.uniqueness_ratio {
+                continue; // ambiguous
+            }
+
+            let mut d = (opts.min_disparity + best_k as i32) as f32;
+            if opts.subpixel && best_k > 0 && best_k + 1 < num_d {
+                let cm = cost[(best_k - 1) * area + base];
+                let cp = cost[(best_k + 1) * area + base];
+                if cm.is_finite() && cp.is_finite() {
+                    let denom = cm + cp - 2.0 * best;
+                    if denom.abs() > 1e-6 {
+                        let delta = 0.5 * (cm - cp) / denom;
+                        if delta.abs() < 1.0 {
+                            d += delta;
+                        }
+                    }
+                }
+            }
+            disp_map[base] = d;
+        }
+    }
+    disp_map
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic high-entropy texture, range `[0, 255]` (mirrors the bench
+    /// fixture so the matcher is exercised on the same kind of signal).
+    fn texture_u8(x: usize, y: usize) -> u8 {
+        let sine = (x as f64 * 0.21).sin() * 0.5 + 0.5 + (y as f64 * 0.13).sin() * 0.5 + 0.5;
+        let base = (sine * 63.5) as u8;
+        let hash = (x.wrapping_mul(0x9e37_79b9) ^ y.wrapping_mul(0x6c62_272e)) as u8;
+        base.wrapping_add(hash >> 1)
+    }
+
+    /// Build a synthetic rectified pair for disparity field `d(x,y)`.
+    /// `right[x] = left[x + d]` so that `right[x - d] == left[x]`.
+    fn synth(
+        w: usize,
+        h: usize,
+        disp: impl Fn(usize, usize) -> f32,
+    ) -> (GrayImage, GrayImage, Vec<f32>) {
+        let mut ld = vec![0u8; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                ld[y * w + x] = texture_u8(x, y);
+            }
+        }
+        let left = GrayImage::new(w, h, ld);
+        let mut rd = vec![0u8; w * h];
+        let mut gt = vec![f32::NAN; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let d = disp(x, y);
+                rd[y * w + x] = left.bilinear(x as f64 + d as f64, y as f64).round() as u8;
+                let mx = x as f32 - d;
+                if mx >= 0.0 && mx < w as f32 {
+                    gt[y * w + x] = d;
+                }
+            }
+        }
+        (left, GrayImage::new(w, h, rd), gt)
+    }
+
+    fn rms_over_valid(est: &DisparityMap, gt: &[f32], r: usize) -> (f64, usize) {
+        let (w, h) = (est.width, est.height);
+        let (mut sum_sq, mut n) = (0.0f64, 0usize);
+        for y in r..h - r {
+            for x in r..w - r {
+                let g = gt[y * w + x];
+                let e = est.get(x, y);
+                if g.is_finite() && e.is_finite() {
+                    sum_sq += ((e - g) as f64).powi(2);
+                    n += 1;
+                }
+            }
+        }
+        if n == 0 {
+            (f64::INFINITY, 0)
+        } else {
+            ((sum_sq / n as f64).sqrt(), n)
+        }
+    }
+
+    #[test]
+    fn recovers_constant_disparity() {
+        let (left, right, gt) = synth(80, 60, |_, _| 8.0);
+        let opts = BlockMatchOptions {
+            min_disparity: 0,
+            num_disparities: 16,
+            block_size: 7,
+            ..Default::default()
+        };
+        let est = match_block(&left, &right, &opts).unwrap();
+        let (rms, n) = rms_over_valid(&est, &gt, 4);
+        assert!(n > 1500, "should recover most interior pixels, got {n}");
+        assert!(rms < 0.3, "constant-disparity RMS too high: {rms}");
+    }
+
+    #[test]
+    fn recovers_fractional_disparity_subpixel() {
+        // A constant fractional disparity: integer WTA alone cannot reach it,
+        // so this exercises the parabolic sub-pixel refinement.
+        let (left, right, gt) = synth(80, 60, |_, _| 6.4);
+        let opts = BlockMatchOptions {
+            min_disparity: 0,
+            num_disparities: 16,
+            block_size: 9,
+            ..Default::default()
+        };
+        let est = match_block(&left, &right, &opts).unwrap();
+        let (rms, n) = rms_over_valid(&est, &gt, 5);
+        assert!(n > 1000, "expected dense recovery, got {n}");
+        assert!(rms < 0.25, "sub-pixel RMS too high: {rms}");
+    }
+
+    #[test]
+    fn recovers_slanted_plane() {
+        let (left, right, gt) = synth(100, 70, |x, y| 8.0 + 0.02 * x as f32 + 0.01 * y as f32);
+        let opts = BlockMatchOptions {
+            min_disparity: 0,
+            num_disparities: 16,
+            block_size: 7,
+            ..Default::default()
+        };
+        let est = match_block(&left, &right, &opts).unwrap();
+        let (rms, _) = rms_over_valid(&est, &gt, 4);
+        assert!(rms < 0.4, "slanted-plane RMS too high: {rms}");
+    }
+
+    #[test]
+    fn lr_consistency_invalidates_some_border_pixels() {
+        // Without LR consistency the matcher fills more pixels; enabling it must
+        // not increase the valid count and should drop ambiguous border matches.
+        let (left, right, _) = synth(80, 60, |_, _| 8.0);
+        let base = BlockMatchOptions {
+            num_disparities: 16,
+            block_size: 7,
+            ..Default::default()
+        };
+        let with_lr = match_block(&left, &right, &base).unwrap();
+        let without_lr = match_block(
+            &left,
+            &right,
+            &BlockMatchOptions {
+                lr_consistency: false,
+                ..base
+            },
+        )
+        .unwrap();
+        assert!(
+            with_lr.valid_count() <= without_lr.valid_count(),
+            "LR consistency should only ever remove matches"
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_dimensions() {
+        let a = GrayImage::new(10, 10, vec![0; 100]);
+        let b = GrayImage::new(12, 10, vec![0; 120]);
+        let err = match_block(&a, &b, &BlockMatchOptions::default()).unwrap_err();
+        assert!(matches!(err, MvgError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn rejects_even_block_size() {
+        let a = GrayImage::new(20, 20, vec![0; 400]);
+        let b = GrayImage::new(20, 20, vec![0; 400]);
+        let err = match_block(
+            &a,
+            &b,
+            &BlockMatchOptions {
+                block_size: 8,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, MvgError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn rejects_window_larger_than_image() {
+        let a = GrayImage::new(5, 5, vec![0; 25]);
+        let b = GrayImage::new(5, 5, vec![0; 25]);
+        let err = match_block(
+            &a,
+            &b,
+            &BlockMatchOptions {
+                block_size: 7,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, MvgError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn textureless_region_is_rejected() {
+        // A flat (zero-variance) image yields undefined correlation everywhere,
+        // so every pixel must be invalid rather than spuriously matched.
+        let flat = GrayImage::new(40, 30, vec![128; 40 * 30]);
+        let est = match_block(
+            &flat,
+            &flat.clone(),
+            &BlockMatchOptions {
+                num_disparities: 16,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(est.valid_count(), 0, "flat image must produce no matches");
+    }
+}

--- a/crates/vision-mvg/src/error.rs
+++ b/crates/vision-mvg/src/error.rs
@@ -82,9 +82,6 @@ impl From<MathError> for MvgError {
 
 impl MvgError {
     /// Convenience constructor for [`MvgError::InvalidInput`].
-    ///
-    /// Currently only used by the feature-gated nonlinear refinement.
-    #[cfg(feature = "refine")]
     pub(crate) fn invalid_input(reason: impl Into<String>) -> Self {
         Self::InvalidInput {
             reason: reason.into(),

--- a/crates/vision-mvg/src/lib.rs
+++ b/crates/vision-mvg/src/lib.rs
@@ -29,6 +29,7 @@
 pub mod bundle_adjust;
 pub mod cheirality;
 pub mod degeneracy;
+pub mod dense;
 pub mod error;
 pub mod homography;
 pub mod pose_recovery;
@@ -45,6 +46,7 @@ pub mod types;
 pub use bundle_adjust::{
     BundleAdjustmentOptions, BundleAdjustmentResult, BundleObservation, bundle_adjust,
 };
+pub use dense::{BlockMatchOptions, DisparityMap, GrayImage, match_block};
 pub use error::{MvgError, Result};
 pub use homography::{
     HomographyDecomposition, decompose_homography, homography_from_pose_and_plane,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -317,8 +317,13 @@ dense matcher, no full SfM.
 - **C3** Bundle adjustment with frozen intrinsics, free poses, free structure.
 - **C4** Stereo rectification — including **Scheimpflug-aware rectification** (genuinely
   novel for this project).
-- **C5** Dense matcher integration behind a `dense-opencv` feature flag, wrapping
-  `opencv-rust` SGBM.
+- **C5** Dense matcher. ADR 0015's ceiling was **amended** (2026-06-21): the matcher
+  ships **pure-Rust in `vision-mvg`**, with `opencv-rust` SGBM demoted to a
+  benchmark-only baseline in the unpublished bench crate. The **block-matching MVP
+  (`vision_mvg::dense::match_block`, ZNCC + sub-pixel + LR-consistency) landed
+  2026-06-21** — 94% density at 0.18 px RMS on synthetic GT, 0.44 px board-planarity
+  RMS on the real `data/stereo` rig (two visual-evidence demos under
+  `target/fixtures/`). Remaining: SGM aggregation and the OpenCV SGBM baseline.
 - **C-UI** MVG visualizations layered into the Tauri app (point clouds, depth maps,
   rectified pairs).
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -369,9 +369,25 @@ Systemic causes:
     if added as a normal cargo feature → put it in a workspace-EXCLUDED crate or
     a dedicated CI job with OpenCV). Implements `DenseMatcher`, scored by
     `evaluate`.
-  - [ ] **Pure-Rust matcher** — the actual C5 deliverable (block-matching MVP →
-    SGM). Implements `DenseMatcher`; benchmarked against the OpenCV baseline +
-    target-plane ground truth.
+  - [x] **Pure-Rust matcher** — the block-matching MVP. **Done 2026-06-21.** New
+    `vision_mvg::dense` (always-on, no new deps): `GrayImage` / `DisparityMap` /
+    `BlockMatchOptions` + `match_block` — ZNCC over a square window aggregated in
+    `O(1)/px` via summed-area tables (so the search is `O(W·H·D)` for any block
+    size), winner-take-all with parabolic sub-pixel refinement, and three
+    independent invalidation filters (min-correlation, uniqueness margin,
+    left-right consistency). Typed `MvgError`; surfaced through the facade as
+    `vision_calibration::mvg::dense` (surface-locked). The bench `BlockMatcher`
+    (`impl DenseMatcher`, reached via the facade — no new bench dep) scores it
+    through the harness: synthetic slanted-plane recovery hits **94% density at
+    0.18 px RMS**. Two visual-evidence demos write inspectable PNGs to
+    `target/fixtures/`: `dense_synth` (bench, `--features tier-b`) tiles
+    left | right | GT | estimate | error; `dense_stereo_real` (facade) rectifies
+    the committed `data/stereo` chessboard rig (undistort → C4 rectify → match)
+    and recovers the board plane at **0.44 px planarity-fit RMS** over ~13.5k
+    inlier pixels (no GT needed — the planar target is the reference). 8 matcher
+    unit tests + 1 harness integration gate. Remaining C5 work: SGM aggregation
+    (bounded-memory; the cost volume MVP is the stepping stone) and the OpenCV
+    SGBM baseline above.
 
 ## D — Earn v1.0
 

--- a/docs/tutorials/multiple-view-geometry.md
+++ b/docs/tutorials/multiple-view-geometry.md
@@ -113,6 +113,38 @@ homography is the rotation part of rectification, exactly as OpenCV splits
 `initUndistortRectifyMap`). See [ADR 0015](../adrs/0015-mvg-ceiling.md) for the
 crate's scope boundary.
 
+### 4. Dense matching
+
+Once a pair is rectified, `mvg::dense::match_block` produces a per-pixel
+disparity map by block matching — ZNCC over a square window (so it tolerates
+per-camera gain/bias), winner-take-all with parabolic sub-pixel refinement, and
+left-right-consistency / uniqueness / min-correlation filtering (rejected pixels
+are `NaN`):
+
+```rust
+use vision_calibration::mvg::dense::{match_block, BlockMatchOptions, GrayImage};
+
+// `left` / `right` are rectified grayscale images (resample the source through
+// the rectifying homography first; see the dense_stereo_real example).
+let disp = match_block(&left, &right, &BlockMatchOptions {
+    min_disparity: 0,
+    num_disparities: 64,   // search [min, min + num)
+    block_size: 9,         // odd; larger = smoother, fewer matches near edges
+    ..Default::default()
+})?;
+// disp.get(x, y) is x_left − x_right in pixels, or NaN where the matcher abstains.
+```
+
+This is the block-matching MVP (semi-global aggregation is a follow-up). Two
+runnable demos write inspectable PNGs to `target/fixtures/`:
+
+```bash
+# synthetic ground truth: left | right | GT | estimate | error
+cargo run -p vision-calibration-bench --example dense_synth --features tier-b --release
+# real chessboard rig: undistort → rectify → match → disparity overlay
+cargo run -p vision-calibration --example dense_stereo_real --release
+```
+
 ## Common variations
 
 - **Outliers in the matches** → `mvg::robust::recover_relative_pose_robust` /
@@ -141,6 +173,6 @@ crate's scope boundary.
 - [ADR 0009](../adrs/0009-coordinate-and-pose-conventions.md) — pose and frame
   conventions (`frame_se3_frame`, `T_C_W`).
 - Crate docs for `vision_calibration::mvg::{pose_recovery, triangulation,
-  bundle_adjust, rectification, robust}`.
+  bundle_adjust, rectification, dense, robust}`.
 - The low-level solvers underneath: `vision_calibration::geometry`
   (epipolar, homography, triangulation, camera-matrix).


### PR DESCRIPTION
## What

Implements the **C5-DENSE** deliverable: a pure-Rust dense stereo matcher in the published `vision-mvg` crate, plus two runnable demos that emit **inspectable disparity PNGs** — synthetic ground truth and the real `data/stereo` chessboard rig.

ADR 0015's ceiling (amended 2026-06-21): the matcher ships pure-Rust in `vision-mvg`; OpenCV SGBM stays a benchmark-only baseline.

## The matcher — `vision_mvg::dense::match_block`

- **ZNCC** over a square window, aggregated via summed-area tables → the search is `O(W·H·D)` for any block size; tolerant of per-camera gain/bias (real two-camera pairs).
- **Winner-take-all + parabolic sub-pixel** refinement.
- Three invalidation filters → `NaN`: **min-correlation** (textureless), **uniqueness margin** (ambiguous), **left-right consistency** (occlusion/mismatch).
- Typed `MvgError`; surfaced through the facade as `vision_calibration::mvg::dense`, surface-locked in `facade_compile_surface.rs`. Always-on (no new deps).

## Harness wiring + visual evidence

- Bench `BlockMatcher` (`impl DenseMatcher`) reaches the matcher via the facade — **no new bench dependency**. Harness integration gate: **94% density at 0.18 px RMS** on synthetic GT.
- **`dense_synth`** (bench, `--features tier-b`): tiles **left │ right │ GT │ estimate │ error** → `target/fixtures/dense_synth/composite.png`.
- **`dense_stereo_real`** (facade): undistort → C4 rectify → match on the committed stereo rig; recovers the board plane at **0.44 px planarity-fit RMS** over ~13.5k inlier pixels (ground-truth-free — the planar target is the reference). Writes rectified pair (epipolar lines align), disparity, and overlay PNGs.

## Run it

```bash
cargo run -p vision-calibration-bench --example dense_synth --features tier-b --release
cargo run -p vision-calibration --example dense_stereo_real --release
```

## Tests / gates

8 matcher unit tests + 1 harness integration gate; facade surface lock. All green: `fmt`, `clippy --workspace --all-targets --all-features -D warnings`, workspace tests, `RUSTDOCFLAGS="-D warnings" cargo doc` (also fixed a pre-existing private intra-doc-link warning in the harness).

## Docs

Backlog `C5-DENSE` (pure-Rust matcher marked done), ROADMAP `C5` line, MVG tutorial section.

## Remaining C5 (follow-ups)

- **SGM** semi-global aggregation on top of the cost volume (next).
- **OpenCV SGBM baseline** (needs an OpenCV-equipped env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)