### PR TITLE
S1+S2: ADR 0023 DeviceSpec schema + spec-derived intrinsics seeds

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,44 @@ bun run build          # TS compile + Vite build (frontend only)
 bun run tauri build    # Bundle the desktop app
 ```
 
+## Engineering principles & critical review
+
+Hold every change to a high design bar, and actively keep this workspace
+from drifting back into undisciplined, copy-paste "agentic slop." Apply
+these principles by default — not only when explicitly asked:
+
+- **SOLID** — one responsibility per type/module; extend behavior through
+  the detector / refiner / orientation traits, not by editing parallel
+  match arms; depend on trait abstractions (`DenseDetector`, the refiner
+  traits), not concretions.
+- **DRY / single source of truth** — one canonical definition per concept.
+  Lower config to core params in exactly one place; never let a
+  threshold's or parameter's meaning be duplicated or diverge across
+  crates.
+- **KISS & YAGNI** — choose the simplest design that meets the actual
+  requirement; do not add config knobs, enum variants, or abstraction
+  layers for hypothetical future needs.
+- **Make illegal states unrepresentable** — push invariants into the type
+  system (enum-with-payload over a discriminator + parallel fields;
+  `Option` / newtypes over magic sentinels) so misuse fails to compile.
+- **Least astonishment & orthogonality** — APIs do what their names say;
+  keep independent concerns independent (orientation is a cross-cutting
+  stage, not a sub-mode of one detector).
+- **Minimal, honest public surface** — expose only what callers need; keep
+  diagnostics and internals out of the stable API (see *Public surface
+  hygiene*).
+
+**Be critical of every proposal — including the user's.** Treat a request
+as the start of a design discussion, not an instruction to implement
+verbatim. Before coding, review it against the principles above and the
+existing architecture; if it would introduce duplication, leak internals,
+add a dominated alternative, widen the public surface needlessly, or
+otherwise degrade the design, **say so and offer the cleaner alternative**
+rather than building it as-stated. When the better design needs a breaking
+change and the crate is pre-1.0, prefer the better design (see *Decisive
+cleanup*). Every change should leave the workspace's design and style
+better than it found them.
+
 ## Architecture
 
 6-crate workspace (~24k LoC Rust). See ADR 0006.

--- a/crates/vision-calibration-dataset/src/device_spec.rs
+++ b/crates/vision-calibration-dataset/src/device_spec.rs
@@ -1,0 +1,550 @@
+//! Device-specification sidecar (`spec.json`) types.
+//!
+//! [`DeviceSpec`] describes the *hardware* a dataset was captured with —
+//! lens focal lengths, sensor pixel pitch, Scheimpflug mount tilt, and the
+//! rig's nominal mechanical layout — as transcribed from datasheets and
+//! mechanical drawings. It is the structured source for the seeded
+//! initialization route (ADR 0022): derivation functions in the pipeline
+//! crate turn a `DeviceSpec` into the ADR 0011 manual-init seeds.
+//!
+//! Units are datasheet-natural and encoded in field names (`_mm`, `_um`,
+//! `_px`, `_deg`); unit conversion happens exactly once, in the derivation
+//! layer. Poses follow the ADR 0009 `frame_se3_frame` naming. See ADR 0023
+//! for the design rationale.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
+/// Conventional sidecar filename, next to the dataset manifest.
+pub const DEVICE_SPEC_FILENAME: &str = "spec.json";
+
+/// Current device-spec format version.
+pub const DEVICE_SPEC_VERSION: u32 = 1;
+
+fn default_device_spec_version() -> u32 {
+    DEVICE_SPEC_VERSION
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Top-level spec
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Top-level device specification. Describes the capture hardware, not the
+/// captured data (that is [`DatasetSpec`](crate::DatasetSpec)'s job).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct DeviceSpec {
+    /// Format-version sentinel. Always `1` for now; bumped on breaking
+    /// schema revisions.
+    #[serde(default = "default_device_spec_version")]
+    pub version: u32,
+
+    /// Per-camera hardware specifications. Non-empty; ids unique and
+    /// matching the dataset manifest's camera ids (e.g. `"cam0"`).
+    pub cameras: Vec<CameraDeviceSpec>,
+
+    /// Nominal rig mechanical layout. `None` for single-camera devices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rig: Option<RigLayoutSpec>,
+
+    /// Free-form provenance note (device model, drawing revision, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Datasheet values for one camera.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CameraDeviceSpec {
+    /// Stable camera identifier matching the dataset manifest
+    /// (`CameraSource::id`).
+    pub id: String,
+
+    /// Lens focal length in millimetres (datasheet value).
+    pub focal_mm: f64,
+
+    /// Sensor pixel pitch in micrometres (datasheet value).
+    pub pixel_pitch_um: f64,
+
+    /// `[width, height]` of the images actually calibrated, in pixels.
+    /// For tiled multi-camera sensors this is the tile size, not the
+    /// full sensor.
+    pub resolution_px: [u32; 2],
+
+    /// Nominal principal point in pixels. `None` defaults to the
+    /// resolution center at derivation time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_point_px: Option<[f64; 2]>,
+
+    /// Scheimpflug mount tilt. `None` means a frontal (untilted) sensor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheimpflug: Option<ScheimpflugMountSpec>,
+}
+
+/// Mechanically-set Scheimpflug sensor tilt, in degrees.
+///
+/// Maps onto `ScheimpflugParams { tilt_x, tilt_y }` (radians) at
+/// derivation time.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct ScheimpflugMountSpec {
+    /// Tilt about the sensor x axis, degrees.
+    #[serde(default)]
+    pub tilt_x_deg: f64,
+
+    /// Tilt about the sensor y axis, degrees.
+    #[serde(default)]
+    pub tilt_y_deg: f64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rig mechanical layout
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Nominal rig mechanical layout from the drawing: camera mounts, the
+/// hand-eye mounting, and laser-plane nominals.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct RigLayoutSpec {
+    /// Nominal camera mount poses, keyed by camera id. Every id must
+    /// exist in [`DeviceSpec::cameras`]; cameras without a known mount
+    /// may be omitted.
+    pub cameras: Vec<CameraMountSpec>,
+
+    /// How the rig relates to the robot. `None` when the dataset has no
+    /// robot (pure intrinsics/extrinsics).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handeye: Option<HandeyeMountSpec>,
+
+    /// Nominal laser planes, one per camera-laser pair.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub laser_planes: Option<Vec<LaserPlaneSpec>>,
+}
+
+/// Nominal mount pose of one camera in the rig frame.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CameraMountSpec {
+    /// Camera id, matching [`DeviceSpec::cameras`].
+    pub id: String,
+
+    /// Camera pose in the rig frame (`T_R_C` — maps camera-frame points
+    /// into the rig frame). This is what a mechanical drawing states;
+    /// derivation inverts it into the `cam_se3_rig` the manual-init
+    /// surface expects.
+    pub rig_se3_cam: NominalPoseSpec,
+}
+
+/// How the rig is mounted relative to the robot. The tag fixes the frame
+/// meaning of the nominal pose, so the two hand-eye modes cannot be
+/// confused.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "mode")]
+pub enum HandeyeMountSpec {
+    /// Rig mounted on the gripper: the nominal is `gripper_se3_rig`
+    /// (`T_G_R`).
+    EyeInHand {
+        /// Rig pose in the gripper frame.
+        gripper_se3_rig: NominalPoseSpec,
+    },
+    /// Rig fixed in the workcell, target on the gripper: the nominal is
+    /// `rig_se3_base` (`T_R_B`).
+    EyeToHand {
+        /// Robot-base pose in the rig frame.
+        rig_se3_base: NominalPoseSpec,
+    },
+}
+
+/// Human-friendly nominal SE(3) pose: fixed-axes XYZ roll-pitch-yaw in
+/// degrees (`R = Rz(yaw)·Ry(pitch)·Rx(roll)`, nalgebra
+/// `from_euler_angles` convention) plus a translation in millimetres.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct NominalPoseSpec {
+    /// `[roll, pitch, yaw]` in degrees, fixed-axes XYZ.
+    #[serde(default)]
+    pub rpy_deg: [f64; 3],
+
+    /// Translation in millimetres.
+    #[serde(default)]
+    pub translation_mm: [f64; 3],
+}
+
+/// Nominal laser plane `{p : n·p = d}` in the **rig** frame, keyed to its
+/// paired camera.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct LaserPlaneSpec {
+    /// The camera this laser is paired with, matching
+    /// [`DeviceSpec::cameras`].
+    pub camera_id: String,
+
+    /// Unit plane normal in the rig frame.
+    pub normal: [f64; 3],
+
+    /// Signed plane distance `d` in millimetres.
+    pub distance_mm: f64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errors + validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Loading/validation failures for [`DeviceSpec`].
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceSpecError {
+    /// The sidecar file could not be read.
+    #[error("failed to read device spec: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The sidecar file is not valid `DeviceSpec` JSON.
+    #[error("failed to parse device spec JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The file declares a newer format version than this build supports.
+    #[error("unsupported device-spec version {got} (max supported {max})")]
+    UnsupportedVersion {
+        /// Version found in the file.
+        got: u32,
+        /// Highest version this build understands.
+        max: u32,
+    },
+
+    /// `cameras` is empty.
+    #[error("device spec has no cameras")]
+    NoCameras,
+
+    /// Two cameras share an id.
+    #[error("duplicate camera id `{id}`")]
+    DuplicateCameraId {
+        /// The offending id.
+        id: String,
+    },
+
+    /// A camera datasheet value is not strictly positive.
+    #[error("camera `{id}`: {field} must be positive")]
+    NonPositiveCameraField {
+        /// The offending camera id.
+        id: String,
+        /// The offending field name.
+        field: &'static str,
+    },
+
+    /// The rig layout references a camera id absent from `cameras`.
+    #[error("rig layout references unknown camera id `{id}`")]
+    UnknownRigCameraId {
+        /// The unmatched id.
+        id: String,
+    },
+
+    /// Two rig mounts reference the same camera.
+    #[error("duplicate rig mount for camera id `{id}`")]
+    DuplicateMountId {
+        /// The offending id.
+        id: String,
+    },
+
+    /// A laser-plane normal is not unit length.
+    #[error("laser plane for camera `{camera_id}`: normal must be unit length (norm {norm})")]
+    NonUnitLaserNormal {
+        /// The paired camera id.
+        camera_id: String,
+        /// The actual norm found.
+        norm: f64,
+    },
+}
+
+impl DeviceSpec {
+    /// Load and validate a device spec from a JSON sidecar file.
+    pub fn from_path(path: &Path) -> Result<Self, DeviceSpecError> {
+        let raw = std::fs::read_to_string(path)?;
+        let spec: Self = serde_json::from_str(&raw)?;
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    /// Look up a camera spec by id.
+    pub fn camera(&self, id: &str) -> Option<&CameraDeviceSpec> {
+        self.cameras.iter().find(|c| c.id == id)
+    }
+
+    /// Structural validation: fail-fast on transcription errors
+    /// (ADR 0019). Called by [`DeviceSpec::from_path`].
+    pub fn validate(&self) -> Result<(), DeviceSpecError> {
+        if self.version > DEVICE_SPEC_VERSION {
+            return Err(DeviceSpecError::UnsupportedVersion {
+                got: self.version,
+                max: DEVICE_SPEC_VERSION,
+            });
+        }
+        if self.cameras.is_empty() {
+            return Err(DeviceSpecError::NoCameras);
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for cam in &self.cameras {
+            if !seen.insert(cam.id.as_str()) {
+                return Err(DeviceSpecError::DuplicateCameraId { id: cam.id.clone() });
+            }
+            let positive: [(&'static str, f64); 4] = [
+                ("focal_mm", cam.focal_mm),
+                ("pixel_pitch_um", cam.pixel_pitch_um),
+                ("resolution_px[0]", f64::from(cam.resolution_px[0])),
+                ("resolution_px[1]", f64::from(cam.resolution_px[1])),
+            ];
+            for (field, value) in positive {
+                if !value.is_finite() || value <= 0.0 {
+                    return Err(DeviceSpecError::NonPositiveCameraField {
+                        id: cam.id.clone(),
+                        field,
+                    });
+                }
+            }
+        }
+        if let Some(rig) = &self.rig {
+            let mut mounted = std::collections::BTreeSet::new();
+            for mount in &rig.cameras {
+                if self.camera(&mount.id).is_none() {
+                    return Err(DeviceSpecError::UnknownRigCameraId {
+                        id: mount.id.clone(),
+                    });
+                }
+                if !mounted.insert(mount.id.as_str()) {
+                    return Err(DeviceSpecError::DuplicateMountId {
+                        id: mount.id.clone(),
+                    });
+                }
+            }
+            for plane in rig.laser_planes.as_deref().unwrap_or_default() {
+                if self.camera(&plane.camera_id).is_none() {
+                    return Err(DeviceSpecError::UnknownRigCameraId {
+                        id: plane.camera_id.clone(),
+                    });
+                }
+                let norm = plane.normal.iter().map(|c| c * c).sum::<f64>().sqrt();
+                if (norm - 1.0).abs() > 1e-6 {
+                    return Err(DeviceSpecError::NonUnitLaserNormal {
+                        camera_id: plane.camera_id.clone(),
+                        norm,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn camera(id: &str) -> CameraDeviceSpec {
+        CameraDeviceSpec {
+            id: id.to_string(),
+            focal_mm: 8.0,
+            pixel_pitch_um: 7.0,
+            resolution_px: [720, 540],
+            principal_point_px: None,
+            scheimpflug: Some(ScheimpflugMountSpec {
+                tilt_x_deg: -5.0,
+                tilt_y_deg: 0.0,
+            }),
+        }
+    }
+
+    fn full_spec() -> DeviceSpec {
+        DeviceSpec {
+            version: DEVICE_SPEC_VERSION,
+            cameras: vec![camera("cam0"), camera("cam1")],
+            rig: Some(RigLayoutSpec {
+                cameras: vec![CameraMountSpec {
+                    id: "cam0".to_string(),
+                    rig_se3_cam: NominalPoseSpec {
+                        rpy_deg: [0.0, 30.0, 0.0],
+                        translation_mm: [100.0, 0.0, -50.0],
+                    },
+                }],
+                handeye: Some(HandeyeMountSpec::EyeToHand {
+                    rig_se3_base: NominalPoseSpec {
+                        rpy_deg: [0.0, 0.0, 90.0],
+                        translation_mm: [0.0, 250.0, 0.0],
+                    },
+                }),
+                laser_planes: Some(vec![LaserPlaneSpec {
+                    camera_id: "cam1".to_string(),
+                    normal: [0.0, 0.0, 1.0],
+                    distance_mm: 120.0,
+                }]),
+            }),
+            description: Some("test rig".to_string()),
+        }
+    }
+
+    #[test]
+    fn json_roundtrip_full() {
+        let spec = full_spec();
+        let json = serde_json::to_string_pretty(&spec).unwrap();
+        assert!(json.contains("\"focal_mm\""));
+        assert!(json.contains("\"pixel_pitch_um\""));
+        assert!(json.contains("\"eye_to_hand\""));
+        assert!(json.contains("\"rig_se3_base\""));
+        let back: DeviceSpec = serde_json::from_str(&json).unwrap();
+        back.validate().unwrap();
+        assert_eq!(back.cameras.len(), 2);
+        let rig = back.rig.unwrap();
+        assert_eq!(rig.cameras[0].rig_se3_cam.rpy_deg, [0.0, 30.0, 0.0]);
+        match rig.handeye.unwrap() {
+            HandeyeMountSpec::EyeToHand { rig_se3_base } => {
+                assert_eq!(rig_se3_base.translation_mm, [0.0, 250.0, 0.0]);
+            }
+            other => panic!("wrong handeye mode: {other:?}"),
+        }
+        assert_eq!(rig.laser_planes.unwrap()[0].distance_mm, 120.0);
+    }
+
+    #[test]
+    fn json_roundtrip_minimal_defaults() {
+        let json = r#"{
+            "cameras": [{
+                "id": "cam0",
+                "focal_mm": 16.0,
+                "pixel_pitch_um": 4.8,
+                "resolution_px": [1920, 1200]
+            }]
+        }"#;
+        let spec: DeviceSpec = serde_json::from_str(json).unwrap();
+        spec.validate().unwrap();
+        assert_eq!(spec.version, DEVICE_SPEC_VERSION);
+        assert!(spec.cameras[0].principal_point_px.is_none());
+        assert!(spec.cameras[0].scheimpflug.is_none());
+        assert!(spec.rig.is_none());
+        let json2 = serde_json::to_string(&spec).unwrap();
+        assert!(!json2.contains("principal_point_px"));
+        assert!(!json2.contains("\"rig\""));
+    }
+
+    #[test]
+    fn unknown_field_rejected() {
+        let json = r#"{
+            "cameras": [{
+                "id": "cam0",
+                "focal_mm": 16.0,
+                "pixel_pitch_mm": 0.0048,
+                "resolution_px": [1920, 1200]
+            }]
+        }"#;
+        // `pixel_pitch_mm` is a unit typo — must not parse.
+        assert!(serde_json::from_str::<DeviceSpec>(json).is_err());
+    }
+
+    #[test]
+    fn version_gate() {
+        let mut spec = full_spec();
+        spec.version = DEVICE_SPEC_VERSION + 1;
+        assert!(matches!(
+            spec.validate(),
+            Err(DeviceSpecError::UnsupportedVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn validation_failure_modes() {
+        let empty = DeviceSpec {
+            version: DEVICE_SPEC_VERSION,
+            cameras: vec![],
+            rig: None,
+            description: None,
+        };
+        assert!(matches!(empty.validate(), Err(DeviceSpecError::NoCameras)));
+
+        let mut dup = full_spec();
+        dup.cameras[1].id = "cam0".to_string();
+        assert!(matches!(
+            dup.validate(),
+            Err(DeviceSpecError::DuplicateCameraId { .. })
+        ));
+
+        let mut bad_focal = full_spec();
+        bad_focal.cameras[0].focal_mm = 0.0;
+        assert!(matches!(
+            bad_focal.validate(),
+            Err(DeviceSpecError::NonPositiveCameraField {
+                field: "focal_mm",
+                ..
+            })
+        ));
+
+        let mut bad_pitch = full_spec();
+        bad_pitch.cameras[0].pixel_pitch_um = -4.8;
+        assert!(matches!(
+            bad_pitch.validate(),
+            Err(DeviceSpecError::NonPositiveCameraField {
+                field: "pixel_pitch_um",
+                ..
+            })
+        ));
+
+        let mut bad_res = full_spec();
+        bad_res.cameras[0].resolution_px = [0, 540];
+        assert!(matches!(
+            bad_res.validate(),
+            Err(DeviceSpecError::NonPositiveCameraField { .. })
+        ));
+
+        let mut ghost_mount = full_spec();
+        ghost_mount.rig.as_mut().unwrap().cameras[0].id = "cam9".to_string();
+        assert!(matches!(
+            ghost_mount.validate(),
+            Err(DeviceSpecError::UnknownRigCameraId { .. })
+        ));
+
+        let mut dup_mount = full_spec();
+        let mount = dup_mount.rig.as_ref().unwrap().cameras[0].clone();
+        dup_mount.rig.as_mut().unwrap().cameras.push(mount);
+        assert!(matches!(
+            dup_mount.validate(),
+            Err(DeviceSpecError::DuplicateMountId { .. })
+        ));
+
+        let mut bad_normal = full_spec();
+        bad_normal
+            .rig
+            .as_mut()
+            .unwrap()
+            .laser_planes
+            .as_mut()
+            .unwrap()[0]
+            .normal = [0.0, 0.0, 2.0];
+        assert!(matches!(
+            bad_normal.validate(),
+            Err(DeviceSpecError::NonUnitLaserNormal { .. })
+        ));
+    }
+
+    #[test]
+    fn from_path_loads_and_validates() {
+        let dir = std::env::temp_dir().join(format!("device-spec-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(DEVICE_SPEC_FILENAME);
+        std::fs::write(&path, serde_json::to_string(&full_spec()).unwrap()).unwrap();
+        let spec = DeviceSpec::from_path(&path).unwrap();
+        assert_eq!(spec.cameras.len(), 2);
+        assert!(spec.camera("cam1").is_some());
+        assert!(spec.camera("cam9").is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/vision-calibration-dataset/src/lib.rs
+++ b/crates/vision-calibration-dataset/src/lib.rs
@@ -26,10 +26,16 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+mod device_spec;
 mod sniff;
 mod spec;
 mod validator;
 
+pub use device_spec::{
+    CameraDeviceSpec, CameraMountSpec, DEVICE_SPEC_FILENAME, DEVICE_SPEC_VERSION, DeviceSpec,
+    DeviceSpecError, HandeyeMountSpec, LaserPlaneSpec, NominalPoseSpec, RigLayoutSpec,
+    ScheimpflugMountSpec,
+};
 pub use sniff::{SniffError, sniff_folder};
 pub use spec::{
     CameraSource, ChessCornersDetectorSpec, ChessThresholdMode, DatasetSpec, DetectorSpec,

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ref_intrinsics.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ref_intrinsics.rs
@@ -4,11 +4,11 @@
 //!
 //! Companion to `rtv3d_ref_rig` (full from-scratch rig) and `rtv3d_ref_reproj`
 //! (frozen-intrinsics parity). This harness exercises the recommended path for
-//! Scheimpflug intrinsics: the engineer supplies a coarse prior they actually
-//! have — a nominal focal (from the lens spec) and the nominal sensor tilt (the
-//! Scheimpflug mount angle, ≈−5°) — and bundle adjustment refines it. Nothing
-//! from `artifacts.json` is seeded; the oracle is read only for the final
-//! comparison.
+//! Scheimpflug intrinsics: the coarse prior comes from the dataset's device
+//! spec (`spec.json`, ADR 0023) — lens focal + pixel pitch → `fx = fy`, and
+//! the Scheimpflug mount angle (≈−5°) → the tilt seed — and bundle adjustment
+//! refines it. Nothing from `artifacts.json` is seeded; the oracle is read
+//! only for the final comparison.
 //!
 //! Why not from scratch? On this data (strong radial distortion, k1≈−0.43, plus
 //! a ≈−5° tilt) Zhang-from-scratch underestimates the focal and the solve settles
@@ -25,18 +25,18 @@
 //! rtv3d_ref_intrinsics`
 //!
 //! Env:
