### PR TITLE
S3: extrinsics + hand-eye seeds from the device-spec mechanical layout

### DIFF
--- a/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
@@ -189,8 +189,7 @@ fn main() -> Result<()> {
     let intr_opt;
     {
         let step_t = Instant::now();
-        let intr_init =
-            rh::step_intrinsics_init_all_with_seed(&mut rig_session, manual_init, None)?;
+        let _ = rh::step_intrinsics_init_all_with_seed(&mut rig_session, manual_init, None)?;
         println!(
             "  step_intrinsics_init_all_with_seed: {:.2?}",
             step_t.elapsed()
@@ -221,15 +220,13 @@ fn main() -> Result<()> {
         let step_t = Instant::now();
         match &spec {
             // Spec mode: nominal cam_se3_rig mounts from the mechanical
-            // layout, per-view rig_se3_target anchored on the measured
-            // per-camera target poses (ADR 0011 couples the two).
+            // layout, per-view rig_se3_target anchored on the *optimized*
+            // per-camera target poses — the same refined poses the unseeded
+            // rig init consumes (ADR 0011 couples the two fields).
             Some(spec) => {
-                let rig_seed = device_seed::rig_layout_seed(
-                    spec,
-                    &camera_ids,
-                    &intr_init.per_cam_target_poses,
-                )
-                .context("derive rig layout seed from device spec")?;
+                let rig_seed =
+                    device_seed::rig_layout_seed(spec, &camera_ids, &intr_opt.per_cam_target_poses)
+                        .context("derive rig layout seed from device spec")?;
                 let _rig_init = rh::step_rig_init_with_seed(&mut rig_session, rig_seed)?;
                 println!(
                     "  step_rig_init_with_seed (spec layout): {:.2?}",
@@ -267,10 +264,14 @@ fn main() -> Result<()> {
             }
             // RTV3D_HANDEYE flipped the mode away from the spec's mount (the
             // convention comparison experiment) — fall back to the linear fit.
-            Some(Err(e)) => {
+            // Any other derivation error means the spec is malformed: fail.
+            Some(Err(e @ device_seed::DeviceSeedError::HandeyeModeMismatch { .. })) => {
                 eprintln!("warning: {e}; falling back to unseeded hand-eye init");
                 let _he_init = rh::step_handeye_init(&mut rig_session, None)?;
                 println!("  step_handeye_init: {:.2?}", step_t.elapsed());
+            }
+            Some(Err(e)) => {
+                return Err(e).context("derive hand-eye seed from device spec");
             }
             None => {
                 let _he_init = rh::step_handeye_init(&mut rig_session, None)?;

--- a/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
@@ -25,9 +25,12 @@
 //! - `CELL_SIZE_MM`    — ChArUco cell pitch (default 5.2). The dataset ships
 //!   conflicting specs (4.8 vs 5.2); run both and let the extrinsic
 //!   translation norms / plane distances against the oracle discriminate.
-//! - `RTV3D_SEED`      — `generic` (default; fx=2000, centered pp, zero tilt)
-//!   or `oracle` (seed K/dist/tilt from artifacts.json; cam 5 falls back to
-//!   the generic seed because the oracle entry is degenerate).
+//! - `RTV3D_SEED`      — `spec` (default; intrinsics + rig extrinsics +
+//!   hand-eye seeds derived from the dataset's `spec.json` device spec, ADR
+//!   0023), `generic` (bootstrap comparison path: fx=2000, centered pp, zero
+//!   tilt, unseeded rig/hand-eye init) or `oracle` (seed K/dist/tilt from
+//!   artifacts.json; cam 5 falls back to the generic seed because the oracle
+//!   entry is degenerate).
 //!
 //! Run:
 //! `RTV3D_DATA_DIR=privatedata/rtv3d cargo run --manifest-path
@@ -40,6 +43,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use vision_calibration::{
+    device_seed::{self, DEVICE_SPEC_FILENAME, DeviceSpec},
     rig_handeye::{
         self as rh, RigHandeyeConfig, RigHandeyeIntrinsicsManualInit, RigHandeyeProblem, SensorMode,
     },
@@ -78,9 +82,25 @@ fn main() -> Result<()> {
         .transpose()
         .context("CELL_SIZE_MM must be a number")?
         .unwrap_or(5.2);
-    let seed_mode = std::env::var("RTV3D_SEED").unwrap_or_else(|_| "generic".to_string());
+    let seed_mode = std::env::var("RTV3D_SEED").unwrap_or_else(|_| "spec".to_string());
     println!("data dir = {}", data_dir.display());
     println!("cell size = {cell_size_mm} mm, seed = {seed_mode}");
+
+    // Device spec (ADR 0023) — required for the default `spec` seed mode;
+    // `RTV3D_SEED=generic|oracle` keeps the bootstrap comparison paths.
+    let spec: Option<DeviceSpec> = if seed_mode == "spec" {
+        let spec_path = data_dir.join(DEVICE_SPEC_FILENAME);
+        Some(DeviceSpec::from_path(&spec_path).with_context(|| {
+            format!(
+                "load device spec {} (or set RTV3D_SEED=generic for the bootstrap path)",
+                spec_path.display()
+            )
+        })?)
+    } else {
+        None
+    };
+    let camera_ids: Vec<String> = (0..NUM_CAMERAS).map(|i| format!("cam{i}")).collect();
+    let camera_ids: Vec<&str> = camera_ids.iter().map(String::as_str).collect();
 
     let oracle = load_oracle(&data_dir.join("artifacts.json"))
         .context("load artifacts.json oracle")
@@ -115,7 +135,13 @@ fn main() -> Result<()> {
     let mut rig_session = CalibrationSession::<RigHandeyeProblem>::with_description("rtv3d_rig");
     rig_session.set_input(handeye_dataset)?;
 
-    let manual_init = build_intrinsics_seed(&seed_mode, oracle.as_ref(), tile_w, tile_h)?;
+    let manual_init = match &spec {
+        // Spec mode: fx=fy from lens focal / pixel pitch, pp at resolution
+        // center, nominal mount tilt; distortion auto (ADR 0023).
+        Some(spec) => device_seed::rig_intrinsics_seed(spec, &camera_ids)
+            .context("derive rig intrinsics seed from device spec")?,
+        None => build_intrinsics_seed(&seed_mode, oracle.as_ref(), tile_w, tile_h)?,
+    };
 
     let mut cfg = RigHandeyeConfig::default();
     cfg.solver.max_iters = 200;
@@ -163,7 +189,8 @@ fn main() -> Result<()> {
     let intr_opt;
     {
         let step_t = Instant::now();
-        let _ = rh::step_intrinsics_init_all_with_seed(&mut rig_session, manual_init, None)?;
+        let intr_init =
+            rh::step_intrinsics_init_all_with_seed(&mut rig_session, manual_init, None)?;
         println!(
             "  step_intrinsics_init_all_with_seed: {:.2?}",
             step_t.elapsed()
@@ -192,8 +219,28 @@ fn main() -> Result<()> {
             }
         }
         let step_t = Instant::now();
-        let _rig_init = rh::step_rig_init(&mut rig_session)?;
-        println!("  step_rig_init: {:.2?}", step_t.elapsed());
+        match &spec {
+            // Spec mode: nominal cam_se3_rig mounts from the mechanical
+            // layout, per-view rig_se3_target anchored on the measured
+            // per-camera target poses (ADR 0011 couples the two).
+            Some(spec) => {
+                let rig_seed = device_seed::rig_layout_seed(
+                    spec,
+                    &camera_ids,
+                    &intr_init.per_cam_target_poses,
+                )
+                .context("derive rig layout seed from device spec")?;
+                let _rig_init = rh::step_rig_init_with_seed(&mut rig_session, rig_seed)?;
+                println!(
+                    "  step_rig_init_with_seed (spec layout): {:.2?}",
+                    step_t.elapsed()
+                );
+            }
+            None => {
+                let _rig_init = rh::step_rig_init(&mut rig_session)?;
+                println!("  step_rig_init: {:.2?}", step_t.elapsed());
+            }
+        }
         let step_t = Instant::now();
         let rig_opt = rh::step_rig_optimize(&mut rig_session, None)?;
         println!(
@@ -205,8 +252,31 @@ fn main() -> Result<()> {
             println!("    cam {i} rig reproj = {e:.3} px");
         }
         let step_t = Instant::now();
-        let _he_init = rh::step_handeye_init(&mut rig_session, None)?;
-        println!("  step_handeye_init: {:.2?}", step_t.elapsed());
+        let handeye_mode = rig_session.config.handeye_init.handeye_mode;
+        match spec
+            .as_ref()
+            .map(|s| device_seed::handeye_seed(s, handeye_mode))
+        {
+            // Spec mode with a mount matching the configured hand-eye mode.
+            Some(Ok(he_seed)) => {
+                let _he_init = rh::step_handeye_init_with_seed(&mut rig_session, he_seed, None)?;
+                println!(
+                    "  step_handeye_init_with_seed (spec mount): {:.2?}",
+                    step_t.elapsed()
+                );
+            }
+            // RTV3D_HANDEYE flipped the mode away from the spec's mount (the
+            // convention comparison experiment) — fall back to the linear fit.
+            Some(Err(e)) => {
+                eprintln!("warning: {e}; falling back to unseeded hand-eye init");
+                let _he_init = rh::step_handeye_init(&mut rig_session, None)?;
+                println!("  step_handeye_init: {:.2?}", step_t.elapsed());
+            }
+            None => {
+                let _he_init = rh::step_handeye_init(&mut rig_session, None)?;
+                println!("  step_handeye_init: {:.2?}", step_t.elapsed());
+            }
+        }
         let step_t = Instant::now();
         let _he_opt = rh::step_handeye_optimize(&mut rig_session, None)?;
         println!("  step_handeye_optimize: {:.2?}", step_t.elapsed());

--- a/crates/vision-calibration-pipeline/src/device_seed.rs
+++ b/crates/vision-calibration-pipeline/src/device_seed.rs
@@ -20,7 +20,9 @@
 use vision_calibration_core::{FxFyCxCySkew, Iso3, Real, ScheimpflugParams};
 use vision_calibration_optim::HandEyeMode;
 
-use crate::rig_handeye::{RigHandeyeHandeyeManualInit, RigHandeyeIntrinsicsManualInit};
+use crate::rig_handeye::{
+    RigHandeyeHandeyeManualInit, RigHandeyeIntrinsicsManualInit, RigHandeyeRigManualInit,
+};
 use crate::scheimpflug_intrinsics::ScheimpflugManualInit;
 
 // The schema types every consumer of this module needs, re-exported so the
@@ -64,6 +66,14 @@ pub enum DeviceSeedError {
         spec: HandEyeMode,
         /// Mode the caller's config expects.
         expected: HandEyeMode,
+    },
+
+    /// A view has no observed target pose in any camera, so its
+    /// `rig_se3_target` cannot be anchored.
+    #[error("view {view} has no target pose in any camera")]
+    ViewWithoutTargetPose {
+        /// The offending view index.
+        view: usize,
     },
 }
 
@@ -134,6 +144,40 @@ pub fn nominal_cam_se3_rig(
             Ok(iso3_from_nominal(&mount.rig_se3_cam).inverse())
         })
         .collect()
+}
+
+/// Full rig-stage seed: nominal `cam_se3_rig` from the mechanical layout,
+/// combined with per-view `rig_se3_target` anchored on measured per-camera
+/// target poses (ADR 0011 couples the two fields — both must be seeded
+/// together).
+///
+/// `per_cam_target_poses` is `[view][cam] -> Option<cam_se3_target>` in the
+/// same camera order as `camera_ids` (the shape returned by
+/// `step_intrinsics_init_all*`). For each view, the first camera with an
+/// observed pose anchors it:
+/// `rig_se3_target = cam_se3_rig[c]⁻¹ · cam_se3_target[c]`.
+pub fn rig_layout_seed(
+    spec: &DeviceSpec,
+    camera_ids: &[&str],
+    per_cam_target_poses: &[Vec<Option<Iso3>>],
+) -> Result<RigHandeyeRigManualInit, DeviceSeedError> {
+    let cam_se3_rig = nominal_cam_se3_rig(spec, camera_ids)?;
+    let rig_se3_target = per_cam_target_poses
+        .iter()
+        .enumerate()
+        .map(|(view, cams)| {
+            cams.iter()
+                .zip(&cam_se3_rig)
+                .find_map(|(pose, cam_se3_rig)| {
+                    pose.map(|cam_se3_target| cam_se3_rig.inverse() * cam_se3_target)
+                })
+                .ok_or(DeviceSeedError::ViewWithoutTargetPose { view })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(RigHandeyeRigManualInit {
+        cam_se3_rig: Some(cam_se3_rig),
+        rig_se3_target: Some(rig_se3_target),
+    })
 }
 
 /// Hand-eye stage seed from the mechanical mount.
@@ -373,6 +417,38 @@ mod tests {
         assert!(matches!(
             nominal_cam_se3_rig(&no_rig, &["cam0"]),
             Err(DeviceSeedError::MissingRigLayout)
+        ));
+    }
+
+    #[test]
+    fn rig_layout_seed_anchors_views_on_first_available_camera() {
+        let spec = rig_spec();
+        // cam1's mount is identity, so a view anchored on cam1 has
+        // rig_se3_target == cam_se3_target directly.
+        let target_pose = iso3_from_nominal(&NominalPoseSpec {
+            rpy_deg: [0.0, 0.0, 0.0],
+            translation_mm: [10.0, 20.0, 500.0],
+        });
+        // View 0: only cam0 sees the target; view 1: only cam1.
+        let poses = vec![vec![Some(target_pose), None], vec![None, Some(target_pose)]];
+        let seed = rig_layout_seed(&spec, &["cam0", "cam1"], &poses).unwrap();
+        let cam_se3_rig = seed.cam_se3_rig.unwrap();
+        let rig_se3_target = seed.rig_se3_target.unwrap();
+        assert_eq!(rig_se3_target.len(), 2);
+        // View 1 (identity mount): rig_se3_target == the raw target pose.
+        assert!(
+            (rig_se3_target[1].translation.vector - target_pose.translation.vector).norm() < 1e-12
+        );
+        // View 0: rig_se3_target = cam_se3_rig[0]⁻¹ · cam_se3_target —
+        // consistency: cam_se3_rig[0] · rig_se3_target[0] == target pose.
+        let recomposed = cam_se3_rig[0] * rig_se3_target[0];
+        assert!((recomposed.translation.vector - target_pose.translation.vector).norm() < 1e-12);
+
+        // A view with no observation in any camera is a typed error.
+        let holey = vec![vec![None, None]];
+        assert!(matches!(
+            rig_layout_seed(&spec, &["cam0", "cam1"], &holey),
+            Err(DeviceSeedError::ViewWithoutTargetPose { view: 0 })
         ));
     }
 

--- a/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
@@ -170,6 +170,12 @@ pub struct RigHandeyeIntrinsicsOptimizeAllResult {
     pub per_cam_sensors: Option<Vec<ScheimpflugParams>>,
     /// Per-camera mean reprojection error in pixels.
     pub per_cam_reproj_errors: Vec<f64>,
+    /// Per-camera target poses refined alongside the intrinsics:
+    /// `[view][cam] -> Option<Iso3>` (`camera_se3_target`). This is what the
+    /// unseeded rig init consumes; seeded rig inits (e.g.
+    /// [`crate::device_seed::rig_layout_seed`]) should anchor on these, not
+    /// on the coarser init-time poses.
+    pub per_cam_target_poses: Vec<Vec<Option<Iso3>>>,
 }
 
 /// Typed return value of [`step_rig_init`] / [`step_rig_init_with_seed`] for rig
@@ -558,7 +564,7 @@ pub fn step_intrinsics_optimize_all(
 
     session.state.per_cam_intrinsics = Some(optimized_cameras.clone());
     session.state.per_cam_sensors = optimized_sensors.clone();
-    session.state.per_cam_target_poses = Some(per_cam_target_poses);
+    session.state.per_cam_target_poses = Some(per_cam_target_poses.clone());
     session.state.per_cam_reproj_errors = Some(per_cam_reproj_errors.clone());
 
     let avg_error: f64 =
@@ -572,6 +578,7 @@ pub fn step_intrinsics_optimize_all(
         per_cam_intrinsics: optimized_cameras,
         per_cam_sensors: optimized_sensors,
         per_cam_reproj_errors,
+        per_cam_target_poses,
     })
 }
 

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -161,6 +161,7 @@ pub mod device_seed {
         handeye_seed,
         nominal_cam_se3_rig,
         rig_intrinsics_seed,
+        rig_layout_seed,
         scheimpflug_seed,
     };
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,9 +72,11 @@ the `RTV3D_RINGGRID_FOCAL` env sweep) → S3 (extrinsics + hand-eye from layout)
 → S4 (one-command acceptance harness over all registered datasets; absent
 datasets print `UNAVAILABLE`, never a silent pass; the failing 0.4 px
 from-scratch gate demotes to informational per the parked V7).
-**Status 2026-07-02: S1 + S2 shipped** (ADR 0023, `device_seed` facade module,
-both intrinsics examples spec-driven; ringgrid cam1 sits at 0.5008 px — a
-pre-existing, seed-independent knife edge owned by Q3).
+**Status 2026-07-02: S1 + S2 + S3 shipped** (ADR 0023, `device_seed` facade
+module, both intrinsics examples spec-driven, `rtv3d_rig` layout/hand-eye
+seeded via `RTV3D_SEED=spec` default with bootstrap kept behind the flag;
+ringgrid cam1 sits at 0.5008 px — a pre-existing, seed-independent knife edge
+owned by Q3).
 
 ### Track Q — Algorithmic soundness: proofs + regression
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,9 +41,21 @@ acceptance route** (ADR 0022); from-scratch stays experimental.
   0.5008 px **independent of the seed** (1142.9 and 1150.0 px seeds give the
   identical value; pre-existing knife-edge, tracked under Q3 ringgrid bias —
   the gate is not relaxed).
-- [ ] S3-SPEC-EXTRINSICS - Extrinsics + hand-eye seeds from the mechanical
-  layout, wired into `rtv3d_rig.rs` (currently bootstrapped; keep bootstrap
-  behind a flag for comparison). Gate: the beat-the-oracle criteria unchanged.
+- [x] S3-SPEC-EXTRINSICS - **Done 2026-07-02.** New
+  `device_seed::rig_layout_seed(spec, ids, per_cam_target_poses)` builds the
+  coupled `RigHandeyeRigManualInit` (nominal `cam_se3_rig` mounts from the
+  layout; per-view `rig_se3_target` anchored on the first camera with a
+  measured target pose — the ADR 0011 coupling honored). `rtv3d_rig.rs` now
+  defaults to `RTV3D_SEED=spec`: intrinsics via `rig_intrinsics_seed`, rig
+  stage via `step_rig_init_with_seed`, hand-eye via
+  `step_handeye_init_with_seed` (spec mount, mode-checked; warns and falls
+  back to the linear fit when `RTV3D_HANDEYE` flips the convention
+  experiment). Bootstrap kept behind `RTV3D_SEED=generic|oracle`. Local rtv3d
+  `spec.json` carries the hexagonal layout (yaw ±57.5°/±122.4°/179.7°, cam0
+  identity reference, EyeToHand `rig_se3_base` |t|≈254 mm) as drawing-grade
+  nominals. Gate: all three beat-the-oracle verdicts PASS in **both** seed
+  modes, converging to the same optimum (per-cam hand-eye reproj
+  bit-identical), confirming seeds change the start point, not the answer.
 - [ ] S4-ACCEPT-HARNESS - One-command acceptance runner in
   `vision-calibration-bench`: iterate all registered datasets, run the seeded
   official route, evaluate gates; exit 0 iff all on-disk datasets pass; absent


### PR DESCRIPTION
## Summary

Track S, session S3: extrinsics + hand-eye seeds from the device spec's mechanical layout, wired into the full rtv3d rig calibration. Completes the seed-derivation surface started in #88.

### Pipeline (`device_seed`)
- **`rig_layout_seed(spec, camera_ids, per_cam_target_poses) -> RigHandeyeRigManualInit`** — builds the *coupled* rig-stage seed required by ADR 0011: nominal `cam_se3_rig` from the mechanical layout, and per-view `rig_se3_target` anchored on the first camera with a measured target pose (`cam_se3_rig[c]⁻¹ · cam_se3_target[c]`). Views with no observation in any camera are a typed error (`ViewWithoutTargetPose`).
- Facade re-export updated; unit test covers anchoring on different cameras per view, frame-consistency round-trip, and the error path.

### Example (`rtv3d_rig.rs`)
- **`RTV3D_SEED=spec` is the new default**: intrinsics seeds via `rig_intrinsics_seed` (fx=fy from focal/pitch, nominal tilt, distortion auto), rig stage via `step_rig_init_with_seed` with the layout seed, hand-eye via `step_handeye_init_with_seed` with the spec mount (mode-checked; when the `RTV3D_HANDEYE` convention experiment flips the mode away from the spec's mount, it warns and falls back to the linear fit rather than seeding the wrong transform).
- **Bootstrap kept behind the flag** (`RTV3D_SEED=generic|oracle`) per the backlog requirement.
- Local gitignored `privatedata/rtv3d/spec.json` (public repo policy from #88) carries the drawing-grade nominals: hexagonal camera arrangement (yaw ±57.5°/±122.4°/179.7°, cam0 identity reference), EyeToHand `rig_se3_base` |t|≈254 mm, focal 14 mm / 7 µm ≈ 2000 px.

## Gate results (beat-the-oracle criteria unchanged)

Spec-seeded run — **all three verdicts PASS**:
- reprojection (cams 0–4 < oracle, cam 5 sane): joint BA 1.00–1.45 px, all YES
- extrinsic scale (cams 1–4, |t| within 10 %): PASS
- laser plane fit (σ < oracle, all cams): PASS

The solve converges to the same optimum as the bootstrap path (per-camera hand-eye reprojection bit-identical to the pre-change baseline), confirming the seeds change the starting point, not the answer. `RTV3D_SEED=generic` re-verified green as the comparison path.

## Verification
- `cargo fmt/clippy/test/doc` green (workspace, all features, `-D warnings`).
- `rtv3d_rig` run logs archived in-session for both seed modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
