### PR TITLE
C-UI: depth-from-disparity + 3D point cloud in the Depth workspace

### DIFF
--- a/app/src-tauri/src/disparity.rs
+++ b/app/src-tauri/src/disparity.rs
@@ -45,6 +45,10 @@ pub struct DisparityResult {
     pub disparity_png: String,
     /// Disparity colormap blended over the rectified left image.
     pub overlay_png: String,
+    /// Depth colormap (jet over metric depth `Z = f·B / d`; invalid black).
+    pub depth_png: String,
+    /// Reprojected 3D point cloud (reference-camera frame, metres).
+    pub point_cloud: PointCloud,
     /// Matched (downscaled) image width.
     pub width: usize,
     /// Matched (downscaled) image height.
@@ -64,6 +68,21 @@ pub struct DisparityResult {
     /// Whether semi-global aggregation was used.
     pub semi_global: bool,
 }
+
+/// A reprojected 3D point cloud for the frontend's WebGL renderer.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PointCloud {
+    /// Flat `[x, y, z, …]` positions in the reference-camera frame (metres).
+    pub positions: Vec<f32>,
+    /// Flat `[r, g, b, …]` per-point grayscale colours in `[0, 1]`.
+    pub colors: Vec<f32>,
+    /// Number of points (`positions.len() / 3`).
+    pub count: usize,
+}
+
+/// Upper bound on rendered points; the cloud is grid-subsampled past this.
+const MAX_POINTS: usize = 60_000;
 
 /// Tauri command: compute a disparity map for the `(cam_a, cam_b)` pair at
 /// `pose` and return colormapped PNGs + metrics.