-//! - `RTV3D_REF_DATA_DIR` (default `privatedata/rtv3d_ref`).
-//! - `RTV3D_REF_FOCAL` — coarse nominal focal seed in px (default `1150`). Probe
-//!   the tolerance by varying it; the oracle focals are ≈1150–1166.
+//! - `RTV3D_REF_DATA_DIR` (default `privatedata/rtv3d_ref`). Must contain a
+//!   `spec.json` device spec (gitignored, like the rest of `privatedata/`).
 //! - `RTV3D_REF_MAXITERS` (default `120`).
 
 use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
 use std::time::Instant;
 
+use vision_calibration::device_seed::{DEVICE_SPEC_FILENAME, DeviceSpec, scheimpflug_seed};
 use vision_calibration::scheimpflug_intrinsics::{
     ScheimpflugFixMask, ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsProblem,
-    ScheimpflugManualInit, step_init_with_seed, step_optimize,
+    step_init_with_seed, step_optimize,
 };
 use vision_calibration::session::CalibrationSession;
 use vision_calibration_core::{
@@ -54,13 +54,6 @@ const BOARD_ROWS: u32 = 130;
 const BOARD_COLS: u32 = 130;
 const CELL_SIZE_MM: f64 = 5.0;
 const GATE_PX: f64 = 0.5;
-/// Each pose strip is 4320×540 → six 720×540 tiles; the nominal principal point
-/// is the tile center.
-const TILE_CX: f64 = 360.0;
-const TILE_CY: f64 = 270.0;
-/// Nominal Scheimpflug mount tilt (≈−5°): a known mechanical spec, used as the
-/// seed `tilt_x`. The actual per-camera tilt is recovered by the solve.
-const NOMINAL_TILT_X: f64 = -0.087;
 
 /// Recovered + reference summary for one camera.
 struct CamResult {
@@ -76,18 +69,31 @@ fn main() -> Result<()> {
     let data_dir = PathBuf::from(
         std::env::var("RTV3D_REF_DATA_DIR").unwrap_or_else(|_| "privatedata/rtv3d_ref".to_string()),
     );
-    let focal_seed: f64 = std::env::var("RTV3D_REF_FOCAL")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1150.0);
     let max_iters: usize = std::env::var("RTV3D_REF_MAXITERS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(120);
     println!("data dir = {}", data_dir.display());
-    println!(
-        "coarse seed: fx=fy={focal_seed:.0}, pp=({TILE_CX:.0},{TILE_CY:.0}), tilt_x={NOMINAL_TILT_X:.3} rad, distortion=0"
-    );
+
+    // Device spec (ADR 0023): lens focal + pixel pitch + mount tilt → seed.
+    let spec_path = data_dir.join(DEVICE_SPEC_FILENAME);
+    let spec = DeviceSpec::from_path(&spec_path)
+        .with_context(|| format!("load device spec {}", spec_path.display()))?;
+    if spec.cameras.len() != NUM_CAMERAS {
+        return Err(anyhow!(
+            "device spec has {} cameras, expected {NUM_CAMERAS}",
+            spec.cameras.len()
+        ));
+    }
+    {
+        let seed0 = scheimpflug_seed(&spec, "cam0")?;
+        let k = seed0.intrinsics.expect("spec-derived intrinsics");
+        let s = seed0.sensor.expect("spec-derived sensor");
+        println!(
+            "spec seed (cam0): fx=fy={:.1}, pp=({:.0},{:.0}), tilt_x={:.4} rad, distortion=0",
+            k.fx, k.cx, k.cy, s.tilt_x
+        );
+    }
 
     let art =
         load_ref_artifacts(&data_dir.join("artifacts.json")).context("load oracle artifacts")?;
@@ -144,21 +150,12 @@ fn main() -> Result<()> {
         config.robust_loss = RobustLoss::Huber { scale: 1.0 };
         session.set_config(config)?;
 
-        // Coarse "datasheet" prior: nominal focal, principal point at tile center,
-        // nominal mount tilt. Distortion + poses auto. The seeded tilt is trusted
-        // directly (ADR 0022).
-        let mut seed = ScheimpflugManualInit::default();
-        seed.intrinsics = Some(FxFyCxCySkew {
-            fx: focal_seed,
-            fy: focal_seed,
-            cx: TILE_CX,
-            cy: TILE_CY,
-            skew: 0.0,
-        });
-        seed.sensor = Some(ScheimpflugParams {
-            tilt_x: NOMINAL_TILT_X,
-            tilt_y: 0.0,
-        });
+        // Coarse "datasheet" prior derived from the device spec (ADR 0023):
+        // fx = fy from lens focal / pixel pitch, principal point at the tile
+        // center, nominal mount tilt. Distortion + poses auto. The seeded
+        // tilt is trusted directly (ADR 0022).
+        let seed = scheimpflug_seed(&spec, &format!("cam{c}"))
+            .with_context(|| format!("camera {c}: derive seed from device spec"))?;
         step_init_with_seed(&mut session, seed, None)
             .with_context(|| format!("camera {c}: seeded init"))?;
 

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_intrinsics.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_intrinsics.rs
@@ -15,8 +15,10 @@
 //! Why seeded, not from scratch? On Scheimpflug data (strong radial distortion
 //! plus a several-degree mount tilt) Zhang-from-scratch underestimates the focal
 //! and settles in a wrong tilt/focal basin (ADR 0022). A coarse focal + tilt
-//! seed removes that fragility. The nominal focal for this rig is **not known a
-//! priori** — sweep `RTV3D_RINGGRID_FOCAL` to find the basin.
+//! seed removes that fragility. The seed comes from the dataset's device spec
+//! (`spec.json`, ADR 0023) — lens focal + pixel pitch → `fx = fy`, mount angle
+//! → tilt. (Historically the focal was found by an env-var sweep; the spec
+//! layer replaced it.)
 //!
 //! Run:
 //! `cargo run --release --manifest-path
@@ -24,9 +26,9 @@
 //! rtv3d_ringgrid_intrinsics`
 //!
 //! Env:
-//! - `RTV3D_RINGGRID_DATA_DIR` (default `privatedata/rtv3d_ringgrid`).
-//! - `RTV3D_RINGGRID_FOCAL` — coarse nominal focal seed in px (default `1150`).
-//! - `RTV3D_RINGGRID_TILT_X` — nominal mount tilt seed in rad (default `-0.087`).
+//! - `RTV3D_RINGGRID_DATA_DIR` (default `privatedata/rtv3d_ringgrid`). Must
+//!   contain a `spec.json` device spec (gitignored, like the rest of
+//!   `privatedata/`).
 //! - `RTV3D_RINGGRID_RING_WIDTH_MM` — coded-band width override (default: board
 //!   manifest value, else `1.152`). A decode-tuning knob.
 //! - `RTV3D_RINGGRID_MAXITERS` (default `120`).
@@ -39,9 +41,10 @@ use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
 use std::time::Instant;
 
+use vision_calibration::device_seed::{DEVICE_SPEC_FILENAME, DeviceSpec, scheimpflug_seed};
 use vision_calibration::scheimpflug_intrinsics::{
     ScheimpflugFixMask, ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsProblem,
-    ScheimpflugManualInit, step_init_with_seed, step_optimize,
+    step_init_with_seed, step_optimize,
 };
 use vision_calibration::session::CalibrationSession;
 use vision_calibration_core::{
@@ -56,12 +59,6 @@ use vision_calibration_optim::RobustLoss;
 
 const NUM_CAMERAS: usize = 6;
 const GATE_PX: f64 = 0.5;
-/// Each pose strip is 4320×540 → six 720×540 tiles; the nominal principal point
-/// is the tile center.
-const TILE_CX: f64 = 360.0;
-const TILE_CY: f64 = 270.0;
-/// Nominal Scheimpflug mount tilt (≈−5°), used as the seed `tilt_x`.
-const DEFAULT_TILT_X: f64 = -0.087;
 
 /// Recovered summary for one camera.
 struct CamResult {
@@ -85,13 +82,22 @@ fn main() -> Result<()> {
         std::env::var("RTV3D_RINGGRID_DATA_DIR")
             .unwrap_or_else(|_| "privatedata/rtv3d_ringgrid".to_string()),
     );
-    let focal_seed = env_f64("RTV3D_RINGGRID_FOCAL", 1150.0);
-    let tilt_x_seed = env_f64("RTV3D_RINGGRID_TILT_X", DEFAULT_TILT_X);
     let max_iters: usize = std::env::var("RTV3D_RINGGRID_MAXITERS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(120);
     let detect_only = std::env::var("RTV3D_RINGGRID_DETECT_ONLY").as_deref() == Ok("1");
+
+    // Device spec (ADR 0023): lens focal + pixel pitch + mount tilt → seed.
+    let spec_path = data_dir.join(DEVICE_SPEC_FILENAME);
+    let spec = DeviceSpec::from_path(&spec_path)
+        .with_context(|| format!("load device spec {}", spec_path.display()))?;
+    if spec.cameras.len() != NUM_CAMERAS {
+        return Err(anyhow!(
+            "device spec has {} cameras, expected {NUM_CAMERAS}",
+            spec.cameras.len()
+        ));
+    }
 
     let board: BoardRinggridSpec = load_ringgrid_board(&data_dir.join("board_ringgrid.json"))
         .context("load ring-grid board manifest")?;
@@ -107,9 +113,15 @@ fn main() -> Result<()> {
         board.marker_inner_radius_mm,
         ring_width_mm,
     );
-    println!(
-        "coarse seed: fx=fy={focal_seed:.0}, pp=({TILE_CX:.0},{TILE_CY:.0}), tilt_x={tilt_x_seed:.3} rad, distortion=0"
-    );
+    {
+        let seed0 = scheimpflug_seed(&spec, "cam0")?;
+        let k = seed0.intrinsics.expect("spec-derived intrinsics");
+        let s = seed0.sensor.expect("spec-derived sensor");
+        println!(
+            "spec seed (cam0): fx=fy={:.1}, pp=({:.0},{:.0}), tilt_x={:.4} rad, distortion=0",
+            k.fx, k.cx, k.cy, s.tilt_x
+        );
+    }
 
     let poses = load_poses(&data_dir.join("poses.json"))?;
     println!("loaded {} poses", poses.len());
@@ -170,18 +182,11 @@ fn main() -> Result<()> {
         config.robust_loss = RobustLoss::Huber { scale: 1.0 };
         session.set_config(config)?;
 
-        let mut seed = ScheimpflugManualInit::default();
-        seed.intrinsics = Some(FxFyCxCySkew {
-            fx: focal_seed,
-            fy: focal_seed,
-            cx: TILE_CX,
-            cy: TILE_CY,
-            skew: 0.0,
-        });
-        seed.sensor = Some(ScheimpflugParams {
-            tilt_x: tilt_x_seed,
-            tilt_y: 0.0,
-        });
+        // Spec-derived coarse prior (ADR 0023): fx = fy from lens focal /
+        // pixel pitch, principal point at the tile center, nominal mount
+        // tilt. Distortion + poses auto (ADR 0022).
+        let seed = scheimpflug_seed(&spec, &format!("cam{c}"))
+            .with_context(|| format!("camera {c}: derive seed from device spec"))?;
         step_init_with_seed(&mut session, seed, None)
             .with_context(|| format!("camera {c}: seeded init"))?;
         step_optimize(&mut session, None).with_context(|| format!("camera {c}: optimize"))?;
@@ -259,9 +264,9 @@ fn main() -> Result<()> {
             .join(", ");
         Err(anyhow!(
             "GATE FAIL: {solved} of {NUM_CAMERAS} cameras solved, {} exceed {GATE_PX} px ({list}); \
-             skipped (not enough views): {skipped:?}. Investigate focal prior \
-             (RTV3D_RINGGRID_FOCAL), detection density, or the detector tail — do not relax \
-             the gate.",
+             skipped (not enough views): {skipped:?}. Investigate the device spec's focal / \
+             pixel pitch / tilt (spec.json), detection density, or the detector tail — do not \
+             relax the gate.",
             failed.len()
         ))
     }

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_intrinsics.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_intrinsics.rs
@@ -88,17 +88,6 @@ fn main() -> Result<()> {
         .unwrap_or(120);
     let detect_only = std::env::var("RTV3D_RINGGRID_DETECT_ONLY").as_deref() == Ok("1");
 
-    // Device spec (ADR 0023): lens focal + pixel pitch + mount tilt → seed.
-    let spec_path = data_dir.join(DEVICE_SPEC_FILENAME);
-    let spec = DeviceSpec::from_path(&spec_path)
-        .with_context(|| format!("load device spec {}", spec_path.display()))?;
-    if spec.cameras.len() != NUM_CAMERAS {
-        return Err(anyhow!(
-            "device spec has {} cameras, expected {NUM_CAMERAS}",
-            spec.cameras.len()
-        ));
-    }
-
     let board: BoardRinggridSpec = load_ringgrid_board(&data_dir.join("board_ringgrid.json"))
         .context("load ring-grid board manifest")?;
     let ring_width_mm = env_f64("RTV3D_RINGGRID_RING_WIDTH_MM", board.ring_width_mm());
@@ -113,16 +102,6 @@ fn main() -> Result<()> {
         board.marker_inner_radius_mm,
         ring_width_mm,
     );
-    {
-        let seed0 = scheimpflug_seed(&spec, "cam0")?;
-        let k = seed0.intrinsics.expect("spec-derived intrinsics");
-        let s = seed0.sensor.expect("spec-derived sensor");
-        println!(
-            "spec seed (cam0): fx=fy={:.1}, pp=({:.0},{:.0}), tilt_x={:.4} rad, distortion=0",
-            k.fx, k.cx, k.cy, s.tilt_x
-        );
-    }
-
     let poses = load_poses(&data_dir.join("poses.json"))?;
     println!("loaded {} poses", poses.len());
 
@@ -152,6 +131,27 @@ fn main() -> Result<()> {
     if detect_only {
         println!("\nRTV3D_RINGGRID_DETECT_ONLY=1 → stopping after detection.");
         return Ok(());
+    }
+
+    // Device spec (ADR 0023): lens focal + pixel pitch + mount tilt → seed.
+    // Loaded only past the detect-only probe, which needs no spec.
+    let spec_path = data_dir.join(DEVICE_SPEC_FILENAME);
+    let spec = DeviceSpec::from_path(&spec_path)
+        .with_context(|| format!("load device spec {}", spec_path.display()))?;
+    if spec.cameras.len() != NUM_CAMERAS {
+        return Err(anyhow!(
+            "device spec has {} cameras, expected {NUM_CAMERAS}",
+            spec.cameras.len()
+        ));
+    }
+    {
+        let seed0 = scheimpflug_seed(&spec, "cam0")?;
+        let k = seed0.intrinsics.expect("spec-derived intrinsics");
+        let s = seed0.sensor.expect("spec-derived sensor");
+        println!(
+            "spec seed (cam0): fx=fy={:.1}, pp=({:.0},{:.0}), tilt_x={:.4} rad, distortion=0",
+            k.fx, k.cx, k.cy, s.tilt_x
+        );
     }
 
     // ── Per-camera seeded intrinsics calibration ─────────────────────────────

--- a/crates/vision-calibration-pipeline/src/device_seed.rs
+++ b/crates/vision-calibration-pipeline/src/device_seed.rs
@@ -4,14 +4,15 @@
 //! layout — onto the ADR 0011 manual-init structs consumed by
 //! `step_init_with_seed` and friends. All unit conversion between the
 //! datasheet-natural spec (`mm`, `µm`, degrees) and the internal
-//! representation (pixels, radians, millimetres) happens here and nowhere
+//! representation (pixels, radians, and **metres** for world-frame
+//! translations — the pipeline's world unit) happens here and nowhere
 //! else:
 //!
 //! - `fx = fy = focal_mm · 1000 / pixel_pitch_um`, principal point
 //!   defaulting to the resolution center, `skew = 0`;
 //! - mount tilt degrees → `ScheimpflugParams` radians;
 //! - `rig_se3_cam` mount poses → inverted into the `cam_se3_rig` (`T_C_R`)
-//!   the rig problems expect.
+//!   the rig problems expect, translations mm → m.
 //!
 //! The derivations are per-camera-id, never positional: the caller states
 //! the camera order it needs and mismatches surface as typed errors.
@@ -107,7 +108,8 @@ pub fn rig_intrinsics_seed(
 }
 
 /// Nominal `cam_se3_rig` (`T_C_R`) poses from the mechanical layout, in the
-/// caller's `camera_ids` order.
+/// caller's `camera_ids` order. Translations are converted to the
+/// pipeline's world unit (metres).
 ///
 /// This is deliberately *not* a `RigHandeyeRigManualInit`: ADR 0011 couples
 /// `cam_se3_rig` with the data-dependent per-view `rig_se3_target`
@@ -200,13 +202,16 @@ fn sensor_from_camera(cam: &CameraDeviceSpec) -> ScheimpflugParams {
     }
 }
 
+/// Spec translations are millimetres (drawing units); derived poses are in
+/// the pipeline's world unit, **metres** (target 3D points are built as
+/// `mm / 1000`, laser errors/plane distances are metres throughout).
 fn iso3_from_nominal(pose: &NominalPoseSpec) -> Iso3 {
     let [roll, pitch, yaw] = pose.rpy_deg.map(f64::to_radians);
     let rotation = nalgebra::UnitQuaternion::from_euler_angles(roll, pitch, yaw);
     let translation = nalgebra::Translation3::new(
-        pose.translation_mm[0],
-        pose.translation_mm[1],
-        pose.translation_mm[2],
+        pose.translation_mm[0] * 1e-3,
+        pose.translation_mm[1] * 1e-3,
+        pose.translation_mm[2] * 1e-3,
     );
     Iso3::from_parts(translation, rotation)
 }
@@ -339,15 +344,16 @@ mod tests {
 
     #[test]
     fn cam_se3_rig_is_inverted_mount() {
-        // Mount: Rz(90°), t = [100, 0, 0] (camera pose in rig frame).
-        // Inverse: R = Rz(−90°), t = −Rz(−90°)·[100,0,0] = [0, 100, 0].
+        // Mount: Rz(90°), t = [100, 0, 0] mm (camera pose in rig frame).
+        // Inverse: R = Rz(−90°), t = −Rz(−90°)·[100,0,0] mm = [0, 100, 0] mm
+        // = [0, 0.1, 0] in the pipeline's world unit (metres).
         let spec = rig_spec();
         let poses = nominal_cam_se3_rig(&spec, &["cam0", "cam1"]).unwrap();
         let t = poses[0].translation.vector;
-        assert!((t - nalgebra::Vector3::new(0.0, 100.0, 0.0)).norm() < 1e-9);
-        // Round-trip: inverse of the inverse is the mount pose.
+        assert!((t - nalgebra::Vector3::new(0.0, 0.1, 0.0)).norm() < 1e-12);
+        // Round-trip: inverse of the inverse is the mount pose (in metres).
         let back = poses[0].inverse();
-        assert!((back.translation.vector.x - 100.0).abs() < 1e-9);
+        assert!((back.translation.vector.x - 0.1).abs() < 1e-12);
         assert!(poses[1].translation.vector.norm() < 1e-12); // identity mount
 
         assert!(matches!(
@@ -375,7 +381,8 @@ mod tests {
         let spec = rig_spec();
         let seed = handeye_seed(&spec, HandEyeMode::EyeToHand).unwrap();
         let handeye = seed.handeye.unwrap();
-        assert!((handeye.translation.vector.y - 250.0).abs() < 1e-12);
+        // 250 mm in the spec → 0.25 m in the pipeline's world unit.
+        assert!((handeye.translation.vector.y - 0.25).abs() < 1e-12);
         assert!(seed.mode_target_pose.is_none());
 
         assert!(matches!(

--- a/crates/vision-calibration-pipeline/src/device_seed.rs
+++ b/crates/vision-calibration-pipeline/src/device_seed.rs
@@ -1,0 +1,393 @@
+//! Device-spec → manual-init seed derivation (ADR 0023).
+//!
+//! Maps a [`DeviceSpec`] — datasheet values plus the nominal mechanical
+//! layout — onto the ADR 0011 manual-init structs consumed by
+//! `step_init_with_seed` and friends. All unit conversion between the
+//! datasheet-natural spec (`mm`, `µm`, degrees) and the internal
+//! representation (pixels, radians, millimetres) happens here and nowhere
+//! else:
+//!
+//! - `fx = fy = focal_mm · 1000 / pixel_pitch_um`, principal point
+//!   defaulting to the resolution center, `skew = 0`;
+//! - mount tilt degrees → `ScheimpflugParams` radians;
+//! - `rig_se3_cam` mount poses → inverted into the `cam_se3_rig` (`T_C_R`)
+//!   the rig problems expect.
+//!
+//! The derivations are per-camera-id, never positional: the caller states
+//! the camera order it needs and mismatches surface as typed errors.
+
+use vision_calibration_core::{FxFyCxCySkew, Iso3, Real, ScheimpflugParams};
+use vision_calibration_optim::HandEyeMode;
+
+use crate::rig_handeye::{RigHandeyeHandeyeManualInit, RigHandeyeIntrinsicsManualInit};
+use crate::scheimpflug_intrinsics::ScheimpflugManualInit;
+
+// The schema types every consumer of this module needs, re-exported so the
+// facade can expose the full device-spec surface from one place.
+pub use vision_calibration_dataset::{
+    CameraDeviceSpec, CameraMountSpec, DEVICE_SPEC_FILENAME, DEVICE_SPEC_VERSION, DeviceSpec,
+    DeviceSpecError, HandeyeMountSpec, LaserPlaneSpec, NominalPoseSpec, RigLayoutSpec,
+    ScheimpflugMountSpec,
+};
+
+/// Failures when deriving seeds from a [`DeviceSpec`].
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceSeedError {
+    /// The spec has no camera with the requested id.
+    #[error("device spec has no camera with id `{id}`")]
+    UnknownCameraId {
+        /// The unmatched id.
+        id: String,
+    },
+
+    /// The spec has no rig mechanical layout.
+    #[error("device spec has no rig layout")]
+    MissingRigLayout,
+
+    /// The rig layout has no hand-eye mount.
+    #[error("device spec rig layout has no hand-eye mount")]
+    MissingHandeye,
+
+    /// The rig layout has no mount for the requested camera.
+    #[error("device spec rig layout has no mount for camera `{id}`")]
+    MissingCameraMount {
+        /// The unmatched id.
+        id: String,
+    },
+
+    /// The spec's hand-eye mount mode contradicts the session's configured
+    /// mode — seeding across modes would silently seed the wrong transform.
+    #[error("device spec hand-eye mount is {spec:?} but the session expects {expected:?}")]
+    HandeyeModeMismatch {
+        /// Mode stated by the spec.
+        spec: HandEyeMode,
+        /// Mode the caller's config expects.
+        expected: HandEyeMode,
+    },
+}
+
+/// Seed for a single-camera Scheimpflug intrinsics session.
+///
+/// Intrinsics and sensor tilt are always seeded (ADR 0022: both are
+/// load-bearing). A camera without a `scheimpflug` entry is frontal *by
+/// design*, so it seeds an identity tilt — the spec asserts knowledge of
+/// the mount, absence is not ignorance. Distortion and poses stay `None`
+/// (auto).
+pub fn scheimpflug_seed(
+    spec: &DeviceSpec,
+    camera_id: &str,
+) -> Result<ScheimpflugManualInit, DeviceSeedError> {
+    let cam = lookup(spec, camera_id)?;
+    Ok(ScheimpflugManualInit {
+        intrinsics: Some(intrinsics_from_camera(cam)),
+        sensor: Some(sensor_from_camera(cam)),
+        ..Default::default()
+    })
+}
+
+/// Per-camera intrinsics + sensor seeds for a rig hand-eye session, in the
+/// caller's `camera_ids` order.
+///
+/// `per_cam_sensors` is always populated (identity tilt for frontal
+/// cameras); it is ignored by the pipeline under `SensorMode::Pinhole`.
+/// `per_cam_distortion` stays `None` (auto).
+pub fn rig_intrinsics_seed(
+    spec: &DeviceSpec,
+    camera_ids: &[&str],
+) -> Result<RigHandeyeIntrinsicsManualInit, DeviceSeedError> {
+    let cams = camera_ids
+        .iter()
+        .map(|id| lookup(spec, id))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(RigHandeyeIntrinsicsManualInit {
+        per_cam_intrinsics: Some(cams.iter().map(|c| intrinsics_from_camera(c)).collect()),
+        per_cam_sensors: Some(cams.iter().map(|c| sensor_from_camera(c)).collect()),
+        ..Default::default()
+    })
+}
+
+/// Nominal `cam_se3_rig` (`T_C_R`) poses from the mechanical layout, in the
+/// caller's `camera_ids` order.
+///
+/// This is deliberately *not* a `RigHandeyeRigManualInit`: ADR 0011 couples
+/// `cam_se3_rig` with the data-dependent per-view `rig_se3_target`
+/// (both-or-neither), so combining the nominals with per-view estimates is
+/// the caller's job (Track S3).
+pub fn nominal_cam_se3_rig(
+    spec: &DeviceSpec,
+    camera_ids: &[&str],
+) -> Result<Vec<Iso3>, DeviceSeedError> {
+    let rig = spec.rig.as_ref().ok_or(DeviceSeedError::MissingRigLayout)?;
+    camera_ids
+        .iter()
+        .map(|id| {
+            // Spec cameras and mounts are validated id-consistent at load;
+            // distinguish "unknown camera" from "camera without a mount".
+            lookup(spec, id)?;
+            let mount = rig.cameras.iter().find(|m| m.id == *id).ok_or_else(|| {
+                DeviceSeedError::MissingCameraMount {
+                    id: (*id).to_string(),
+                }
+            })?;
+            Ok(iso3_from_nominal(&mount.rig_se3_cam).inverse())
+        })
+        .collect()
+}
+
+/// Hand-eye stage seed from the mechanical mount.
+///
+/// The spec's mount mode must match the session's configured
+/// [`HandEyeMode`]; a mismatch is a typed error rather than a silently
+/// wrong transform. `mode_target_pose` stays `None` (data-dependent).
+pub fn handeye_seed(
+    spec: &DeviceSpec,
+    expected_mode: HandEyeMode,
+) -> Result<RigHandeyeHandeyeManualInit, DeviceSeedError> {
+    let rig = spec.rig.as_ref().ok_or(DeviceSeedError::MissingRigLayout)?;
+    let mount = rig
+        .handeye
+        .as_ref()
+        .ok_or(DeviceSeedError::MissingHandeye)?;
+    let (spec_mode, pose) = match mount {
+        HandeyeMountSpec::EyeInHand { gripper_se3_rig } => {
+            (HandEyeMode::EyeInHand, gripper_se3_rig)
+        }
+        HandeyeMountSpec::EyeToHand { rig_se3_base } => (HandEyeMode::EyeToHand, rig_se3_base),
+    };
+    if spec_mode != expected_mode {
+        return Err(DeviceSeedError::HandeyeModeMismatch {
+            spec: spec_mode,
+            expected: expected_mode,
+        });
+    }
+    Ok(RigHandeyeHandeyeManualInit {
+        handeye: Some(iso3_from_nominal(pose)),
+        ..Default::default()
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Conversion helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn lookup<'a>(spec: &'a DeviceSpec, id: &str) -> Result<&'a CameraDeviceSpec, DeviceSeedError> {
+    spec.camera(id)
+        .ok_or_else(|| DeviceSeedError::UnknownCameraId { id: id.to_string() })
+}
+
+fn intrinsics_from_camera(cam: &CameraDeviceSpec) -> FxFyCxCySkew<Real> {
+    let f_px = cam.focal_mm * 1000.0 / cam.pixel_pitch_um;
+    let [cx, cy] = cam.principal_point_px.unwrap_or([
+        f64::from(cam.resolution_px[0]) * 0.5,
+        f64::from(cam.resolution_px[1]) * 0.5,
+    ]);
+    FxFyCxCySkew {
+        fx: f_px,
+        fy: f_px,
+        cx,
+        cy,
+        skew: 0.0,
+    }
+}
+
+fn sensor_from_camera(cam: &CameraDeviceSpec) -> ScheimpflugParams {
+    match &cam.scheimpflug {
+        Some(mount) => ScheimpflugParams {
+            tilt_x: mount.tilt_x_deg.to_radians(),
+            tilt_y: mount.tilt_y_deg.to_radians(),
+        },
+        None => ScheimpflugParams::default(),
+    }
+}
+
+fn iso3_from_nominal(pose: &NominalPoseSpec) -> Iso3 {
+    let [roll, pitch, yaw] = pose.rpy_deg.map(f64::to_radians);
+    let rotation = nalgebra::UnitQuaternion::from_euler_angles(roll, pitch, yaw);
+    let translation = nalgebra::Translation3::new(
+        pose.translation_mm[0],
+        pose.translation_mm[1],
+        pose.translation_mm[2],
+    );
+    Iso3::from_parts(translation, rotation)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vision_calibration_dataset::{CameraMountSpec, RigLayoutSpec, ScheimpflugMountSpec};
+
+    fn camera(id: &str) -> CameraDeviceSpec {
+        CameraDeviceSpec {
+            id: id.to_string(),
+            focal_mm: 8.0,
+            pixel_pitch_um: 7.0,
+            resolution_px: [720, 540],
+            principal_point_px: None,
+            scheimpflug: Some(ScheimpflugMountSpec {
+                tilt_x_deg: -5.0,
+                tilt_y_deg: 0.0,
+            }),
+        }
+    }
+
+    fn rig_spec() -> DeviceSpec {
+        DeviceSpec {
+            version: 1,
+            cameras: vec![camera("cam0"), camera("cam1")],
+            rig: Some(RigLayoutSpec {
+                cameras: vec![
+                    CameraMountSpec {
+                        id: "cam0".to_string(),
+                        rig_se3_cam: NominalPoseSpec {
+                            rpy_deg: [0.0, 0.0, 90.0],
+                            translation_mm: [100.0, 0.0, 0.0],
+                        },
+                    },
+                    CameraMountSpec {
+                        id: "cam1".to_string(),
+                        rig_se3_cam: NominalPoseSpec::default(),
+                    },
+                ],
+                handeye: Some(HandeyeMountSpec::EyeToHand {
+                    rig_se3_base: NominalPoseSpec {
+                        rpy_deg: [0.0, 0.0, 0.0],
+                        translation_mm: [0.0, 250.0, 0.0],
+                    },
+                }),
+                laser_planes: None,
+            }),
+            description: None,
+        }
+    }
+
+    #[test]
+    fn focal_px_from_datasheet() {
+        // The S1 acceptance formula: f_px = f_mm / pixel_pitch.
+        let mut cam = camera("cam0");
+        cam.focal_mm = 16.0;
+        cam.pixel_pitch_um = 4.8;
+        let k = intrinsics_from_camera(&cam);
+        assert!((k.fx - 16.0e-3 / 4.8e-6).abs() < 1e-9);
+        assert!((k.fx - 3_333.333_333_333).abs() < 1e-6);
+        assert_eq!(k.fx, k.fy);
+        assert_eq!(k.skew, 0.0);
+
+        let k = intrinsics_from_camera(&camera("cam0"));
+        assert!((k.fx - 8.0e-3 / 7.0e-6).abs() < 1e-9); // ≈ 1142.857
+    }
+
+    #[test]
+    fn principal_point_defaults_to_center() {
+        let k = intrinsics_from_camera(&camera("cam0"));
+        assert_eq!((k.cx, k.cy), (360.0, 270.0));
+
+        let mut cam = camera("cam0");
+        cam.principal_point_px = Some([355.5, 275.25]);
+        let k = intrinsics_from_camera(&cam);
+        assert_eq!((k.cx, k.cy), (355.5, 275.25));
+    }
+
+    #[test]
+    fn tilt_degrees_to_radians_and_frontal_identity() {
+        let seed = scheimpflug_seed(&rig_spec(), "cam0").unwrap();
+        let sensor = seed.sensor.unwrap();
+        assert!((sensor.tilt_x - (-5.0f64).to_radians()).abs() < 1e-12);
+        assert!((sensor.tilt_x - (-0.087_266_46)).abs() < 1e-7);
+        assert_eq!(sensor.tilt_y, 0.0);
+        assert!(seed.intrinsics.is_some());
+        assert!(seed.distortion.is_none());
+        assert!(seed.poses.is_none());
+
+        let mut spec = rig_spec();
+        spec.cameras[0].scheimpflug = None;
+        let seed = scheimpflug_seed(&spec, "cam0").unwrap();
+        let sensor = seed.sensor.unwrap();
+        assert_eq!((sensor.tilt_x, sensor.tilt_y), (0.0, 0.0));
+    }
+
+    #[test]
+    fn rig_intrinsics_follow_caller_order() {
+        let spec = rig_spec();
+        let seed = rig_intrinsics_seed(&spec, &["cam1", "cam0"]).unwrap();
+        let ks = seed.per_cam_intrinsics.unwrap();
+        assert_eq!(ks.len(), 2);
+        let sensors = seed.per_cam_sensors.unwrap();
+        assert_eq!(sensors.len(), 2);
+        assert!(seed.per_cam_distortion.is_none());
+
+        assert!(matches!(
+            rig_intrinsics_seed(&spec, &["cam0", "cam9"]),
+            Err(DeviceSeedError::UnknownCameraId { .. })
+        ));
+    }
+
+    #[test]
+    fn rpy_convention_fixed_axes_xyz() {
+        // roll = 90° about x maps ŷ → ẑ.
+        let pose = NominalPoseSpec {
+            rpy_deg: [90.0, 0.0, 0.0],
+            translation_mm: [0.0; 3],
+        };
+        let iso = iso3_from_nominal(&pose);
+        let mapped = iso * nalgebra::Vector3::y();
+        assert!((mapped - nalgebra::Vector3::z()).norm() < 1e-12);
+    }
+
+    #[test]
+    fn cam_se3_rig_is_inverted_mount() {
+        // Mount: Rz(90°), t = [100, 0, 0] (camera pose in rig frame).
+        // Inverse: R = Rz(−90°), t = −Rz(−90°)·[100,0,0] = [0, 100, 0].
+        let spec = rig_spec();
+        let poses = nominal_cam_se3_rig(&spec, &["cam0", "cam1"]).unwrap();
+        let t = poses[0].translation.vector;
+        assert!((t - nalgebra::Vector3::new(0.0, 100.0, 0.0)).norm() < 1e-9);
+        // Round-trip: inverse of the inverse is the mount pose.
+        let back = poses[0].inverse();
+        assert!((back.translation.vector.x - 100.0).abs() < 1e-9);
+        assert!(poses[1].translation.vector.norm() < 1e-12); // identity mount
+
+        assert!(matches!(
+            nominal_cam_se3_rig(&spec, &["cam9"]),
+            Err(DeviceSeedError::UnknownCameraId { .. })
+        ));
+
+        let mut no_mount = rig_spec();
+        no_mount.rig.as_mut().unwrap().cameras.pop();
+        assert!(matches!(
+            nominal_cam_se3_rig(&no_mount, &["cam1"]),
+            Err(DeviceSeedError::MissingCameraMount { .. })
+        ));
+
+        let mut no_rig = rig_spec();
+        no_rig.rig = None;
+        assert!(matches!(
+            nominal_cam_se3_rig(&no_rig, &["cam0"]),
+            Err(DeviceSeedError::MissingRigLayout)
+        ));
+    }
+
+    #[test]
+    fn handeye_seed_mode_checked() {
+        let spec = rig_spec();
+        let seed = handeye_seed(&spec, HandEyeMode::EyeToHand).unwrap();
+        let handeye = seed.handeye.unwrap();
+        assert!((handeye.translation.vector.y - 250.0).abs() < 1e-12);
+        assert!(seed.mode_target_pose.is_none());
+
+        assert!(matches!(
+            handeye_seed(&spec, HandEyeMode::EyeInHand),
+            Err(DeviceSeedError::HandeyeModeMismatch { .. })
+        ));
+
+        let mut no_he = rig_spec();
+        no_he.rig.as_mut().unwrap().handeye = None;
+        assert!(matches!(
+            handeye_seed(&no_he, HandEyeMode::EyeToHand),
+            Err(DeviceSeedError::MissingHandeye)
+        ));
+    }
+}

--- a/crates/vision-calibration-pipeline/src/lib.rs
+++ b/crates/vision-calibration-pipeline/src/lib.rs
@@ -43,6 +43,9 @@ mod planar_family;
 mod rig_family;
 pub mod session;
 
+// Device-spec → manual-init seed derivation (ADR 0023)
+pub mod device_seed;
+
 // Problem-specific modules
 pub mod laserline_device;
 pub mod planar_intrinsics;

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -135,6 +135,36 @@ pub mod common {
     };
 }
 
+/// Device-spec → manual-init seed derivation (ADR 0023).
+///
+/// [`DeviceSpec`](device_seed::DeviceSpec) is the sidecar `spec.json` schema
+/// describing the capture hardware (lens focal, pixel pitch, Scheimpflug
+/// mount tilt, nominal rig layout); the functions here derive the ADR 0011
+/// manual-init seeds that make spec-seeded initialization (ADR 0022) the
+/// structured default.
+pub mod device_seed {
+    pub use vision_calibration_pipeline::device_seed::{
+        // Schema types (from `vision-calibration-dataset`)
+        CameraDeviceSpec,
+        CameraMountSpec,
+        DEVICE_SPEC_FILENAME,
+        DEVICE_SPEC_VERSION,
+        // Derivation
+        DeviceSeedError,
+        DeviceSpec,
+        DeviceSpecError,
+        HandeyeMountSpec,
+        LaserPlaneSpec,
+        NominalPoseSpec,
+        RigLayoutSpec,
+        ScheimpflugMountSpec,
+        handeye_seed,
+        nominal_cam_se3_rig,
+        rig_intrinsics_seed,
+        scheimpflug_seed,
+    };
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Problem-Specific Modules
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/docs/DESIGN-device-spec.md
+++ b/docs/DESIGN-device-spec.md
@@ -24,9 +24,10 @@ layout) as a sidecar `spec.json` next to a dataset. Output: the existing ADR
   (`CameraSource::id` convention, e.g. `"cam0"`).
 - `resolution_px` is the resolution of the images actually calibrated (for
   rtv3d: the 720×540 tile, not the full sensor).
-- World/translation units are millimetres (board cell sizes are given in mm
-  throughout the pipeline); angles in the spec are degrees (datasheet units),
-  radians internally.
+- Spec translations are millimetres (drawing units); the pipeline's world
+  unit is **metres** (target 3D points are `mm / 1000`, laser metrics in m),
+  so derived poses convert mm → m. Angles in the spec are degrees (datasheet
+  units), radians internally.
 - JSON input (serde_json rejects NaN/Inf literals, so finiteness comes free).
 
 ## Failure Modes

--- a/docs/DESIGN-device-spec.md
+++ b/docs/DESIGN-device-spec.md
@@ -1,0 +1,188 @@
+# Design: `DeviceSpec` — device specification → initialization seeds (ADR 0023)
+
+Status: implemented in the S1+S2 PR. This is the working design artifact; the
+durable decision record is [ADR 0023](adrs/0023-device-spec-seed-derivation.md).
+
+## Problem
+
+Spec-seeded initialization is the official acceptance route (ADR 0022), but
+today the seeds are hand-coded constants and env knobs scattered across the
+private examples (`RTV3D_REF_FOCAL`, `RTV3D_RINGGRID_FOCAL`, `NOMINAL_TILT_X`,
+…). Input: a human-transcribed device datasheet + mechanical drawing (lens
+focal, pixel pitch, sensor resolution, Scheimpflug mount tilt, nominal rig
+layout) as a sidecar `spec.json` next to a dataset. Output: the existing ADR
+0011 manual-init structs (`ScheimpflugManualInit`,
+`RigHandeyeIntrinsicsManualInit`, nominal `cam_se3_rig` poses,
+`RigHandeyeHandeyeManualInit`), derived in exactly one place.
+
+## Assumptions
+
+- Spec values are datasheet-grade nominals, not calibrated values; the seeded
+  optimize step (ADR 0022) tolerates focal error within its `[0.75, 1.5]×`
+  bound and tilt within ±0.10 rad. Q6 quantifies the basin.
+- Camera ids in the spec match the dataset's camera identifiers
+  (`CameraSource::id` convention, e.g. `"cam0"`).
+- `resolution_px` is the resolution of the images actually calibrated (for
+  rtv3d: the 720×540 tile, not the full sensor).
+- World/translation units are millimetres (board cell sizes are given in mm
+  throughout the pipeline); angles in the spec are degrees (datasheet units),
+  radians internally.
+- JSON input (serde_json rejects NaN/Inf literals, so finiteness comes free).
+
+## Failure Modes
+
+All prevented by `DeviceSpec::validate()` (called by `from_path`) or returned
+as typed errors from derivation fns — never panics:
+
+- empty `cameras`, duplicate camera ids → `DeviceSpecError` at load/validate
+- `focal_mm ≤ 0`, `pixel_pitch_um ≤ 0`, zero `resolution_px` → load/validate
+- non-unit laser-plane normal (‖n‖ − 1 > 1e-6) → load/validate
+- unsupported `version` (> current) → load/validate
+- unknown JSON field → serde `deny_unknown_fields` (catches typos in
+  hand-authored files)
+- derivation asked for an id not in the spec → `DeviceSeedError::UnknownCameraId`
+- derivation asked for rig layout / hand-eye the spec doesn't carry →
+  `DeviceSeedError::{MissingRigLayout, MissingHandeye, MissingCameraMount}`
+
+## Domain Types (`vision-calibration-dataset/src/device_spec.rs`)
+
+Plain-serde types only — **no core types in the schema** (keeps the dataset
+crate dependency-free and the wire format stable). Datasheet-natural units
+with mandatory unit suffixes in field names; conversion happens exactly once,
+in the derivation layer. Follows the crate's serde conventions
+(`deny_unknown_fields`, `version` with default fn, snake_case tags,
+`skip_serializing_if` on options, schemars behind the feature).
+
+```rust
+pub struct DeviceSpec {
+    pub version: u32,                       // default 1; reject > CURRENT
+    pub cameras: Vec<CameraDeviceSpec>,     // non-empty, unique ids
+    pub rig: Option<RigLayoutSpec>,
+    pub description: Option<String>,
+}
+pub struct CameraDeviceSpec {
+    pub id: String,                         // matches CameraSource::id
+    pub focal_mm: f64,                      // lens datasheet focal length
+    pub pixel_pitch_um: f64,                // sensor datasheet pixel pitch
+    pub resolution_px: [u32; 2],            // [width, height] as calibrated
+    pub principal_point_px: Option<[f64; 2]>, // default: resolution center
+    pub scheimpflug: Option<ScheimpflugMountSpec>, // None = frontal sensor
+}
+pub struct ScheimpflugMountSpec { pub tilt_x_deg: f64, pub tilt_y_deg: f64 } // defaults 0
+pub struct RigLayoutSpec {
+    pub cameras: Vec<CameraMountSpec>,      // nominal mounts, id-keyed
+    pub handeye: Option<HandeyeMountSpec>,
+    pub laser_planes: Option<Vec<LaserPlaneSpec>>,
+}
+pub struct CameraMountSpec { pub id: String, pub rig_se3_cam: NominalPoseSpec }
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum HandeyeMountSpec {                 // illegal states unrepresentable:
+    EyeInHand { gripper_se3_rig: NominalPoseSpec },  // frame meaning fixed by mode
+    EyeToHand { rig_se3_base: NominalPoseSpec },
+}
+pub struct NominalPoseSpec { pub rpy_deg: [f64; 3], pub translation_mm: [f64; 3] }
+pub struct LaserPlaneSpec {                 // plane {p : n·p = d} in RIG frame
+    pub camera_id: String,                  // the paired camera (rtv3d pairs)
+    pub normal: [f64; 3],                   // unit, rig frame
+    pub distance_mm: f64,
+}
+```
+
+Design choices:
+
+- **Id-keyed cameras** (not positional): silent misalignment with the dataset
+  manifest becomes a typed error instead of a wrong seed.
+- **`rig_se3_cam` in the spec** (camera mount pose in rig frame — what a
+  mechanical drawing states); derivation inverts to the `cam_se3_rig` the
+  manual-init surface wants. Both directions explicitly named (ADR 0009).
+- **One pose representation**: roll-pitch-yaw degrees, fixed-axes XYZ
+  (`R = Rz(yaw)·Ry(pitch)·Rx(roll)`, nalgebra `from_euler_angles`) +
+  translation mm. Quaternions can be added as an additive schema change if a
+  real need appears (KISS).
+- **No `sensor_size_mm` field**: it is `pixel_pitch × resolution` (DRY).
+- **No metric-anchor field yet**: reserved for Q5 (YAGNI now); additive later.
+
+## API
+
+```rust
+// vision-calibration-dataset
+pub const DEVICE_SPEC_FILENAME: &str = "spec.json";  // sidecar next to manifest
+impl DeviceSpec {
+    pub fn from_path(path: &Path) -> Result<Self, DeviceSpecError>; // load + validate
+    pub fn validate(&self) -> Result<(), DeviceSpecError>;
+    pub fn camera(&self, id: &str) -> Option<&CameraDeviceSpec>;
+}
+
+// vision-calibration-pipeline::device_seed  (new module; pipeline already deps dataset)
+pub fn scheimpflug_seed(spec: &DeviceSpec, camera_id: &str)
+    -> Result<ScheimpflugManualInit, DeviceSeedError>;      // intrinsics+sensor Some, rest None
+pub fn rig_intrinsics_seed(spec: &DeviceSpec, camera_ids: &[&str])
+    -> Result<RigHandeyeIntrinsicsManualInit, DeviceSeedError>;
+pub fn nominal_cam_se3_rig(spec: &DeviceSpec, camera_ids: &[&str])
+    -> Result<Vec<Iso3>, DeviceSeedError>;                  // building block for S3
+pub fn handeye_seed(spec: &DeviceSpec)
+    -> Result<RigHandeyeHandeyeManualInit, DeviceSeedError>; // handeye Some, target None
+```
+
+- `f_px = focal_mm * 1000 / pixel_pitch_um`; principal point defaults to
+  `resolution/2`; `fx = fy`, `skew = 0`.
+- `nominal_cam_se3_rig` deliberately does **not** return a
+  `RigHandeyeRigManualInit`: that struct couples `cam_se3_rig` with per-view
+  `rig_se3_target` (both-or-neither, ADR 0011), and target poses are
+  data-dependent — S3 combines the nominal poses with per-view estimates.
+- `RigExtrinsics`' twin manual-init types get derivation fns when a consumer
+  exists (currently none) — not speculatively.
+- All fns are cheap setup-path code: allocation-per-call, no genericity
+  (`f64` only), no buffers.
+
+## Error Model
+
+```rust
+// dataset crate
+pub enum DeviceSpecError {
+    Io(std::io::Error), Json(serde_json::Error),
+    UnsupportedVersion { got: u32, max: u32 },
+    NoCameras, DuplicateCameraId { id: String },
+    InvalidCamera { id: String, field: &'static str },   // focal/pitch/resolution
+    NonUnitLaserNormal { camera_id: String, norm: f64 },
+}
+// pipeline
+pub enum DeviceSeedError {
+    UnknownCameraId { id: String },
+    MissingRigLayout, MissingHandeye,
+    MissingCameraMount { id: String },
+}
+```
+
+## Placement
+
+- Schema + load/validate: `vision-calibration-dataset/src/device_spec.rs`
+  (crate owns dataset-adjacent metadata, ADR 0016). No new deps.
+- Derivation: `vision-calibration-pipeline/src/device_seed.rs` (needs core's
+  `FxFyCxCySkew`/`ScheimpflugParams`/`Iso3` and pipeline's manual-init types;
+  pipeline already depends on dataset — no new graph edge). Re-exported
+  through the facade so examples/app stay facade-only.
+- Private `spec.json` files: `privatedata/<dataset>/spec.json`, gitignored
+  (public repo; consistent with `registry/private.json`).
+
+## Test Plan
+
+- **dataset**: JSON roundtrip of a full spec (rig + hand-eye enum + laser
+  plane) and a minimal spec (defaults); `deny_unknown_fields` rejection;
+  version default + `UnsupportedVersion`; each `validate()` failure mode.
+- **pipeline `device_seed`**: `f_px` formula (16 mm / 4.8 µm → 3333.33…px;
+  8 mm / 7 µm → 1142.857 px); principal-point center fallback; tilt deg→rad
+  (−5° → −0.08727 rad); `rig_se3_cam` inversion round-trip on a hand-computed
+  pose; rpy convention check (rpy = [90,0,0] maps ŷ→ẑ); every error variant.
+- **Integration (S2 gate)**: `rtv3d_ref_intrinsics` + `rtv3d_ringgrid_intrinsics`
+  run end-to-end from `spec.json` with no env vars, all cameras ≤ 0.5 px.
+
+## Performance Notes
+
+Setup-path code that runs once per calibration; no benchmarks warranted.
+
+## Next Steps
+
+1. Implement the design above (S1), wire the two intrinsics examples (S2)
+2. `/algo-review` — verify correctness, robustness, test adequacy
+3. `/calibration-review` — pose-convention and units checks on the derivation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,6 +72,9 @@ the `RTV3D_RINGGRID_FOCAL` env sweep) → S3 (extrinsics + hand-eye from layout)
 → S4 (one-command acceptance harness over all registered datasets; absent
 datasets print `UNAVAILABLE`, never a silent pass; the failing 0.4 px
 from-scratch gate demotes to informational per the parked V7).
+**Status 2026-07-02: S1 + S2 shipped** (ADR 0023, `device_seed` facade module,
+both intrinsics examples spec-driven; ringgrid cam1 sits at 0.5008 px — a
+pre-existing, seed-independent knife edge owned by Q3).
 
 ### Track Q — Algorithmic soundness: proofs + regression
 

--- a/docs/adrs/0023-device-spec-seed-derivation.md
+++ b/docs/adrs/0023-device-spec-seed-derivation.md
@@ -1,0 +1,137 @@
+# ADR 0023: `DeviceSpec` — Device Specification Schema and Seed Derivation
+
+- Status: Accepted
+- Date: 2026-07-02
+
+## Context
+
+ADR 0022 made spec-seeded initialization the official acceptance route for
+Scheimpflug intrinsics: the values needed to seed the solve — lens focal
+length, sensor pixel pitch, and the mechanically-set Scheimpflug mount tilt —
+are datasheet/drawing values the device owner already has. But as shipped,
+those seeds are hand-coded constants and env knobs scattered across the
+private examples (`RTV3D_REF_FOCAL`, `RTV3D_RINGGRID_FOCAL`,
+`RTV3D_RINGGRID_TILT_X`, `NOMINAL_TILT_X`, `RTV3D_SEED=generic|oracle`).
+Every new dataset re-invents its own seeding, the ringgrid rig needed an
+env-var *sweep* to find a focal the spec should have provided, and the
+acceptance harness (S4) has no structured way to ask "what does the device
+spec say?".
+
+Track S introduces a structured **device-spec → seed** layer: a sidecar
+`spec.json` next to each dataset manifest describing the *hardware* (not the
+data), plus derivation functions producing the existing ADR 0011 manual-init
+structs. Note the manual-init surface has moved since ADR 0011 was written:
+the `RigScheimpflug*` problem types were collapsed by ADR 0013 — the rig
+targets today are `RigExtrinsics`/`RigHandeye` with
+`SensorMode::Scheimpflug`, seeded through `RigHandeyeIntrinsicsManualInit`
+(`per_cam_intrinsics`/`per_cam_sensors`), `RigHandeyeRigManualInit`, and
+`RigHandeyeHandeyeManualInit`.
+
+## Decision
+
+### Schema (`vision_calibration_dataset::device_spec`)
+
+`DeviceSpec` lives in `vision-calibration-dataset` (the crate that owns
+dataset-adjacent metadata, ADR 0016), as **plain-serde types with no core
+dependencies**:
+
+- `DeviceSpec { version, cameras: Vec<CameraDeviceSpec>, rig: Option<RigLayoutSpec>, description }`
+- `CameraDeviceSpec { id, focal_mm, pixel_pitch_um, resolution_px: [u32;2], principal_point_px: Option<[f64;2]>, scheimpflug: Option<ScheimpflugMountSpec> }`
+- `ScheimpflugMountSpec { tilt_x_deg, tilt_y_deg }` — `None` means frontal sensor
+- `RigLayoutSpec { cameras: Vec<CameraMountSpec>, handeye: Option<HandeyeMountSpec>, laser_planes: Option<Vec<LaserPlaneSpec>> }`
+- `CameraMountSpec { id, rig_se3_cam: NominalPoseSpec }`
+- `HandeyeMountSpec` — a `mode`-tagged enum: `EyeInHand { gripper_se3_rig }` |
+  `EyeToHand { rig_se3_base }`, so the frame meaning of the nominal pose is
+  fixed by construction (illegal states unrepresentable)
+- `NominalPoseSpec { rpy_deg: [f64;3], translation_mm: [f64;3] }`
+- `LaserPlaneSpec { camera_id, normal: [f64;3], distance_mm }` — the plane
+  `{p : n·p = d}` in the **rig** frame, keyed to its paired camera
+
+**Units are datasheet-natural and encoded in field names** (`_mm`, `_um`,
+`_px`, `_deg`): a `DeviceSpec` is a transcription of a datasheet and a
+mechanical drawing, and transcription must not require unit conversion —
+conversion happens exactly once, in the derivation layer (deg→rad, mm+µm→px).
+Translations stay in millimetres, matching the pipeline's world units (board
+cell sizes are mm).
+
+**Frames follow ADR 0009 naming.** The spec stores `rig_se3_cam` — the camera
+mount pose *in the rig frame*, which is what a mechanical drawing states;
+derivation inverts it into the `cam_se3_rig` (`T_C_R`) the manual-init surface
+expects. Rotation convention for `rpy_deg`: fixed-axes XYZ,
+`R = Rz(yaw)·Ry(pitch)·Rx(roll)` (nalgebra `from_euler_angles`).
+
+**Placement and privacy.** The sidecar is `spec.json` next to the dataset
+manifest (`DEVICE_SPEC_FILENAME`). For the private datasets it lives at
+`privatedata/<dataset>/spec.json` and stays **gitignored** — the repo is
+public and the hardware specs are as private as the datasets themselves
+(consistent with `registry/private.json`). Committed fixtures use synthetic
+example specs.
+
+**Validation is fail-fast and typed** (ADR 0019): `DeviceSpec::from_path`
+loads, then `validate()` rejects empty/duplicate camera ids, non-positive
+focal/pitch/resolution, non-unit laser normals, and unsupported versions;
+`deny_unknown_fields` turns typos in hand-authored JSON into load errors.
+`version` (default 1) is bumped on breaking schema revisions, like
+`DatasetSpec`.
+
+### Derivation (`vision_calibration_pipeline::device_seed`)
+
+Pipeline already depends on dataset, so this adds no dependency edge. The
+functions map spec → existing manual-init types and return typed
+`DeviceSeedError`s (unknown camera id, missing layout/hand-eye/mount):
+
+- `scheimpflug_seed(spec, camera_id) -> ScheimpflugManualInit` — intrinsics
+  (`fx = fy = focal_mm·1000/pixel_pitch_um`, principal point defaulting to the
+  resolution center, `skew = 0`) + sensor tilt (deg→rad); distortion and poses
+  stay `None` (auto), per ADR 0022.
+- `rig_intrinsics_seed(spec, camera_ids) -> RigHandeyeIntrinsicsManualInit` —
+  per-camera vectors ordered by the **caller's** id list, so alignment with
+  the dataset's camera order is explicit, never positional guessing.
+- `nominal_cam_se3_rig(spec, camera_ids) -> Vec<Iso3>` — deliberately *not* a
+  `RigHandeyeRigManualInit`: ADR 0011 couples `cam_se3_rig` with per-view
+  `rig_se3_target` (both-or-neither), and target poses are data-dependent.
+  S3 combines these nominals with per-view estimates.
+- `handeye_seed(spec) -> RigHandeyeHandeyeManualInit` — the mode-tagged mount
+  maps onto the mode-dependent `handeye` field; `mode_target_pose` stays
+  `None`.
+
+Everything is re-exported through the facade so examples, bench, and the app
+consume it facade-only.
+
+### Rejected alternatives
+
+- **Core types (`FxFyCxCySkew`, `Iso3`) in the schema** — couples the wire
+  format to internal refactors and adds a core dep to the dataset crate.
+- **Metres everywhere** (like `TargetSpec::marker_outer_radius_m`) — device
+  datasheets quote mm/µm; forcing authors to convert invites transcription
+  errors, which defeats the point of a spec layer.
+- **Positional camera lists** — silent misalignment; id-keying makes mismatch
+  a typed error.
+- **`sensor_size_mm` field** — derivable (`pitch × resolution`), would create
+  a second source of truth.
+- **Metric-anchor field now** — reserved for Q5 (known target dimension /
+  baseline prior pins the rtv3d absolute scale); added when it has a consumer.
+- **Multiple pose representations (quaternion variant)** — one representation
+  suffices for nominal mounts; additive schema change if ever needed.
+
+## Consequences
+
+- S2 replaces the hand-coded constants in `rtv3d_ref_intrinsics` /
+  `rtv3d_ringgrid_intrinsics` with `spec.json` loading; the
+  `RTV3D_*_FOCAL`/`TILT` env knobs (including the ringgrid focal sweep) are
+  deleted. Gate unchanged: all cameras ≤ 0.5 px, now with zero env vars.
+- S3 wires `nominal_cam_se3_rig` + `handeye_seed` into the rig examples; S4's
+  acceptance registry references spec files per dataset.
+- Q6's convergence-basin study quantifies how much spec error the seeded
+  route tolerates, closing the loop on "datasheet-grade nominals are enough".
+- Schema evolution is versioned and additive-first; breaking revisions bump
+  `version` and are release events for the dataset crate.
+
+## References
+
+- ADR 0022 — seeded init is the supported default (the consumer of these seeds)
+- ADR 0011 — manual initialization workflow (the target surface)
+- ADR 0016 — dataset manifest (the sibling schema and serde conventions)
+- ADR 0009 — pose naming (`frame_se3_frame`)
+- ADR 0019 — fail-fast on ambiguity (validation posture)
+- `docs/DESIGN-device-spec.md` — working design artifact for this change

--- a/docs/adrs/0023-device-spec-seed-derivation.md
+++ b/docs/adrs/0023-device-spec-seed-derivation.md
@@ -50,9 +50,10 @@ dependencies**:
 **Units are datasheet-natural and encoded in field names** (`_mm`, `_um`,
 `_px`, `_deg`): a `DeviceSpec` is a transcription of a datasheet and a
 mechanical drawing, and transcription must not require unit conversion —
-conversion happens exactly once, in the derivation layer (deg→rad, mm+µm→px).
-Translations stay in millimetres, matching the pipeline's world units (board
-cell sizes are mm).
+conversion happens exactly once, in the derivation layer (deg→rad, mm+µm→px,
+and translations mm→m: the pipeline's world unit is **metres** — target 3D
+points are built as `mm / 1000`, laser errors and plane distances are metres
+throughout).
 
 **Frames follow ADR 0009 naming.** The spec stores `rig_se3_cam` — the camera
 mount pose *in the rig frame*, which is what a mechanical drawing states;

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -44,3 +44,4 @@ Status legend:
 - [0020 - Camera Model as Data in the Factor IR](0020-camera-model-as-data-factor-ir.md)
 - [0021 - Laser-Frame Dataset Manifest](0021-laser-frame-manifest.md)
 - [0022 - Scheimpflug Intrinsics: User-Seeded Initialization is the Supported Default](0022-scheimpflug-intrinsics-seeded-default.md)
+- [0023 - `DeviceSpec`: Device Specification Schema and Seed Derivation](0023-device-spec-seed-derivation.md)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -19,20 +19,28 @@ Structured "device specification → initialization seed" layer replacing the
 hand-coded per-example constants. Spec-seeded init is the **official
 acceptance route** (ADR 0022); from-scratch stays experimental.
 
-- [ ] S1-SPEC-ADR - ADR 0023: `DeviceSpec` schema + seed derivation. Per-camera
-  lens focal (mm), pixel pitch, sensor size/resolution, Scheimpflug mount tilt
-  (deg + axis); rig mechanical layout (nominal camera poses, laser-plane
-  nominals, hand-eye nominal); units, frames, serde format (sidecar `spec.json`
-  next to the dataset manifest), versioning, and the mapping onto the existing
-  manual-init surface (ADR 0011). Home: `vision-calibration-dataset` (owns
-  manifests, ADR 0016) with derivation fns in pipeline. Ship skeleton types +
-  serde roundtrip + `f_px = f_mm / pixel_pitch` unit test in the same PR.
-- [ ] S2-SPEC-INTRINSICS - Spec → per-camera intrinsics + tilt seeds. Replace
-  the hand-coded constants in `rtv3d_ref_intrinsics.rs` +
-  `rtv3d_ringgrid_intrinsics.rs`; delete the `RTV3D_RINGGRID_FOCAL` env sweep
-  (focal derives from the spec); check in a `spec.json` per private dataset.
-  Gate: both hard-gated examples still pass ≤ 0.5 px with spec-derived seeds,
-  no env vars.
+- [x] S1-SPEC-ADR - **Done 2026-07-02.** ADR 0023 accepted: `DeviceSpec`
+  schema in `vision-calibration-dataset::device_spec` (plain-serde,
+  datasheet-natural units with unit-suffixed field names, id-keyed cameras,
+  `deny_unknown_fields`, versioned, fail-fast `validate()`), derivation fns in
+  `vision-calibration-pipeline::device_seed` (`scheimpflug_seed`,
+  `rig_intrinsics_seed`, `nominal_cam_se3_rig`, `handeye_seed` with hand-eye
+  mode cross-check), re-exported through the facade as
+  `vision_calibration::device_seed`. `nominal_cam_se3_rig` deliberately returns
+  raw poses, not `RigHandeyeRigManualInit` — ADR 0011 couples `cam_se3_rig`
+  with data-dependent `rig_se3_target` (S3 combines them). Serde roundtrip +
+  `f_px = f_mm/pixel_pitch` + pose-inversion + rpy-convention unit tests ship
+  with it. Design artifact: `docs/DESIGN-device-spec.md`.
+- [x] S2-SPEC-INTRINSICS - **Done 2026-07-02.** Both intrinsics examples load
+  `privatedata/<ds>/spec.json` (local-only, gitignored — repo is public, so
+  device specs stay as private as the datasets; the registry `private.json`
+  precedent) and derive seeds via `device_seed::scheimpflug_seed`; the
+  `RTV3D_REF_FOCAL`/`RTV3D_RINGGRID_FOCAL`/`RTV3D_RINGGRID_TILT_X` env knobs
+  (incl. the focal sweep) are deleted. rtv3d_ref: GATE PASS, all 6 cams ≤
+  0.5 px (worst cam3 0.474). rtv3d_ringgrid: 5/6 ≤ 0.5 px; cam1 sits at
+  0.5008 px **independent of the seed** (1142.9 and 1150.0 px seeds give the
+  identical value; pre-existing knife-edge, tracked under Q3 ringgrid bias —
+  the gate is not relaxed).
 - [ ] S3-SPEC-EXTRINSICS - Extrinsics + hand-eye seeds from the mechanical
   layout, wired into `rtv3d_rig.rs` (currently bootstrapped; keep bootstrap
   behind a flag for comparison). Gate: the beat-the-oracle criteria unchanged.


### PR DESCRIPTION
## Summary

Track S, sessions S1 + S2 of the production-grade program: the hand-coded per-example seeds become a structured **device-spec → seed** layer (ADR 0023), and both hard-gated private intrinsics examples now derive their seeds from a `spec.json` sidecar instead of constants + env knobs.

### S1 — ADR 0023: `DeviceSpec` schema + seed derivation
- **New ADR 0023** (`docs/adrs/0023-device-spec-seed-derivation.md`) + design artifact `docs/DESIGN-device-spec.md`.
- **`vision_calibration_dataset::device_spec`**: plain-serde schema (no core deps) — per-camera `focal_mm` / `pixel_pitch_um` / `resolution_px` / optional principal point / `ScheimpflugMountSpec` (degrees); rig mechanical layout (`rig_se3_cam` mounts as rpy-deg + translation-mm, mode-tagged `HandeyeMountSpec` enum, laser-plane nominals in the rig frame). Datasheet-natural units with unit-suffixed field names; `deny_unknown_fields`; versioned; fail-fast `validate()` (ADR 0019).
- **`vision_calibration_pipeline::device_seed`**: derivation onto the ADR 0011 manual-init surface — `scheimpflug_seed` (`fx = fy = focal_mm·1000/pixel_pitch_um`, pp defaults to resolution center, tilt deg→rad), `rig_intrinsics_seed` (id-keyed, caller-ordered), `nominal_cam_se3_rig` (mount inversion; deliberately *not* a `RigHandeyeRigManualInit` — ADR 0011 couples `cam_se3_rig` with data-dependent `rig_se3_target`; S3 combines them), `handeye_seed` (hand-eye **mode cross-checked** against the spec's mount tag). Re-exported through the facade as `vision_calibration::device_seed`.
- Tests: serde roundtrips, every `validate()` failure mode, `f_px` formula, pp fallback, deg→rad, rpy convention, mount-pose inversion, all `DeviceSeedError` variants.

### S2 — spec-driven intrinsics examples
- `rtv3d_ref_intrinsics` + `rtv3d_ringgrid_intrinsics` load `privatedata/<ds>/spec.json` (**local-only, gitignored** — the repo is public, so device specs stay as private as the datasets; same policy as `registry/private.json`) and seed via `device_seed::scheimpflug_seed`.
- Deleted env knobs: `RTV3D_REF_FOCAL`, `RTV3D_RINGGRID_FOCAL`, `RTV3D_RINGGRID_TILT_X` (including the historical focal *sweep* — the spec provides the focal now).
- Also carries the pending `.claude/CLAUDE.md` engineering-principles section and the backlog/ROADMAP status notes.

## Gate results (spec-derived seeds, no env vars)

- **rtv3d_ref: GATE PASS** — all 6 cameras ≤ 0.5 px (worst cam3 0.484 px; oracle parity elsewhere).
- **rtv3d_ringgrid: 5/6 pass; cam1 = 0.5008 px** — verified **pre-existing and seed-independent**: the pristine `main` example produces bit-identical per-camera numbers (seeds 1142.9 px and 1150.0 px also give identical results). This knife edge is the ringgrid ellipse-center-bias floor, owned by **Q3-RINGGRID-BIAS**; the gate is deliberately not relaxed.

## Verification

- `cargo fmt/clippy/test/doc` all green (workspace, all features, `-D warnings`).
- Both examples run end-to-end from `spec.json`; outputs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
