### PR TITLE
Q1: proof-pack standard + planar-intrinsics template pack

### DIFF
--- a/crates/vision-calibration-core/src/synthetic/planar.rs
+++ b/crates/vision-calibration-core/src/synthetic/planar.rs
@@ -5,9 +5,11 @@
 //! [`crate::CorrespondenceView`] instances.
 
 use crate::{
-    Camera, CorrespondenceView, Error, Iso3, Pt2, Pt3, Real,
+    Camera, CorrespondenceView, Error, Iso3, Pt2, Pt3, Real, Vec2,
     models::{DistortionModel, IntrinsicsModel, ProjectionModel, SensorModel},
 };
+
+use super::noise::UniformPixelNoise;
 use nalgebra::{Translation3, UnitQuaternion, Vector3};
 use std::ops::RangeInclusive;
 
@@ -181,6 +183,43 @@ where
     cam_from_target
         .iter()
         .map(|pose| project_view_all(camera, pose, target_points))
+        .collect()
+}
+
+/// Project multiple views and apply deterministic pixel noise — the
+/// standard input for a synthetic-GT matrix test (`docs/notes/README.md`):
+/// sweep a ground-truth parameter grid × noise levels, feed each cell
+/// through the solver under test, and assert recovery within tolerance.
+///
+/// Noise is keyed on `(view_idx, point_idx)`, so results are stable across
+/// platforms and runs (see [`UniformPixelNoise`]).
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidInput`] if any point in any view is not projectable.
+pub fn project_views_noisy<P, D, Sm, K>(
+    camera: &Camera<Real, P, D, Sm, K>,
+    target_points: &[Pt3],
+    cam_from_target: &[Iso3],
+    noise: &UniformPixelNoise,
+) -> Result<Vec<CorrespondenceView>, Error>
+where
+    P: ProjectionModel<Real>,
+    D: DistortionModel<Real>,
+    Sm: SensorModel<Real>,
+    K: IntrinsicsModel<Real>,
+{
+    cam_from_target
+        .iter()
+        .enumerate()
+        .map(|(view_idx, pose)| {
+            let mut view = project_view_all(camera, pose, target_points)?;
+            for (point_idx, uv) in view.points_2d.iter_mut().enumerate() {
+                let noisy = noise.apply(view_idx, point_idx, Vec2::new(uv.x, uv.y));
+                *uv = Pt2::new(noisy.x, noisy.y);
+            }
+            Ok(view)
+        })
         .collect()
 }
 

--- a/crates/vision-calibration-optim/src/problems/laserline_bundle.rs
+++ b/crates/vision-calibration-optim/src/problems/laserline_bundle.rs
@@ -1014,7 +1014,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO: Fix after laserline pipeline integration"]
     fn ir_uses_s2_for_plane_normal() {
         let dataset = vec![View::new(
             CorrespondenceView::new(

--- a/crates/vision-calibration/tests/planar_intrinsics_matrix.rs
+++ b/crates/vision-calibration/tests/planar_intrinsics_matrix.rs
@@ -1,0 +1,180 @@
+//! Synthetic-GT matrix test for planar intrinsics — the template proof-pack
+//! test (Q1, `docs/notes/README.md`; math note:
+//! `docs/notes/planar-intrinsics.md`).
+//!
+//! Ground-truth grid × noise levels: every cell builds an exact synthetic
+//! dataset via `vision_calibration::synthetic`, runs the standard
+//! `step_init → step_optimize` pipeline, and asserts parameter recovery and
+//! a reprojection error consistent with the injected noise floor.
+
+#![allow(missing_docs)]
+
+use nalgebra::{Rotation3, Translation3};
+use vision_calibration::core::{
+    BrownConrady5, Camera, FxFyCxCySkew, IdentitySensor, IntrinsicsParams, Iso3, Pinhole,
+    PlanarDataset, Pt3, View,
+};
+use vision_calibration::planar_intrinsics::{PlanarIntrinsicsProblem, step_init, step_optimize};
+use vision_calibration::session::CalibrationSession;
+use vision_calibration::synthetic::{noise::UniformPixelNoise, planar};
+
+/// One cell of the ground-truth grid.
+struct GtCell {
+    fx: f64,
+    fy: f64,
+    k1: f64,
+    k2: f64,
+}
+
+/// Board + pose set shared by every cell: an 11×9 grid of 25 mm cells seen
+/// from 8 diverse orientations (mixed pitch/yaw, varying distance). Pose
+/// diversity matters — near-coplanar plane normals leave the image of the
+/// absolute conic underconstrained (see the math note, §identifiability).
+fn board() -> Vec<Pt3> {
+    planar::grid_points(11, 9, 0.025)
+}
+
+fn poses() -> Vec<Iso3> {
+    let angles: [(f64, f64); 8] = [
+        (0.00, 0.00),
+        (0.18, -0.06),
+        (-0.15, 0.10),
+        (0.08, 0.20),
+        (-0.06, -0.18),
+        (0.22, 0.14),
+        (-0.20, -0.10),
+        (0.12, -0.22),
+    ];
+    angles
+        .iter()
+        .enumerate()
+        .map(|(i, (pitch, yaw))| {
+            // Center the 0.25 × 0.2 m board on the optical axis, distance
+            // ramping 0.55 → 0.90 m.
+            Iso3::from_parts(
+                Translation3::new(-0.125, -0.1, 0.55 + 0.05 * i as f64),
+                Rotation3::from_euler_angles(*pitch, *yaw, 0.0).into(),
+            )
+        })
+        .collect()
+}
+
+/// Run the standard planar pipeline on one synthetic dataset; return
+/// (recovered intrinsics, recovered distortion, mean reprojection px).
+fn solve(dataset: PlanarDataset) -> (FxFyCxCySkew<f64>, BrownConrady5<f64>, f64) {
+    let mut session = CalibrationSession::<PlanarIntrinsicsProblem>::new();
+    session.set_input(dataset).expect("input");
+    step_init(&mut session, None).expect("init");
+    step_optimize(&mut session, None).expect("optimize");
+    let out = session.output().expect("output");
+    let IntrinsicsParams::FxFyCxCySkew { params: intr } = out.params.camera.intrinsics;
+    let dist = match &out.params.camera.distortion {
+        vision_calibration::core::DistortionParams::BrownConrady5 { params } => *params,
+        other => panic!("unexpected distortion params: {other:?}"),
+    };
+    (intr, dist, out.mean_reproj_error)
+}
+
+#[test]
+fn planar_intrinsics_recovers_gt_across_grid_and_noise() {
+    // Ground-truth grid: two focal regimes × three distortion strengths.
+    let grid: Vec<GtCell> = [
+        (800.0, 810.0, 0.0, 0.0),
+        (800.0, 810.0, -0.20, 0.08),
+        (800.0, 810.0, -0.40, 0.18),
+        (1400.0, 1385.0, 0.0, 0.0),
+        (1400.0, 1385.0, -0.20, 0.08),
+        (1400.0, 1385.0, -0.40, 0.18),
+    ]
+    .iter()
+    .map(|&(fx, fy, k1, k2)| GtCell { fx, fy, k1, k2 })
+    .collect();
+    // Uniform per-axis pixel noise amplitudes (deterministic, seeded).
+    let noise_levels = [0.0, 0.15, 0.30];
+
+    let board = board();
+    let poses = poses();
+
+    for cell in &grid {
+        for &noise_px in &noise_levels {
+            let gt_intr = FxFyCxCySkew {
+                fx: cell.fx,
+                fy: cell.fy,
+                cx: 366.0,
+                cy: 263.0,
+                skew: 0.0,
+            };
+            let gt_dist = BrownConrady5 {
+                k1: cell.k1,
+                k2: cell.k2,
+                k3: 0.0,
+                p1: 0.0,
+                p2: 0.0,
+                iters: 8,
+            };
+            let camera = Camera::new(Pinhole, gt_dist, IdentitySensor, gt_intr);
+            let noise = UniformPixelNoise {
+                seed: 42,
+                max_abs_px: noise_px,
+            };
+            let views = planar::project_views_noisy(&camera, &board, &poses, &noise)
+                .expect("all board points projectable")
+                .into_iter()
+                .map(View::without_meta)
+                .collect();
+            let dataset = PlanarDataset::new(views).expect("dataset");
+
+            let (intr, dist, mean_reproj) = solve(dataset);
+
+            let label = format!("cell fx={} k1={} noise={noise_px}px", cell.fx, cell.k1);
+            // Focal recovery: exact-data cells must be tight; noisy cells
+            // scale with the noise amplitude (empirical bound with margin).
+            let focal_tol = if noise_px == 0.0 { 0.002 } else { 0.02 };
+            assert!(
+                (intr.fx - gt_intr.fx).abs() / gt_intr.fx < focal_tol,
+                "{label}: fx {} vs gt {}",
+                intr.fx,
+                gt_intr.fx
+            );
+            assert!(
+                (intr.fy - gt_intr.fy).abs() / gt_intr.fy < focal_tol,
+                "{label}: fy {} vs gt {}",
+                intr.fy,
+                gt_intr.fy
+            );
+            // Principal point within ~noise-scaled pixels.
+            let pp_tol = if noise_px == 0.0 { 0.5 } else { 8.0 };
+            assert!(
+                (intr.cx - gt_intr.cx).abs() < pp_tol && (intr.cy - gt_intr.cy).abs() < pp_tol,
+                "{label}: pp ({}, {}) vs gt ({}, {})",
+                intr.cx,
+                intr.cy,
+                gt_intr.cx,
+                gt_intr.cy
+            );
+            // Distortion recovery (k3/p1/p2 fixed at zero by default config,
+            // matching the GT).
+            let k_tol = if noise_px == 0.0 { 0.005 } else { 0.05 };
+            assert!(
+                (dist.k1 - gt_dist.k1).abs() < k_tol,
+                "{label}: k1 {} vs gt {}",
+                dist.k1,
+                gt_dist.k1
+            );
+            // Residual floor: uniform noise in [-a, a] per axis has expected
+            // error-norm mean ≈ 0.765·a; allow generous headroom, and demand
+            // near-zero residuals on exact data.
+            // (1e-4 px on exact data: comfortably above the solver's
+            // convergence tolerance, far below any physical noise floor.)
+            let reproj_bound = if noise_px == 0.0 {
+                1e-4
+            } else {
+                noise_px * 0.9 + 0.02
+            };
+            assert!(
+                mean_reproj <= reproj_bound,
+                "{label}: mean reproj {mean_reproj} > bound {reproj_bound}"
+            );
+        }
+    }
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -92,12 +92,19 @@ Scheimpflug intrinsics (seeded), rig extrinsics, hand-eye, laserline bundle,
 ringgrid detection/bias, rectification (short note only — C4 gate exists),
 two-view/triangulation.
 
-- [ ] Q1-PROOF-STANDARD - Codify the standard in `docs/notes/README.md` +
-  deliver the planar-intrinsics pack as the template (generalize the
-  `seeded_coarse_prior_converges_on_strong_tilt_distortion` pattern into a
-  reusable matrix-test helper in the synthetic module). Also fix or convert
-  the one `#[ignore]`d test (`optim/src/problems/laserline_bundle.rs`,
-  "Fix after laserline pipeline integration") into a tracked item.
+- [x] Q1-PROOF-STANDARD - **Done 2026-07-02.** Standard codified in
+  `docs/notes/README.md` (math note + synthetic-GT matrix test + property
+  tests where real invariants exist + committed Fit record; basin study for
+  init routes). Template pack delivered: `docs/notes/planar-intrinsics.md`
+  (model, Zhang init, cost, identifiability/degeneracies incl. the
+  plane-diversity and k3-collinearity arguments, gauge, noise sensitivity)
+  + new reusable `synthetic::planar::project_views_noisy` (deterministic
+  noise over projected views) + matrix test
+  `crates/vision-calibration/tests/planar_intrinsics_matrix.rs` (2 focal
+  regimes × 3 distortion strengths × 3 noise levels, 18 cells in ~4 s;
+  asserts focal/pp/k1 recovery + residual noise floor per cell). The
+  `#[ignore]`d laserline IR test passes as-is — its "fix after laserline
+  pipeline integration" TODO predates B3c-3 — so it is simply re-enabled.
 - [ ] Q2-REGRESSION-WIRING - (after S4; deliberately early so Q3/Q4/Q5/Q7 are
   regression-guarded) Commit baseline Fit records for every on-disk dataset
   via the S4 runner; add regression gates (fail if RMS worsens beyond stated

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -1,0 +1,39 @@
+# Math notes — the proof-pack standard
+
+Track Q of the production-grade program requires a **proof pack** per
+algorithm family before v1.0. A proof pack is the minimum evidence that a
+family is *sound* — not merely "tests pass", but "we can state what the
+algorithm assumes, what it cannot observe, and how it degrades":
+
+1. **Math note** (`docs/notes/<family>.md`, 1–3 pages): the model
+   equations, the optimized cost, identifiability / degeneracy analysis
+   (what is unobservable and why), gauge freedoms, and noise sensitivity.
+   Written against the code as shipped — cite the modules that implement
+   each equation.
+2. **Synthetic-GT matrix test**: a ground-truth parameter grid × noise
+   levels, every cell built with `vision_calibration::synthetic`
+   (deterministic noise via `UniformPixelNoise`,
+   `planar::project_views_noisy`) and pushed through the *standard*
+   pipeline. Assert parameter recovery within stated tolerances and a
+   residual consistent with the injected noise floor. Template:
+   `crates/vision-calibration/tests/planar_intrinsics_matrix.rs`.
+3. **Property tests** where a real invariant exists (round-trips, gauge
+   invariance, rectification `|Δv|` bounds) — not where they would only
+   restate the implementation.
+4. **Committed regression Fit record + gate** via the bench machinery
+   (`calib-bench accept` per-entry gates today; Q2 adds baseline records
+   and drift gates).
+
+Initialization routines additionally get a **convergence-basin study**
+(perturb the seed over a radius grid, measure gate-pass rate — Q6), the
+empirical evidence behind ADR 0022.
+
+Families (backlog Q1/Q8): planar intrinsics (template, this directory),
+Scheimpflug intrinsics (seeded), rig extrinsics, hand-eye, laserline
+bundle, ringgrid detection/bias (Q3), rectification (short note — the C4
+gate exists), two-view/triangulation.
+
+## Notes
+
+- [Planar intrinsics](planar-intrinsics.md) — Zhang init + Brown–Conrady
+  refinement (the template pack).

--- a/docs/notes/planar-intrinsics.md
+++ b/docs/notes/planar-intrinsics.md
@@ -1,0 +1,95 @@
+# Planar intrinsics — proof pack
+
+Family: single-camera intrinsics from planar-target views
+(`PlanarIntrinsicsProblem`; init in `vision-calibration-linear`, refinement
+in `vision-calibration-optim::problems::planar_intrinsics`).
+
+## Model
+
+Composable camera (ADR 0005), planar specialization:
+
+```
+pixel = K( distort( project(X_c) ) ),   X_c = T_C_T · X_t
+```
+
+- `project`: pinhole, `(x, y, z) ↦ (x/z, y/z)`.
+- `distort`: Brown–Conrady 5 on normalized coordinates,
+  `x_d = x(1 + k1 r² + k2 r⁴ + k3 r⁶) + 2 p1 x y + p2 (r² + 2x²)` (and
+  symmetrically for `y`), `r² = x² + y²`.
+- `K`: `u = fx·x_d + skew·y_d + cx`, `v = fy·y_d + cy`.
+- `T_C_T` (`camera_se3_target`, ADR 0009): one SE(3) pose per view; the
+  target frame is the board plane `z = 0`.
+
+## Initialization (Zhang)
+
+Per view, a Hartley-normalized DLT homography `H_i` maps board points to
+pixels. Writing `H = K [r1 r2 t]`, the orthonormality of `r1, r2` yields
+two linear constraints per view on the image of the absolute conic
+`ω = K⁻ᵀK⁻¹`; stacking views gives `V b = 0`, solved by SVD, and `K` is
+recovered from `ω` by Cholesky-style closed forms. Poses follow from
+`K⁻¹H` with unit-norm scaling; distortion is estimated iteratively by
+alternating a linear least-squares fit of `(k1, k2)` against the current
+undistorted projections (`linear::distortion_fit`).
+
+## Cost
+
+Non-linear refinement minimizes total squared reprojection error
+
+```
+E(K, d, {T_i}) = Σ_i Σ_j ρ( ‖ π(K, d, T_i · X_j) − u_ij ‖² )
+```
+
+over `fx, fy, cx, cy [, skew]`, the unfixed distortion coefficients, and
+all per-view poses (SE(3) manifold, ADR 0009); `ρ` is the configured
+robust loss (default: none; Huber for real detector tails). Factors are
+autodiff-generic (ADR 0008).
+
+## Identifiability and degeneracies
+
+- **View count**: each homography gives 2 constraints on `ω`. With skew
+  free, `K` has 5 DOF → ≥ 3 views; with `skew = 0` (our default), ≥ 2.
+  The pipeline requires ≥ 3 usable views.
+- **Plane-orientation diversity**: constraints from views whose plane
+  normals are (near-)parallel are (near-)dependent — a pose set that only
+  translates, or only rotates about the optical axis, leaves `ω` rank
+  deficient. This is why the matrix test's pose set mixes pitch and yaw.
+- **Fronto-parallel bias**: with little perspective foreshortening, focal
+  length trades off against target distance (`fx·z` nearly constant per
+  view); expect inflated focal variance, not a wrong minimum.
+- **Distortion collinearity**: over a limited radius range the monomials
+  `r², r⁴, r⁶` are nearly collinear, so `k3` is weakly identifiable unless
+  the corners reach deep into the image periphery — the rationale for
+  `fix_k3: true` by default (CLAUDE.md); enabling it on narrow-FOV data
+  degrades conditioning without improving fit.
+- **Principal point**: weakly observable under weak distortion + narrow
+  FOV (it trades against `t_x, t_y` per view); observability improves with
+  strong radial distortion, which pins the distortion center.
+
+## Gauge
+
+None global: the board fixes each view's target frame, `K` and `d` are
+shared, and every `T_i` is an independent free block. (Contrast with rig
+extrinsics, where a reference camera pins the rig frame.)
+
+## Noise sensitivity
+
+For iid pixel noise with per-axis std `σ` and `N ≫ #params` residuals, the
+post-fit mean reprojection approaches the noise floor (for uniform
+`[-a, a]` per-axis noise the expected error-norm mean is `≈ 0.765·a`) and
+parameter errors scale linearly in `σ` through `(JᵀJ)⁻¹`. Empirically
+(matrix test below): focal recovery within 2 % and `k1` within 0.05 at
+`a = 0.3 px` on an 8-view / 99-point board; exact data reproduces GT to
+solver tolerance (< 1e-4 px).
+
+## Evidence
+
+- **Matrix test**: `crates/vision-calibration/tests/planar_intrinsics_matrix.rs`
+  — GT grid (2 focal regimes × 3 distortion strengths) × noise
+  `{0, 0.15, 0.3} px`, standard `step_init → step_optimize` pipeline;
+  asserts focal/pp/k1 recovery and the residual noise floor per cell.
+- **Acceptance gates**: `calib-bench accept` — `stereo_left`/`stereo_right`
+  (planar entries) gated at ≤ 0.4 px per camera from measured baselines
+  (S4); Q2 adds committed Fit records with drift gates.
+- **Related**: ADR 0022 (the Scheimpflug sibling's seeded route and why
+  from-scratch is fragile there — the tilt↔focal↔distortion trade-off does
+  not arise in the frontal planar family).


### PR DESCRIPTION
## Summary

Track Q, session Q1: codifies the **proof-pack standard** and ships the planar-intrinsics pack as the template.

- **`docs/notes/README.md`** — the standard: math note + synthetic-GT matrix test + property tests (only where a real invariant exists) + committed regression Fit record; init routines additionally get a convergence-basin study (Q6).
- **`docs/notes/planar-intrinsics.md`** — template math note: model equations, Zhang init, the optimized cost, identifiability/degeneracy analysis (plane-orientation diversity requirement, fronto-parallel focal↔distance trade-off, `r²/r⁴/r⁶` collinearity as the documented rationale for `fix_k3: true`, weak principal-point observability), gauge, and noise sensitivity.
- **`synthetic::planar::project_views_noisy`** — the reusable matrix-test builder: projects GT views and applies deterministic (`UniformPixelNoise`) per-observation noise.
- **`tests/planar_intrinsics_matrix.rs`** — the template matrix test: 2 focal regimes × 3 distortion strengths × 3 noise levels (18 cells, ~4 s) through the standard `step_init → step_optimize` pipeline, asserting focal/pp/k1 recovery and the per-cell residual noise floor (exact data ≤ 1e-4 px; noisy cells bounded by the injected amplitude).
- **Re-enabled** the one `#[ignore]`d test in the workspace (`optim` laserline IR `ir_uses_s2_for_plane_normal`) — it passes; its TODO predates the laserline pipeline integration (B3c-3).

## Verification
- New matrix test green (18/18 cells); full workspace `fmt/clippy/test/doc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)