@@ -168,10 +187,15 @@ fn compute(
     let (lo, hi) = valid_range(&disp).unwrap_or((0.0, 1.0));
     let (plane_rms, plane_inliers) = planarity_rms(&disp);
 
+    // Reproject to metric depth + a 3D point cloud (rectified-frame pinhole).
+    let (point_cloud, depth) = reproject(&disp, &rect_left, &rect.k_rect, rect.baseline);
+
     Ok(DisparityResult {
         rectified_pair_png: pair_with_epilines_url(&rect_left, &rect_right)?,
         disparity_png: disparity_url(&disp, lo, hi)?,
         overlay_png: overlay_url(&rect_left, &disp, lo, hi)?,
+        depth_png: depth_url(&depth, w, h)?,
+        point_cloud,
         width: w,
         height: h,
         density,
@@ -350,6 +374,62 @@ fn planarity_rms(d: &DisparityMap) -> (f64, usize) {
 }
 
 // ---------------------------------------------------------------------------
+// Reprojection (disparity → metric depth + point cloud)
+// ---------------------------------------------------------------------------
+
+/// Reproject the disparity map to metric depth and a 3D point cloud through the
+/// rectified pinhole: `Z = f·B / d`, `X = (x−cx)·Z/fx`, `Y = (y−cy)·Z/fy`.
+/// Returns the (grid-subsampled) point cloud and a per-pixel depth map (`NaN`
+/// where disparity is invalid).
+fn reproject(
+    disp: &DisparityMap,
+    rect_left: &GrayImage,
+    k_rect: &Mat3,
+    baseline: f64,
+) -> (PointCloud, Vec<f32>) {
+    let (w, h) = (disp.width, disp.height);
+    let fx = k_rect[(0, 0)] as f32;
+    let fy = k_rect[(1, 1)] as f32;
+    let cx = k_rect[(0, 2)] as f32;
+    let cy = k_rect[(1, 2)] as f32;
+    let b = baseline as f32;
+
+    let mut depth = vec![f32::NAN; w * h];
+    // Grid subsample so the rendered cloud stays under MAX_POINTS.
+    let step = (((w * h) as f64 / MAX_POINTS as f64).sqrt().ceil() as usize).max(1);
+    let mut positions = Vec::new();
+    let mut colors = Vec::new();
+    for y in 0..h {
+        for x in 0..w {
+            let d = disp.get(x, y);
+            if !(d.is_finite() && d > 0.0) {
+                continue;
+            }
+            let z = fx * b / d;
+            depth[y * w + x] = z;
+            if x % step == 0 && y % step == 0 {
+                positions.push((x as f32 - cx) * z / fx);
+                positions.push((y as f32 - cy) * z / fy);
+                positions.push(z);
+                let g = rect_left.get(x, y) as f32 / 255.0;
+                colors.push(g);
+                colors.push(g);
+                colors.push(g);
+            }
+        }
+    }
+    let count = positions.len() / 3;
+    (
+        PointCloud {
+            positions,
+            colors,
+            count,
+        },
+        depth,
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
@@ -360,6 +440,30 @@ fn jet(t: f32) -> [u8; 3] {
     let g = ((1.5 - (4.0 * t - 2.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
     let b = ((1.5 - (4.0 * t - 1.0).abs()).clamp(0.0, 1.0) * 255.0) as u8;
     [r, g, b]
+}
+
+/// Depth colormap (jet over the metric depth range; near = blue, far = red).
+fn depth_url(depth: &[f32], w: usize, h: usize) -> Result<String, String> {
+    let mut lo = f32::INFINITY;
+    let mut hi = f32::NEG_INFINITY;
+    for &z in depth {
+        if z.is_finite() {
+            lo = lo.min(z);
+            hi = hi.max(z);
+        }
+    }
+    let span = (hi - lo).max(1e-6);
+    let rgb: Vec<[u8; 3]> = depth
+        .iter()
+        .map(|&z| {
+            if z.is_finite() {
+                jet((z - lo) / span)
+            } else {
+                [0, 0, 0]
+            }
+        })
+        .collect();
+    rgb_to_url(w, h, &rgb)
 }
 
 fn disparity_url(d: &DisparityMap, lo: f32, hi: f32) -> Result<String, String> {
@@ -479,13 +583,27 @@ mod tests {
         assert!(res.disparity_png.starts_with("data:image/png;base64,"));
         assert!(res.overlay_png.starts_with("data:image/png;base64,"));
         assert!(res.rectified_pair_png.starts_with("data:image/png;base64,"));
+        assert!(res.depth_png.starts_with("data:image/png;base64,"));
         assert!(res.semi_global);
+
+        // Point cloud: reprojected board points cluster near the calibrated
+        // board depth (~0.5 m) in the reference frame.
+        let pc = &res.point_cloud;
+        assert!(pc.count > 1000, "few cloud points: {}", pc.count);
+        assert_eq!(pc.positions.len(), pc.count * 3);
+        assert_eq!(pc.colors.len(), pc.count * 3);
+        let mean_z: f32 = pc.positions.iter().skip(2).step_by(3).sum::<f32>() / pc.count as f32;
+        assert!(
+            (0.3..0.9).contains(&mean_z),
+            "mean reprojected depth off: {mean_z} m"
+        );
 
         // Optional visual dump for manual inspection (DUMP_DISPARITY=1).
         if std::env::var("DUMP_DISPARITY").is_ok() {
             for (name, url) in [
                 ("overlay", &res.overlay_png),
                 ("disparity", &res.disparity_png),
+                ("depth", &res.depth_png),
                 ("pair", &res.rectified_pair_png),
             ] {
                 let b64 = url.strip_prefix("data:image/png;base64,").unwrap();

--- a/app/src-tauri/src/disparity.rs
+++ b/app/src-tauri/src/disparity.rs
@@ -187,8 +187,9 @@ fn compute(
     let (lo, hi) = valid_range(&disp).unwrap_or((0.0, 1.0));
     let (plane_rms, plane_inliers) = planarity_rms(&disp);
 
-    // Reproject to metric depth + a 3D point cloud (rectified-frame pinhole).
-    let (point_cloud, depth) = reproject(&disp, &rect_left, &rect.k_rect, rect.baseline);
+    // Reproject to metric depth + a 3D point cloud (reference-camera frame).
+    let (point_cloud, depth) =
+        reproject(&disp, &rect_left, &rect.k_rect, &rect.r_rect, rect.baseline);
 
     Ok(DisparityResult {
         rectified_pair_png: pair_with_epilines_url(&rect_left, &rect_right)?,
@@ -379,12 +380,17 @@ fn planarity_rms(d: &DisparityMap) -> (f64, usize) {
 
 /// Reproject the disparity map to metric depth and a 3D point cloud through the
 /// rectified pinhole: `Z = f·B / d`, `X = (x−cx)·Z/fx`, `Y = (y−cy)·Z/fy`.
-/// Returns the (grid-subsampled) point cloud and a per-pixel depth map (`NaN`
-/// where disparity is invalid).
+/// The triangulated point lives in the **rectified** frame; `r_rect` (camera-0
+/// direction → rectified frame) is inverted to express cloud points in the
+/// reference camera's frame, matching the 3D view's axes gizmo. The depth map
+/// stays rectified-frame `Z` — it is indexed by rectified pixels. Returns the
+/// (grid-subsampled) point cloud and a per-pixel depth map (`NaN` where
+/// disparity is invalid).
 fn reproject(
     disp: &DisparityMap,
     rect_left: &GrayImage,
     k_rect: &Mat3,
+    r_rect: &Mat3,
     baseline: f64,
 ) -> (PointCloud, Vec<f32>) {
     let (w, h) = (disp.width, disp.height);
@@ -393,6 +399,7 @@ fn reproject(
     let cx = k_rect[(0, 2)] as f32;
     let cy = k_rect[(1, 2)] as f32;
     let b = baseline as f32;
+    let cam_from_rect = r_rect.transpose();
 
     let mut depth = vec![f32::NAN; w * h];
     // Grid subsample so the rendered cloud stays under MAX_POINTS.
@@ -408,9 +415,15 @@ fn reproject(
             let z = fx * b / d;
             depth[y * w + x] = z;
             if x % step == 0 && y % step == 0 {
-                positions.push((x as f32 - cx) * z / fx);
-                positions.push((y as f32 - cy) * z / fy);
-                positions.push(z);
+                let p_rect = Vec3::new(
+                    ((x as f32 - cx) * z / fx) as f64,
+                    ((y as f32 - cy) * z / fy) as f64,
+                    z as f64,
+                );
+                let p_cam = cam_from_rect * p_rect;
+                positions.push(p_cam.x as f32);
+                positions.push(p_cam.y as f32);
+                positions.push(p_cam.z as f32);
                 let g = rect_left.get(x, y) as f32 / 255.0;
                 colors.push(g);
                 colors.push(g);

--- a/app/src/workspaces/DepthWorkspace/PointCloudView.tsx
+++ b/app/src/workspaces/DepthWorkspace/PointCloudView.tsx
@@ -1,0 +1,86 @@
+import { OrbitControls } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
+import { useMemo } from "react";
+import { useThemeColors } from "../Viewer3DWorkspace/useThemeColors";
+
+interface PointCloudViewProps {
+  /** Flat `[x, y, z, …]` positions (reference-camera frame, metres). */
+  positions: Float32Array;
+  /** Flat `[r, g, b, …]` per-point colours in `[0, 1]`. */
+  colors: Float32Array;
+}
+
+/** Orbitable WebGL point cloud reprojected from the disparity map. Lazy-loaded
+ * (Three.js is heavy) and framed automatically from the cloud bounds. */
+export function PointCloudView({ positions, colors }: PointCloudViewProps) {
+  const theme = useThemeColors();
+  const frame = useMemo(() => computeFrame(positions), [positions]);
+
+  return (
+    // Remount on a new cloud so the auto-framed camera re-applies.
+    <Canvas
+      key={positions.length}
+      camera={{ position: frame.cameraPos, fov: 40, near: 0.001, far: 100 }}
+      gl={{ antialias: true }}
+      style={{ background: theme.background }}
+    >
+      <points>
+        <bufferGeometry>
+          <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+          <bufferAttribute attach="attributes-color" args={[colors, 3]} />
+        </bufferGeometry>
+        <pointsMaterial size={2} sizeAttenuation={false} vertexColors />
+      </points>
+      {/* Reference-camera frame gizmo at the origin. */}
+      <axesHelper args={[frame.radius * 0.4]} />
+      <OrbitControls
+        target={frame.target}
+        makeDefault
+        enableDamping
+        dampingFactor={0.08}
+        minDistance={frame.radius * 0.1}
+        maxDistance={frame.radius * 30}
+      />
+    </Canvas>
+  );
+}
+
+interface Frame {
+  target: [number, number, number];
+  cameraPos: [number, number, number];
+  radius: number;
+}
+
+/** Centroid + bounding radius → an OrbitControls target and a camera placed on
+ * the reference-camera side (−z) so the surface faces the viewer. */
+function computeFrame(positions: Float32Array): Frame {
+  const n = Math.max(positions.length / 3, 1);
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  for (let i = 0; i < positions.length; i += 3) {
+    cx += positions[i];
+    cy += positions[i + 1];
+    cz += positions[i + 2];
+  }
+  cx /= n;
+  cy /= n;
+  cz /= n;
+
+  let r = 1e-3;
+  for (let i = 0; i < positions.length; i += 3) {
+    const dx = positions[i] - cx;
+    const dy = positions[i + 1] - cy;
+    const dz = positions[i + 2] - cz;
+    r = Math.max(r, Math.hypot(dx, dy, dz));
+  }
+
+  const d = r * 2.6;
+  const len = Math.hypot(0.4, -0.5, -1);
+  const dir: [number, number, number] = [0.4 / len, -0.5 / len, -1 / len];
+  return {
+    target: [cx, cy, cz],
+    cameraPos: [cx + dir[0] * d, cy + dir[1] * d, cz + dir[2] * d],
+    radius: r,
+  };
+}

--- a/app/src/workspaces/DepthWorkspace/index.tsx
+++ b/app/src/workspaces/DepthWorkspace/index.tsx
@@ -1,7 +1,19 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useMemo, useState } from "react";
+import { lazy, Suspense, useMemo, useState } from "react";
 import { PoseStepper } from "../../components/PoseStepper";
 import { useStore } from "../../store";
+
+// Three.js is heavy (~900 KB); only pull it in when the 3D view is opened.
+const PointCloudView = lazy(() =>
+  import("./PointCloudView").then((m) => ({ default: m.PointCloudView })),
+);
+
+/** A reprojected 3D point cloud (flat position/colour arrays). */
+interface PointCloud {
+  positions: number[];
+  colors: number[];
+  count: number;
+}
 
 /** Result of the `compute_disparity` Tauri command (camelCase, matching the
  * Rust `#[serde(rename_all = "camelCase")]` struct). All images are
@@ -10,6 +22,8 @@ interface DisparityResult {
   rectifiedPairPng: string;
   disparityPng: string;
   overlayPng: string;
+  depthPng: string;
+  pointCloud: PointCloud;
   width: number;
   height: number;
   density: number;
@@ -21,7 +35,7 @@ interface DisparityResult {
   semiGlobal: boolean;
 }
 
-type ViewMode = "rectified" | "disparity" | "overlay";
+type ViewMode = "rectified" | "disparity" | "overlay" | "depth" | "3d";
 
 // Matching is done at reduced resolution to keep the disparity search (and the
 // dev-build solve time) tractable; rebuild in release for full resolution.
@@ -32,6 +46,8 @@ const VIEW_LABEL: Record<ViewMode, string> = {
   rectified: "rectified pair",
   disparity: "disparity",
   overlay: "overlay",
+  depth: "depth",
+  "3d": "3D cloud",
 };
 
 /** Dense stereo / depth workspace: rectify a synchronized pair and dense-match
@@ -61,6 +77,16 @@ export function DepthWorkspace() {
   const frameB = useMemo(
     () => frames.find((f) => f.pose === selectedPose && f.camera === cameraB) ?? null,
     [frames, selectedPose, cameraB],
+  );
+  const cloud = useMemo(
+    () =>
+      result
+        ? {
+            positions: new Float32Array(result.pointCloud.positions),
+            colors: new Float32Array(result.pointCloud.colors),
+          }
+        : null,
+    [result],
   );
 
   if (!data || !kind) {
@@ -103,7 +129,11 @@ export function DepthWorkspace() {
         ? result.disparityPng
         : viewMode === "overlay"
           ? result.overlayPng
-          : result.rectifiedPairPng;
+          : viewMode === "depth"
+            ? result.depthPng
+            : viewMode === "rectified"
+              ? result.rectifiedPairPng
+              : null; // "3d" is rendered as WebGL below
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-2.5">
@@ -144,21 +174,27 @@ export function DepthWorkspace() {
         </div>
       )}
 
-      <div className="grid min-h-0 flex-1 place-items-center overflow-hidden rounded-md bg-bg-soft p-2">
-        {imgSrc ? (
+      <div className="relative grid min-h-0 flex-1 place-items-center overflow-hidden rounded-md bg-bg-soft">
+        {viewMode === "3d" && cloud ? (
+          <Suspense fallback={<Hint>Loading 3D…</Hint>}>
+            <div className="absolute inset-0">
+              <PointCloudView positions={cloud.positions} colors={cloud.colors} />
+            </div>
+          </Suspense>
+        ) : imgSrc ? (
           <img
             src={imgSrc}
             alt={VIEW_LABEL[viewMode]}
-            className="max-h-full max-w-full object-contain [image-rendering:pixelated]"
+            className="max-h-full max-w-full object-contain p-2 [image-rendering:pixelated]"
           />
         ) : (
-          <p className="max-w-[26rem] text-center text-[12px] text-muted-foreground">
+          <Hint>
             {cameraA === cameraB
               ? "Pick two different cameras (left ≠ right)."
               : frameA && frameB
                 ? "Press “Compute disparity” to rectify and dense-match this pair."
                 : "No image pair for this pose / camera selection."}
-          </p>
+          </Hint>
         )}
       </div>
 
@@ -169,6 +205,7 @@ export function DepthWorkspace() {
           <Stat label="disparity" value={`${result.dispMin.toFixed(1)}–${result.dispMax.toFixed(1)} px`} />
           <Stat label="planarity RMS" value={`${result.planeRms.toFixed(2)} px`} />
           <Stat label="plane inliers" value={`${result.planeInliers}`} />
+          <Stat label="cloud points" value={`${result.pointCloud.count}`} />
           <Stat label="baseline" value={`${(result.baselineM * 1000).toFixed(0)} mm`} />
           <Stat label="match size" value={`${result.width}×${result.height}`} />
         </div>
@@ -182,6 +219,12 @@ function Stat({ label, value }: { label: string; value: string }) {
     <span>
       {label} <span className="text-foreground tabular-nums">{value}</span>
     </span>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="max-w-[26rem] text-center text-[12px] text-muted-foreground">{children}</p>
   );
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -325,12 +325,13 @@ dense matcher, no full SfM.
   94% density at 0.18 px RMS on synthetic GT; on the real `data/stereo` rig SGM
   doubles board coverage (21%→49%) at 0.44–0.74 px board-planarity RMS (visual-
   evidence demos under `target/fixtures/`). Remaining: the OpenCV SGBM baseline.
-- **C-UI** MVG visualizations layered into the Tauri app (point clouds, depth maps,
-  rectified pairs). **First slice landed 2026-06-21:** a **Depth (dense stereo)
-  workspace** — server-side `compute_disparity` Tauri command (rectify → match →
-  colormap, block or SGM) over a rig export's stereo pair, with rectified-pair /
-  disparity / overlay views + a metrics strip. Remaining: point clouds from
-  triangulation, depth-from-disparity reprojection.
+- **C-UI** MVG visualizations layered into the Tauri app. **Landed 2026-06-21:** a
+  **Depth (dense stereo) workspace** — server-side `compute_disparity` Tauri command
+  (rectify → match → colormap, block or SGM) over a rig export's stereo pair, with
+  **rectified-pair / disparity / overlay / depth / 3D-point-cloud** views + a metrics
+  strip. The command reprojects the disparity to metric depth + a coloured 3D point
+  cloud (`Z = f·B/d`); the cloud renders in a lazy-loaded React-Three-Fiber view.
+  Remaining (future): multi-pose cloud fusion, textured-mesh export.
 
 ### Track D — Earn v1.0 (continuous ratchet)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -410,7 +410,20 @@ Systemic causes:
   metrics strip) + `/depth` route + rail nav. End-to-end Rust test on the
   committed `data/stereo` rig (board recovered, valid PNGs); `bun run build` +
   18 vitest tests green; app `cargo fmt`/clippy clean. Matches at downscale 4 for
-  dev responsiveness. Remaining C-UI: point clouds (triangulation), depth maps.
+  dev responsiveness.
+
+- [x] C-UI-POINTCLOUD - **Depth-from-disparity + 3D point cloud** in the Depth
+  workspace. **Done 2026-06-21.** `compute_disparity` now reprojects the disparity
+  through the rectified pinhole (`Z = f·B/d`, `X=(x−cx)·Z/fx`, `Y=(y−cy)·Z/fy`) to a
+  metric **depth colormap** (`depthPng`) and a grid-subsampled coloured **3D point
+  cloud** (`pointCloud {positions, colors, count}`, ≤ 60k points, grayscale from the
+  rectified left image). The workspace gains **depth** and **3D** view modes; the 3D
+  cloud renders in a new lazy-loaded React-Three-Fiber `PointCloudView` (auto-framed
+  `<points>` + OrbitControls, reusing `Viewer3DWorkspace/useThemeColors`), so
+  Three.js stays code-split out of the default bundle (main chunk 1203 → 469 kB).
+  Rust test extended (cloud count / array shape / mean reprojected depth ≈ board Z);
+  depth colormap visually verified on the committed rig. Closes the implementable
+  C-UI remainder; the OpenCV SGBM baseline (C5) stays env-blocked.
 
 ## D — Earn v1.0
 


### PR DESCRIPTION
## What

Completes the implementable **C-UI** remainder: the Depth workspace now reprojects the disparity map to **metric depth** and an interactive **3D point cloud**. (The only thing left after this is the env-blocked OpenCV SGBM baseline.)

## Backend — `app/src-tauri/src/disparity.rs`

`compute_disparity` reprojects each valid disparity through the rectified pinhole — `Z = f·B/d`, `X = (x−cx)·Z/fx`, `Y = (y−cy)·Z/fy` — into:
- a **metric depth colormap** (`depthPng`, jet over depth), and
- a grid-subsampled, grayscale-coloured **3D point cloud** (`pointCloud {positions, colors, count}`, ≤ 60k points).

## Frontend — `DepthWorkspace`

New **depth** and **3D** view modes. The 3D cloud renders in a new **lazy-loaded** React-Three-Fiber `PointCloudView` (auto-framed `<points>` + `OrbitControls`, reusing `Viewer3DWorkspace/useThemeColors`), so three.js stays code-split out of the default bundle — **main chunk 1203 → 469 kB**. Added a "cloud points" stat.

## Verification

- Rust end-to-end test extended: cloud count > 1000, position/colour array shapes consistent, **mean reprojected depth ≈ board Z (~0.5 m)**.
- Depth colormap visually verified on the committed `data/stereo` rig (board fills as a uniform near-depth region; background scatters — geometry is correct).
- `bun run build` (tsc + vite) green; **18 vitest** tests pass; app `cargo fmt` + `clippy` clean.

## Notes

The 3D point-cloud **render** itself isn't screenshot-verified (no headless Tauri GUI here) — the cloud *data* and depth reprojection are verified by the test + the depth colormap, and the R3F `<points>` setup mirrors the existing `Viewer3DWorkspace` patterns. Worth a `bun run tauri dev` spot-check of the 3D view before merge.

## Track status

C-UI is now functionally complete; C5's only open item is the OpenCV SGBM baseline (needs system OpenCV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)