### PR TITLE
Q4: distortion-model selection on the Scheimpflug path

### DIFF
--- a/app/src/schemas/rig_extrinsics_config.json
+++ b/app/src/schemas/rig_extrinsics_config.json
@@ -33,6 +33,36 @@
       ],
       "type": "object"
     },
+    "DistortionKind": {
+      "description": "Distortion slot of a [`CameraModelDesc`].\n\n`dim() == 0` means the factor takes no distortion parameter block.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No distortion; no parameter block.",
+          "type": "string"
+        },
+        {
+          "const": "brown_conrady5",
+          "description": "Brown-Conrady `[k1, k2, k3, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "rational8",
+          "description": "Rational polynomial `[k1, k2, k3, k4, k5, k6, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "thin_prism9",
+          "description": "Brown-Conrady + thin-prism `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.",
+          "type": "string"
+        },
+        {
+          "const": "division1",
+          "description": "Fitzgibbon division model `[lambda]`.",
+          "type": "string"
+        }
+      ]
+    },
     "RobustLoss": {
       "description": "Robust loss applied to a residual block.\n\nEach residual block has its own loss; per-point robustification is achieved\nby using one residual block per observation.",
       "oneOf": [
@@ -159,6 +189,11 @@
                 "p2": true
               },
               "description": "Distortion mask applied during per-camera Scheimpflug intrinsics\nrefinement. Defaults to [`DistortionFixMask::radial_only`]\n(k1, k2 free; k3, p1, p2 fixed) — a safe choice for typical\nScheimpflug rigs where tangential distortion can absorb tilt-like\nsignal. Narrow-FOV rigs that overfit k2 may want\n`(k1, p1, p2) free, (k2, k3) fixed` instead."
+            },
+            "distortion_model": {
+              "$ref": "#/$defs/DistortionKind",
+              "default": "brown_conrady5",
+              "description": "Distortion model for the per-camera Scheimpflug intrinsics.\n\nOnly [`DistortionKind::BrownConrady5`] (the default) is supported:\nthe joint rig bundle adjustment is Brown-Conrady-typed. Non-BC5\nmodels are rejected up front by the rig `validate_config` (ADR 0019)\nrather than deep in the solver. The field exists for schema\nsymmetry with the single-camera Scheimpflug path."
             },
             "fix_scheimpflug_in_intrinsics": {
               "$ref": "#/$defs/ScheimpflugFixMask",

--- a/app/src/schemas/rig_handeye_config.json
+++ b/app/src/schemas/rig_handeye_config.json
@@ -78,6 +78,36 @@
       ],
       "type": "object"
     },
+    "DistortionKind": {
+      "description": "Distortion slot of a [`CameraModelDesc`].\n\n`dim() == 0` means the factor takes no distortion parameter block.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No distortion; no parameter block.",
+          "type": "string"
+        },
+        {
+          "const": "brown_conrady5",
+          "description": "Brown-Conrady `[k1, k2, k3, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "rational8",
+          "description": "Rational polynomial `[k1, k2, k3, k4, k5, k6, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "thin_prism9",
+          "description": "Brown-Conrady + thin-prism `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.",
+          "type": "string"
+        },
+        {
+          "const": "division1",
+          "description": "Fitzgibbon division model `[lambda]`.",
+          "type": "string"
+        }
+      ]
+    },
     "FxFyCxCySkew": {
       "description": "Standard pinhole intrinsics with optional skew.",
       "properties": {
@@ -461,6 +491,11 @@
                 "p2": true
               },
               "description": "Distortion mask applied during per-camera Scheimpflug intrinsics\nrefinement. Defaults to [`DistortionFixMask::radial_only`]\n(k1, k2 free; k3, p1, p2 fixed) — a safe choice for typical\nScheimpflug rigs where tangential distortion can absorb tilt-like\nsignal. Narrow-FOV rigs that overfit k2 may want\n`(k1, p1, p2) free, (k2, k3) fixed` instead."
+            },
+            "distortion_model": {
+              "$ref": "#/$defs/DistortionKind",
+              "default": "brown_conrady5",
+              "description": "Distortion model for the per-camera Scheimpflug intrinsics.\n\nOnly [`DistortionKind::BrownConrady5`] (the default) is supported:\nthe joint rig bundle adjustment is Brown-Conrady-typed. Non-BC5\nmodels are rejected up front by the rig `validate_config` (ADR 0019)\nrather than deep in the solver. The field exists for schema\nsymmetry with the single-camera Scheimpflug path."
             },
             "fix_scheimpflug_in_intrinsics": {
               "$ref": "#/$defs/ScheimpflugFixMask",

--- a/app/src/schemas/rig_handeye_laserline_config.json
+++ b/app/src/schemas/rig_handeye_laserline_config.json
@@ -78,6 +78,36 @@
       ],
       "type": "object"
     },
+    "DistortionKind": {
+      "description": "Distortion slot of a [`CameraModelDesc`].\n\n`dim() == 0` means the factor takes no distortion parameter block.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No distortion; no parameter block.",
+          "type": "string"
+        },
+        {
+          "const": "brown_conrady5",
+          "description": "Brown-Conrady `[k1, k2, k3, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "rational8",
+          "description": "Rational polynomial `[k1, k2, k3, k4, k5, k6, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "thin_prism9",
+          "description": "Brown-Conrady + thin-prism `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.",
+          "type": "string"
+        },
+        {
+          "const": "division1",
+          "description": "Fitzgibbon division model `[lambda]`.",
+          "type": "string"
+        }
+      ]
+    },
     "FxFyCxCySkew": {
       "description": "Standard pinhole intrinsics with optional skew.",
       "properties": {
@@ -684,6 +714,11 @@
                 "p2": true
               },
               "description": "Distortion mask applied during per-camera Scheimpflug intrinsics\nrefinement. Defaults to [`DistortionFixMask::radial_only`]\n(k1, k2 free; k3, p1, p2 fixed) — a safe choice for typical\nScheimpflug rigs where tangential distortion can absorb tilt-like\nsignal. Narrow-FOV rigs that overfit k2 may want\n`(k1, p1, p2) free, (k2, k3) fixed` instead."
+            },
+            "distortion_model": {
+              "$ref": "#/$defs/DistortionKind",
+              "default": "brown_conrady5",
+              "description": "Distortion model for the per-camera Scheimpflug intrinsics.\n\nOnly [`DistortionKind::BrownConrady5`] (the default) is supported:\nthe joint rig bundle adjustment is Brown-Conrady-typed. Non-BC5\nmodels are rejected up front by the rig `validate_config` (ADR 0019)\nrather than deep in the solver. The field exists for schema\nsymmetry with the single-camera Scheimpflug path."
             },
             "fix_scheimpflug_in_intrinsics": {
               "$ref": "#/$defs/ScheimpflugFixMask",

--- a/app/src/schemas/scheimpflug_intrinsics_config.json
+++ b/app/src/schemas/scheimpflug_intrinsics_config.json
@@ -33,6 +33,36 @@
       ],
       "type": "object"
     },
+    "DistortionKind": {
+      "description": "Distortion slot of a [`CameraModelDesc`].\n\n`dim() == 0` means the factor takes no distortion parameter block.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No distortion; no parameter block.",
+          "type": "string"
+        },
+        {
+          "const": "brown_conrady5",
+          "description": "Brown-Conrady `[k1, k2, k3, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "rational8",
+          "description": "Rational polynomial `[k1, k2, k3, k4, k5, k6, p1, p2]`.",
+          "type": "string"
+        },
+        {
+          "const": "thin_prism9",
+          "description": "Brown-Conrady + thin-prism `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`.",
+          "type": "string"
+        },
+        {
+          "const": "division1",
+          "description": "Fitzgibbon division model `[lambda]`.",
+          "type": "string"
+        }
+      ]
+    },
     "IntrinsicsFixMask": {
       "description": "Mask for fixing intrinsics parameters during optimization.\n\nEach field corresponds to a component of the camera matrix K:\n```text\nK = | fx   skew  cx |\n    | 0    fy    cy |\n    | 0    0     1  |\n```\n\nSet a field to `true` to keep that parameter fixed during optimization.\n\n# Example\n\n```\nuse vision_calibration_core::IntrinsicsFixMask;\n\n// Fix only the principal point\nlet mask = IntrinsicsFixMask {\n    cx: true,\n    cy: true,\n    ..Default::default()\n};\n\nassert!(!mask.fx); // fx will be optimized\nassert!(mask.cx);  // cx is fixed\n```",
       "properties": {
@@ -162,6 +192,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Configuration for planar Scheimpflug intrinsics calibration.",
   "properties": {
+    "distortion_model": {
+      "$ref": "#/$defs/DistortionKind",
+      "default": "brown_conrady5",
+      "description": "Distortion model refined during optimization.\n\nBrown-Conrady5 is the default and is byte-identical to the pre-M-WIRE\npath. The extended models (Rational8, ThinPrism9, Division1) are wired\nthrough the single-camera Scheimpflug path; the linear init always\nproduces Brown-Conrady coefficients, which are embedded into the chosen\nmodel with any extra degrees of freedom zeroed before the non-linear\nrefine. Rig Scheimpflug pipelines remain Brown-Conrady only."
+    },
     "fix_distortion": {
       "$ref": "#/$defs/DistortionFixMask",
       "description": "Distortion parameter fix mask for non-linear optimization."

--- a/crates/vision-calibration-bench/src/registry.rs
+++ b/crates/vision-calibration-bench/src/registry.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::DistortionFixMask;
 use vision_calibration_dataset::DatasetSpec;
-use vision_calibration_optim::{HandEyeMode, RobustLoss, ScheimpflugFixMask};
+use vision_calibration_optim::{DistortionKind, HandEyeMode, RobustLoss, ScheimpflugFixMask};
 use vision_calibration_pipeline::rig_handeye::{RigHandeyeConfig, SensorMode};
 use vision_calibration_pipeline::single_cam_handeye::SingleCamHandeyeConfig;
 
@@ -487,6 +487,8 @@ impl From<BenchSensorMode> for SensorMode {
                     .map(Into::into)
                     .unwrap_or_default(),
                 refine_scheimpflug_in_rig_ba,
+                // Rig Scheimpflug bundle adjustment is Brown-Conrady-typed.
+                distortion_model: DistortionKind::BrownConrady5,
             },
         }
     }

--- a/crates/vision-calibration-bench/src/run.rs
+++ b/crates/vision-calibration-bench/src/run.rs
@@ -739,6 +739,10 @@ pub mod tier_b {
             detection: Some(detection),
             laser: None,
             robot_corrections: None,
+            // Single-camera Scheimpflug intrinsics emits Fit-only metrics and no
+            // camera artifact. The `camera_artifact("brown_conrady5", …)` path is
+            // reached only by the rig runs, which stay Brown-Conrady even after the
+            // Q4-MWIRE distortion-model selection (rig BA is BC5-typed).
             artifacts: None,
             delta_to_prior: None,
             timing,
@@ -2279,9 +2283,12 @@ pub mod tier_b {
         estimate: vision_calibration_optim::ScheimpflugIntrinsicsEstimate,
         note: Option<String>,
     ) -> Result<StagedIntrinsicsSolve> {
+        // Bench staged solves are Brown-Conrady (the committed defaults);
+        // `IntrinsicsParamReport` is BC5-shaped, so read the concrete coefficients.
+        let distortion = estimate.params.distortion_bc5();
         let camera = Camera::new(
             Pinhole,
-            estimate.params.distortion,
+            distortion,
             estimate.params.sensor.compile(),
             estimate.params.intrinsics,
         );
@@ -2302,11 +2309,11 @@ pub mod tier_b {
             cx: estimate.params.intrinsics.cx,
             cy: estimate.params.intrinsics.cy,
             skew: estimate.params.intrinsics.skew,
-            k1: estimate.params.distortion.k1,
-            k2: estimate.params.distortion.k2,
-            k3: estimate.params.distortion.k3,
-            p1: estimate.params.distortion.p1,
-            p2: estimate.params.distortion.p2,
+            k1: distortion.k1,
+            k2: distortion.k2,
+            k3: distortion.k3,
+            p1: distortion.p1,
+            p2: distortion.p2,
             tau_x: estimate.params.sensor.tilt_x,
             tau_y: estimate.params.sensor.tilt_y,
         };

--- a/crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/puzzle_130x130_rig.rs
@@ -161,6 +161,8 @@ fn main() -> Result<()> {
             p2: false,
         },
         refine_scheimpflug_in_rig_ba: false,
+        // Rig Scheimpflug bundle adjustment is Brown-Conrady-typed.
+        distortion_model: vision_calibration_optim::DistortionKind::BrownConrady5,
     };
     cfg.rig.refine_intrinsics_in_rig_ba = false;
     let robot_rot_sigma = cfg.handeye_ba.robot_rot_sigma;

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ref_intrinsics.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ref_intrinsics.rs
@@ -28,6 +28,11 @@
 //! - `RTV3D_REF_DATA_DIR` (default `privatedata/rtv3d_ref`). Must contain a
 //!   `spec.json` device spec (gitignored, like the rest of `privatedata/`).
 //! - `RTV3D_REF_MAXITERS` (default `120`).
+//! - `Q4_DISTORTION_SWEEP=1` — after the gated run, re-run the same seeded
+//!   route once per distortion model (BrownConrady5, Rational8, ThinPrism9,
+//!   Division1) and print a per-camera / per-model mean-reprojection table.
+//!   Informational only: it never changes the output of the default run nor
+//!   the process exit code.
 
 use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
@@ -47,7 +52,7 @@ use vision_calibration_examples_private::{
     RefArtifacts, RefIntrinsic, detect_target, load_gray, load_poses, load_ref_artifacts,
     split_horizontal, split_opencv_distortion,
 };
-use vision_calibration_optim::RobustLoss;
+use vision_calibration_optim::{DistortionKind, RobustLoss};
 
 const NUM_CAMERAS: usize = 6;
 const BOARD_ROWS: u32 = 130;
@@ -126,6 +131,12 @@ fn main() -> Result<()> {
     }
     println!("detect: {:.2?}", t_det.elapsed());
 
+    // Opt-in per-model sweep re-runs the seeded route on the same detections;
+    // the gated loop below consumes `per_cam_views`, so snapshot them first
+    // (only when the sweep is enabled — the default path is untouched).
+    let sweep_views: Option<Vec<Vec<View<NoMeta>>>> =
+        sweep_enabled().then(|| per_cam_views.clone());
+
     // ── Per-camera seeded intrinsics calibration ─────────────────────────────
     let t0 = Instant::now();
     let mut results: Vec<CamResult> = Vec::with_capacity(NUM_CAMERAS);
@@ -190,6 +201,11 @@ fn main() -> Result<()> {
 
     report(&art, &results);
 
+    // ── Opt-in distortion-model sweep (informational; never gates) ───────────
+    if let Some(sweep_views) = &sweep_views {
+        run_distortion_sweep(&spec, sweep_views, max_iters);
+    }
+
     // ── Hard gate: every camera ≤ 0.5 px ─────────────────────────────────────
     let failed: Vec<(usize, f64)> = results
         .iter()
@@ -212,6 +228,110 @@ fn main() -> Result<()> {
              richer distortion, detector tail), do not relax the gate.",
             failed.len()
         ))
+    }
+}
+
+/// Whether the opt-in per-distortion-model sweep is requested.
+fn sweep_enabled() -> bool {
+    std::env::var("Q4_DISTORTION_SWEEP").as_deref() == Ok("1")
+}
+
+/// Run the seeded Scheimpflug intrinsics solve for one camera under a given
+/// distortion model and return its mean reprojection error (px).
+///
+/// Mirrors the gated run's config exactly — same seed, same fix masks, same
+/// robust loss — changing only `distortion_model`. Non-BC5 models produce a
+/// different `DistortionParams` variant on output, but the sweep only reads
+/// the scalar reprojection metric, so no variant matching is needed.
+fn sweep_solve_camera(
+    spec: &DeviceSpec,
+    cam: usize,
+    views: Vec<View<NoMeta>>,
+    model: DistortionKind,
+    max_iters: usize,
+) -> Result<f64> {
+    let dataset = PlanarDataset::new(views)?;
+    let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+    session.set_input(dataset)?;
+
+    let mut config = ScheimpflugIntrinsicsConfig::default();
+    config.max_iters = max_iters;
+    config.fix_scheimpflug = ScheimpflugFixMask {
+        tilt_x: false,
+        tilt_y: false,
+    };
+    config.robust_loss = RobustLoss::Huber { scale: 1.0 };
+    config.distortion_model = model;
+    session.set_config(config)?;
+
+    let seed = scheimpflug_seed(spec, &format!("cam{cam}"))?;
+    step_init_with_seed(&mut session, seed, None)?;
+    step_optimize(&mut session, None)?;
+
+    let out = session.output().expect("output after optimize");
+    Ok(out.mean_reproj_error)
+}
+
+/// Median of the finite values (proper even-length average); `None` if empty.
+fn median(mut xs: Vec<f64>) -> Option<f64> {
+    xs.retain(|v| v.is_finite());
+    if xs.is_empty() {
+        return None;
+    }
+    xs.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+    let n = xs.len();
+    Some(if n % 2 == 1 {
+        xs[n / 2]
+    } else {
+        (xs[n / 2 - 1] + xs[n / 2]) / 2.0
+    })
+}
+
+/// Opt-in per-distortion-model sweep (env `Q4_DISTORTION_SWEEP=1`).
+///
+/// For each model it re-runs the same seeded route per camera and reports the
+/// mean reprojection error (the gated metric), plus a per-model median across
+/// cameras. Purely informational — it never affects the process exit code. A
+/// solve that errors is reported as `ERR`; a non-finite reprojection as
+/// `DIVERGED`.
+fn run_distortion_sweep(spec: &DeviceSpec, per_cam_views: &[Vec<View<NoMeta>>], max_iters: usize) {
+    let models = [
+        DistortionKind::BrownConrady5,
+        DistortionKind::Rational8,
+        DistortionKind::ThinPrism9,
+        DistortionKind::Division1,
+    ];
+    println!(
+        "\n── Q4 distortion-model sweep (mean reprojection px; informational, does NOT affect gate) ──"
+    );
+    print!("  {:<13} |", "model");
+    for c in 0..NUM_CAMERAS {
+        print!(" {:>8} |", format!("cam{c}"));
+    }
+    println!(" {:>8}", "median");
+    for model in models {
+        let results: Vec<Result<f64>> = per_cam_views
+            .iter()
+            .enumerate()
+            .map(|(c, views)| sweep_solve_camera(spec, c, views.clone(), model, max_iters))
+            .collect();
+        print!("  {:<13} |", format!("{model:?}"));
+        for cell in &results {
+            let s = match cell {
+                Ok(v) if v.is_finite() => format!("{v:.4}"),
+                Ok(_) => "DIVERGED".to_string(),
+                Err(_) => "ERR".to_string(),
+            };
+            print!(" {s:>8} |");
+        }
+        let finite: Vec<f64> = results
+            .iter()
+            .filter_map(|c| c.as_ref().ok().copied())
+            .collect();
+        match median(finite) {
+            Some(m) => println!(" {m:>8.4}"),
+            None => println!(" {:>8}", "n/a"),
+        }
     }
 }
 

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ref_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ref_rig.rs
@@ -141,6 +141,8 @@ fn main() -> Result<()> {
             p2: true,
         },
         refine_scheimpflug_in_rig_ba: false,
+        // Rig Scheimpflug bundle adjustment is Brown-Conrady-typed.
+        distortion_model: vision_calibration_optim::DistortionKind::BrownConrady5,
     };
     cfg.rig.refine_intrinsics_in_rig_ba = false;
     session.set_config(cfg)?;

--- a/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
@@ -179,6 +179,8 @@ fn main() -> Result<()> {
             p2: true,
         },
         refine_scheimpflug_in_rig_ba: false,
+        // Rig Scheimpflug bundle adjustment is Brown-Conrady-typed.
+        distortion_model: vision_calibration_optim::DistortionKind::BrownConrady5,
     };
     cfg.rig.refine_intrinsics_in_rig_ba = false;
     let robot_rot_sigma = cfg.handeye_ba.robot_rot_sigma;

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_intrinsics.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_intrinsics.rs
@@ -36,6 +36,11 @@
 //!   density and exit before solving (fast detection probe).
 //! - `RTV3D_PUZZLE_REF_DIR` — puzzleboard oracle dir for the baseline column
 //!   (default `privatedata/rtv3d_ref`; skipped if absent).
+//! - `Q4_DISTORTION_SWEEP=1` — after the gated run, re-run the same seeded
+//!   route once per distortion model (BrownConrady5, Rational8, ThinPrism9,
+//!   Division1) and print a per-camera / per-model mean-reprojection table.
+//!   Informational only: it never changes the output of the default run nor
+//!   the process exit code.
 
 use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
@@ -55,9 +60,11 @@ use vision_calibration_examples_private::{
     BoardRinggridSpec, detect_ringgrid, load_gray, load_poses, load_ref_artifacts,
     load_ringgrid_board, split_horizontal,
 };
-use vision_calibration_optim::RobustLoss;
+use vision_calibration_optim::{DistortionKind, RobustLoss};
 
 const NUM_CAMERAS: usize = 6;
+/// Minimum views required to attempt a per-camera solve (matches the gated run).
+const MIN_VIEWS: usize = 3;
 const GATE_PX: f64 = 0.5;
 
 /// Recovered summary for one camera.
@@ -154,11 +161,17 @@ fn main() -> Result<()> {
         );
     }
 
+    // Opt-in per-model sweep re-runs the seeded route on the same detections;
+    // the gated loop below consumes `per_cam_views`, so snapshot them first
+    // (only when the sweep is enabled — the default path is untouched).
+    let sweep_views: Option<Vec<Vec<View<NoMeta>>>> =
+        sweep_enabled().then(|| per_cam_views.clone());
+
     // ── Per-camera seeded intrinsics calibration ─────────────────────────────
     let t0 = Instant::now();
     let mut results: Vec<Option<CamResult>> = Vec::with_capacity(NUM_CAMERAS);
     for (c, views) in per_cam_views.into_iter().enumerate() {
-        if views.len() < 3 {
+        if views.len() < MIN_VIEWS {
             println!("camera {c}: only {} views — skipping solve", views.len());
             results.push(None);
             continue;
@@ -235,6 +248,11 @@ fn main() -> Result<()> {
 
     report(&results, puzzle_reproj.as_deref());
 
+    // ── Opt-in distortion-model sweep (informational; never gates) ───────────
+    if let Some(sweep_views) = &sweep_views {
+        run_distortion_sweep(&spec, sweep_views, max_iters);
+    }
+
     // ── Hard gate: all NUM_CAMERAS solved, each ≤ 0.5 px ─────────────────────
     let failed: Vec<(usize, f64)> = results
         .iter()
@@ -269,6 +287,114 @@ fn main() -> Result<()> {
              relax the gate.",
             failed.len()
         ))
+    }
+}
+
+/// Whether the opt-in per-distortion-model sweep is requested.
+fn sweep_enabled() -> bool {
+    std::env::var("Q4_DISTORTION_SWEEP").as_deref() == Ok("1")
+}
+
+/// Run the seeded Scheimpflug intrinsics solve for one camera under a given
+/// distortion model and return its mean reprojection error (px).
+///
+/// Mirrors the gated run's config exactly — same seed, same fix masks, same
+/// robust loss — changing only `distortion_model`. Non-BC5 models produce a
+/// different `DistortionParams` variant on output, but the sweep only reads
+/// the scalar reprojection metric, so no variant matching is needed.
+fn sweep_solve_camera(
+    spec: &DeviceSpec,
+    cam: usize,
+    views: Vec<View<NoMeta>>,
+    model: DistortionKind,
+    max_iters: usize,
+) -> Result<f64> {
+    let dataset = PlanarDataset::new(views)?;
+    let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+    session.set_input(dataset)?;
+
+    let mut config = ScheimpflugIntrinsicsConfig::default();
+    config.max_iters = max_iters;
+    config.fix_scheimpflug = ScheimpflugFixMask {
+        tilt_x: false,
+        tilt_y: false,
+    };
+    config.robust_loss = RobustLoss::Huber { scale: 1.0 };
+    config.distortion_model = model;
+    session.set_config(config)?;
+
+    let seed = scheimpflug_seed(spec, &format!("cam{cam}"))?;
+    step_init_with_seed(&mut session, seed, None)?;
+    step_optimize(&mut session, None)?;
+
+    let out = session.output().expect("output after optimize");
+    Ok(out.mean_reproj_error)
+}
+
+/// Median of the finite values (proper even-length average); `None` if empty.
+fn median(mut xs: Vec<f64>) -> Option<f64> {
+    xs.retain(|v| v.is_finite());
+    if xs.is_empty() {
+        return None;
+    }
+    xs.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+    let n = xs.len();
+    Some(if n % 2 == 1 {
+        xs[n / 2]
+    } else {
+        (xs[n / 2 - 1] + xs[n / 2]) / 2.0
+    })
+}
+
+/// Opt-in per-distortion-model sweep (env `Q4_DISTORTION_SWEEP=1`).
+///
+/// For each model it re-runs the same seeded route per camera and reports the
+/// mean reprojection error (the gated metric), plus a per-model median across
+/// cameras. Purely informational — it never affects the process exit code.
+/// Cameras with too few views are `skip`ped (as in the gated run); a solve
+/// that errors is `ERR`; a non-finite reprojection is `DIVERGED`.
+fn run_distortion_sweep(spec: &DeviceSpec, per_cam_views: &[Vec<View<NoMeta>>], max_iters: usize) {
+    let models = [
+        DistortionKind::BrownConrady5,
+        DistortionKind::Rational8,
+        DistortionKind::ThinPrism9,
+        DistortionKind::Division1,
+    ];
+    println!(
+        "\n── Q4 distortion-model sweep (mean reprojection px; informational, does NOT affect gate) ──"
+    );
+    print!("  {:<13} |", "model");
+    for c in 0..NUM_CAMERAS {
+        print!(" {:>8} |", format!("cam{c}"));
+    }
+    println!(" {:>8}", "median");
+    for model in models {
+        let results: Vec<Option<Result<f64>>> = per_cam_views
+            .iter()
+            .enumerate()
+            .map(|(c, views)| {
+                (views.len() >= MIN_VIEWS)
+                    .then(|| sweep_solve_camera(spec, c, views.clone(), model, max_iters))
+            })
+            .collect();
+        print!("  {:<13} |", format!("{model:?}"));
+        for cell in &results {
+            let s = match cell {
+                None => "skip".to_string(),
+                Some(Ok(v)) if v.is_finite() => format!("{v:.4}"),
+                Some(Ok(_)) => "DIVERGED".to_string(),
+                Some(Err(_)) => "ERR".to_string(),
+            };
+            print!(" {s:>8} |");
+        }
+        let finite: Vec<f64> = results
+            .iter()
+            .filter_map(|c| c.as_ref().and_then(|r| r.as_ref().ok()).copied())
+            .collect();
+        match median(finite) {
+            Some(m) => println!(" {m:>8.4}"),
+            None => println!(" {:>8}", "n/a"),
+        }
     }
 }
 

--- a/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_ringgrid_rig.rs
@@ -172,6 +172,8 @@ fn main() -> Result<()> {
             p2: true,
         },
         refine_scheimpflug_in_rig_ba: false,
+        // Rig Scheimpflug bundle adjustment is Brown-Conrady-typed.
+        distortion_model: vision_calibration_optim::DistortionKind::BrownConrady5,
     };
     cfg.rig.refine_intrinsics_in_rig_ba = false;
     // Robot-pose refinement on by default; `RTV3D_RINGGRID_REFINE_ROBOT=0` holds

--- a/crates/vision-calibration-optim/src/lib.rs
+++ b/crates/vision-calibration-optim/src/lib.rs
@@ -159,7 +159,8 @@ pub use crate::ir::{
 };
 
 pub use crate::params::distortion::{
-    DISTORTION_DIM, pack_distortion, pack_distortion_params, unpack_distortion_params,
+    DISTORTION_DIM, distortion_kind, pack_distortion, pack_distortion_params,
+    unpack_distortion_params, with_leading_radial,
 };
 pub use crate::params::intrinsics::{INTRINSICS_DIM, pack_intrinsics};
 pub use crate::params::laser_plane::LaserPlane;

--- a/crates/vision-calibration-optim/src/params/distortion.rs
+++ b/crates/vision-calibration-optim/src/params/distortion.rs
@@ -4,7 +4,7 @@ use crate::Error;
 use crate::ir::DistortionKind;
 use nalgebra::{DVector, DVectorView};
 use vision_calibration_core::{
-    BrownConrady5, DistortionParams, RationalPolynomial, Real, ThinPrism,
+    BrownConrady5, DistortionFixMask, DistortionParams, RationalPolynomial, Real, ThinPrism,
 };
 
 /// Dimension of the Brown-Conrady distortion vector [k1, k2, k3, p1, p2].
@@ -65,6 +65,53 @@ pub fn pack_distortion_params(d: &DistortionParams) -> DVector<f64> {
             nalgebra::dvector![*lambda]
         }
     }
+}
+
+/// Translate a Brown-Conrady-shaped [`DistortionFixMask`] onto the packed
+/// coefficient layout of `kind`, returning the fixed indices into that layout.
+///
+/// This is the single name-based mechanism used for **both** user-supplied fix
+/// masks and the pipeline's staging masks (A0/A1), so the extended models
+/// honour the same "which coefficients are free" invariants as Brown-Conrady.
+/// The packed orderings are the ones produced by [`pack_distortion_params`];
+/// index accordingly.
+///
+/// The `DistortionFixMask` has five named bits `{k1, k2, k3, p1, p2}`. They map
+/// by name onto every model's shared coefficients; each model's extra
+/// coefficients follow the mask bit of the *family* they belong to:
+///
+/// - **BrownConrady5** `[k1, k2, k3, p1, p2]`: exactly [`DistortionFixMask::to_indices`]
+///   (byte-identical to the pre-M-WIRE path).
+/// - **Rational8** `[k1, k2, k3, k4, k5, k6, p1, p2]`: `k1,k2,k3,p1,p2` by name;
+///   the higher-order radial block `k4,k5,k6` follows the `k3` bit (OpenCV-style
+///   — it is the same radial family, promoted/demoted together).
+/// - **ThinPrism9** `[k1, k2, k3, p1, p2, s1, s2, s3, s4]`: `k1,k2,k3,p1,p2` by
+///   name; the thin-prism block `s1..s4` follows the tangential pair — fixed iff
+///   **both** `p1` and `p2` are fixed (prism is a tangential-family refinement).
+/// - **Division1** `[lambda]`: the single barrel term follows the leading radial
+///   `k1` bit, consistent with [`with_leading_radial`].
+/// - **None**: no coefficients, so no indices.
+pub fn fix_mask_indices(mask: &DistortionFixMask, kind: DistortionKind) -> Vec<usize> {
+    // Fixed-flag per packed coefficient, in `pack_distortion_params` order.
+    let flags: Vec<bool> = match kind {
+        DistortionKind::None => Vec::new(),
+        DistortionKind::BrownConrady5 => vec![mask.k1, mask.k2, mask.k3, mask.p1, mask.p2],
+        DistortionKind::Rational8 => vec![
+            mask.k1, mask.k2, mask.k3, mask.k3, mask.k3, mask.k3, mask.p1, mask.p2,
+        ],
+        DistortionKind::ThinPrism9 => {
+            let prism = mask.p1 && mask.p2;
+            vec![
+                mask.k1, mask.k2, mask.k3, mask.p1, mask.p2, prism, prism, prism, prism,
+            ]
+        }
+        DistortionKind::Division1 => vec![mask.k1],
+    };
+    flags
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, fixed)| fixed.then_some(i))
+        .collect()
 }
 
 /// Map a [`DistortionParams`] variant to its [`DistortionKind`] discriminant.
@@ -319,6 +366,94 @@ mod tests {
         assert!(
             err.to_string().contains("5"),
             "error should mention expected length 5: {err}"
+        );
+    }
+
+    // ── Name-based fix-mask translation ─────────────────────────────────────
+
+    #[test]
+    fn fix_mask_bc5_is_identity_with_to_indices() {
+        // Every possible BC5 mask must translate to exactly `to_indices()`.
+        for bits in 0u8..32 {
+            let mask = DistortionFixMask {
+                k1: bits & 1 != 0,
+                k2: bits & 2 != 0,
+                k3: bits & 4 != 0,
+                p1: bits & 8 != 0,
+                p2: bits & 16 != 0,
+            };
+            assert_eq!(
+                fix_mask_indices(&mask, DistortionKind::BrownConrady5),
+                mask.to_indices(),
+                "BC5 translation diverged from to_indices() for {mask:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fix_mask_all_fixed_covers_every_index() {
+        let mask = DistortionFixMask::all_fixed();
+        for kind in [
+            DistortionKind::None,
+            DistortionKind::BrownConrady5,
+            DistortionKind::Rational8,
+            DistortionKind::ThinPrism9,
+            DistortionKind::Division1,
+        ] {
+            let expected: Vec<usize> = (0..kind.dim()).collect();
+            assert_eq!(
+                fix_mask_indices(&mask, kind),
+                expected,
+                "all-fixed mask must fix every packed index for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fix_mask_a1_shape_frees_leading_radial_per_kind() {
+        // The A1 staging mask: {k1, k2 free; k3, p1, p2 fixed}.
+        let a1 = DistortionFixMask {
+            k1: false,
+            k2: false,
+            k3: true,
+            p1: true,
+            p2: true,
+        };
+        // BC5 `[k1,k2,k3,p1,p2]`: fix k3,p1,p2.
+        assert_eq!(
+            fix_mask_indices(&a1, DistortionKind::BrownConrady5),
+            vec![2, 3, 4]
+        );
+        // Rational8 `[k1,k2,k3,k4,k5,k6,p1,p2]`: k4,k5,k6 follow k3 → fixed.
+        assert_eq!(
+            fix_mask_indices(&a1, DistortionKind::Rational8),
+            vec![2, 3, 4, 5, 6, 7]
+        );
+        // ThinPrism9 `[k1,k2,k3,p1,p2,s1,s2,s3,s4]`: s1..s4 follow (p1&&p2) → fixed.
+        assert_eq!(
+            fix_mask_indices(&a1, DistortionKind::ThinPrism9),
+            vec![2, 3, 4, 5, 6, 7, 8]
+        );
+        // Division1 `[lambda]`: lambda follows k1 (free) → nothing fixed.
+        assert_eq!(
+            fix_mask_indices(&a1, DistortionKind::Division1),
+            Vec::<usize>::new()
+        );
+    }
+
+    #[test]
+    fn fix_mask_thinprism_prism_follows_tangential_pair() {
+        // Only one of p1/p2 fixed ⇒ prism block stays free.
+        let one_tangential = DistortionFixMask {
+            k1: false,
+            k2: false,
+            k3: false,
+            p1: true,
+            p2: false,
+        };
+        assert_eq!(
+            fix_mask_indices(&one_tangential, DistortionKind::ThinPrism9),
+            vec![3], // p1 only; s1..s4 free because p2 is free
         );
     }
 }

--- a/crates/vision-calibration-optim/src/params/distortion.rs
+++ b/crates/vision-calibration-optim/src/params/distortion.rs
@@ -67,6 +67,56 @@ pub fn pack_distortion_params(d: &DistortionParams) -> DVector<f64> {
     }
 }
 
+/// Map a [`DistortionParams`] variant to its [`DistortionKind`] discriminant.
+///
+/// This is the single source of truth for the params → kind mapping shared by
+/// the planar and Scheimpflug problem builders.
+pub fn distortion_kind(d: &DistortionParams) -> DistortionKind {
+    match d {
+        DistortionParams::None => DistortionKind::None,
+        DistortionParams::BrownConrady5 { .. } => DistortionKind::BrownConrady5,
+        DistortionParams::Rational { .. } => DistortionKind::Rational8,
+        DistortionParams::ThinPrism { .. } => DistortionKind::ThinPrism9,
+        DistortionParams::Division { .. } => DistortionKind::Division1,
+    }
+}
+
+/// Return a copy of `d` with its **leading radial coefficient** set to `value`,
+/// preserving the model variant and all other coefficients.
+///
+/// The leading radial term is `k1` for [`DistortionParams::BrownConrady5`],
+/// [`DistortionParams::Rational`], and [`DistortionParams::ThinPrism`], and
+/// `lambda` for [`DistortionParams::Division`] (also the primary barrel term).
+/// [`DistortionParams::None`] carries no coefficient, so it is returned
+/// unchanged (a leading-radial multi-start collapses to a single start).
+///
+/// Used by the Scheimpflug warm-start to sweep the leading barrel coefficient
+/// across a coarse grid without hard-coding the Brown-Conrady layout.
+pub fn with_leading_radial(d: &DistortionParams, value: f64) -> DistortionParams {
+    match d {
+        DistortionParams::None => DistortionParams::None,
+        DistortionParams::BrownConrady5 { params } => DistortionParams::BrownConrady5 {
+            params: BrownConrady5 {
+                k1: value,
+                ..*params
+            },
+        },
+        DistortionParams::Rational { params } => DistortionParams::Rational {
+            params: RationalPolynomial {
+                k1: value,
+                ..*params
+            },
+        },
+        DistortionParams::ThinPrism { params } => DistortionParams::ThinPrism {
+            params: ThinPrism {
+                k1: value,
+                ..*params
+            },
+        },
+        DistortionParams::Division { .. } => DistortionParams::Division { lambda: value },
+    }
+}
+
 /// Unpack a [`DistortionParams`] from an IR-ordered distortion vector.
 ///
 /// `kind` selects the expected length and layout; returns

--- a/crates/vision-calibration-optim/src/problems/planar_family_shared.rs
+++ b/crates/vision-calibration-optim/src/problems/planar_family_shared.rs
@@ -2,14 +2,14 @@ use crate::Error;
 use nalgebra::DVector;
 use std::collections::{HashMap, HashSet};
 use vision_calibration_core::{
-    BrownConrady5, FxFyCxCySkew, Iso3, PlanarDataset, Real, ScheimpflugParams,
+    DistortionParams, FxFyCxCySkew, Iso3, PlanarDataset, Real, ScheimpflugParams,
 };
 
 use crate::ir::{
     Bound, CameraModelDesc, FactorKind, FixedMask, ManifoldKind, ProblemIR, ReprojChain,
     ResidualBlock, RobustLoss,
 };
-use crate::params::distortion::{DISTORTION_DIM, pack_distortion};
+use crate::params::distortion::pack_distortion_params;
 use crate::params::intrinsics::{INTRINSICS_DIM, pack_intrinsics};
 use crate::params::pose_se3::iso3_to_se3_dvec;
 
@@ -49,7 +49,7 @@ impl PlanarSensorIrOptions {
 pub(crate) fn build_planar_reprojection_ir(
     dataset: &PlanarDataset,
     intrinsics: &FxFyCxCySkew<Real>,
-    distortion: &BrownConrady5<Real>,
+    distortion: &DistortionParams,
     poses: &[Iso3],
     opts: &PlanarReprojectionIrOptions,
 ) -> Result<(ProblemIR, HashMap<String, DVector<f64>>), Error> {
@@ -83,14 +83,24 @@ pub(crate) fn build_planar_reprojection_ir(
     );
     initial_map.insert("cam".to_string(), pack_intrinsics(intrinsics)?);
 
-    let dist_id = ir.add_param_block(
-        "dist",
-        DISTORTION_DIM,
-        ManifoldKind::Euclidean,
-        FixedMask::fix_indices(&opts.fix_distortion_indices),
-        None,
-    );
-    initial_map.insert("dist".to_string(), pack_distortion(distortion));
+    // Variable-dimension distortion block selected by the camera model
+    // descriptor. `dim == 0` (identity distortion) emits no block; otherwise the
+    // packed vector length must equal the descriptor's distortion dimension (the
+    // IR validation guards a mismatch).
+    let dist_dim = opts.model.distortion.dim();
+    let dist_id = if dist_dim > 0 {
+        let id = ir.add_param_block(
+            "dist",
+            dist_dim,
+            ManifoldKind::Euclidean,
+            FixedMask::fix_indices(&opts.fix_distortion_indices),
+            None,
+        );
+        initial_map.insert("dist".to_string(), pack_distortion_params(distortion));
+        Some(id)
+    } else {
+        None
+    };
 
     let sensor_id = if let Some(sensor) = opts.sensor {
         let id = ir.add_param_block(
@@ -131,7 +141,10 @@ pub(crate) fn build_planar_reprojection_ir(
             .zip(view.obs.points_2d.iter())
             .enumerate()
         {
-            let mut params = vec![cam_id, dist_id];
+            let mut params = vec![cam_id];
+            if let Some(dist_id) = dist_id {
+                params.push(dist_id);
+            }
             if opts.model.sensor.dim() > 0 {
                 let sensor_id = sensor_id
                     .expect("internal invariant: sensor_id required for a sensor-bearing model");

--- a/crates/vision-calibration-optim/src/problems/scheimpflug_intrinsics.rs
+++ b/crates/vision-calibration-optim/src/problems/scheimpflug_intrinsics.rs
@@ -2,8 +2,8 @@
 
 use crate::Error;
 use crate::backend::{BackendKind, BackendSolveOptions, SolveReport, solve_with_backend};
-use crate::ir::{Bound, RobustLoss};
-use crate::params::distortion::unpack_distortion;
+use crate::ir::{Bound, CameraModelDesc, DistortionKind, RobustLoss};
+use crate::params::distortion::{distortion_kind, unpack_distortion_params};
 use crate::params::intrinsics::unpack_intrinsics;
 use crate::params::pose_se3::se3_dvec_to_iso3;
 use crate::problems::planar_family_shared::{
@@ -12,8 +12,9 @@ use crate::problems::planar_family_shared::{
 use nalgebra::DVectorView;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
-    BrownConrady5, Camera, CorrespondenceView, DistortionFixMask, FxFyCxCySkew, IntrinsicsFixMask,
-    Iso3, Pinhole, PlanarDataset, Real, ScheimpflugParams, View,
+    BrownConrady5, CameraParams, CorrespondenceView, DistortionFixMask, DistortionParams,
+    FxFyCxCySkew, IntrinsicsFixMask, IntrinsicsParams, Iso3, PlanarDataset, ProjectionParams, Real,
+    ScheimpflugParams, SensorParams, View,
 };
 
 /// Mask for Scheimpflug tilt parameters.
@@ -108,12 +109,18 @@ impl ScheimpflugBounds {
 }
 
 /// Initial/refined parameters for Scheimpflug intrinsics optimization.
+///
+/// The distortion is model-agnostic ([`DistortionParams`]) so the Scheimpflug
+/// path supports Brown-Conrady5 (the default) as well as the extended
+/// Rational8 / ThinPrism9 / Division1 models. Brown-Conrady5 remains
+/// byte-identical to the pre-M-WIRE path (packed vector `[k1, k2, k3, p1, p2]`,
+/// descriptor `PINHOLE4_DIST5_SCHEIMPFLUG2`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheimpflugIntrinsicsParams {
     /// Camera intrinsics.
     pub intrinsics: FxFyCxCySkew<Real>,
-    /// Brown-Conrady distortion parameters.
-    pub distortion: BrownConrady5<Real>,
+    /// Distortion parameters (model-agnostic).
+    pub distortion: DistortionParams,
     /// Scheimpflug sensor tilt parameters.
     pub sensor: ScheimpflugParams,
     /// Target poses per view (`camera_se3_target`).
@@ -121,10 +128,36 @@ pub struct ScheimpflugIntrinsicsParams {
 }
 
 impl ScheimpflugIntrinsicsParams {
-    /// Construct parameter pack with validation.
+    /// Construct a parameter pack from concrete Brown-Conrady distortion.
+    ///
+    /// Back-compat entry point for rig calibration and Brown-Conrady callers;
+    /// wraps `distortion` into [`DistortionParams::BrownConrady5`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InsufficientData`] if `camera_se3_target` is empty.
     pub fn new(
         intrinsics: FxFyCxCySkew<Real>,
         distortion: BrownConrady5<Real>,
+        sensor: ScheimpflugParams,
+        camera_se3_target: Vec<Iso3>,
+    ) -> Result<Self, Error> {
+        Self::new_with_distortion(
+            intrinsics,
+            DistortionParams::BrownConrady5 { params: distortion },
+            sensor,
+            camera_se3_target,
+        )
+    }
+
+    /// Construct a parameter pack from a model-agnostic [`DistortionParams`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InsufficientData`] if `camera_se3_target` is empty.
+    pub fn new_with_distortion(
+        intrinsics: FxFyCxCySkew<Real>,
+        distortion: DistortionParams,
         sensor: ScheimpflugParams,
         camera_se3_target: Vec<Iso3>,
     ) -> Result<Self, Error> {
@@ -137,6 +170,35 @@ impl ScheimpflugIntrinsicsParams {
             sensor,
             camera_se3_target,
         })
+    }
+
+    /// Return the distortion as concrete Brown-Conrady coefficients.
+    ///
+    /// Returns the stored coefficients for [`DistortionParams::BrownConrady5`]
+    /// and [`BrownConrady5::default`] otherwise. Rig calibration is
+    /// Brown-Conrady throughout, so this is always the exact stored value on
+    /// that path.
+    pub fn distortion_bc5(&self) -> BrownConrady5<Real> {
+        match &self.distortion {
+            DistortionParams::BrownConrady5 { params } => *params,
+            _ => BrownConrady5::default(),
+        }
+    }
+
+    /// Return a copy of this parameter pack with the poses replaced.
+    ///
+    /// Intrinsics, distortion, and sensor are cloned unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InsufficientData`] if `camera_se3_target` is empty.
+    pub fn with_poses(&self, camera_se3_target: Vec<Iso3>) -> Result<Self, Error> {
+        Self::new_with_distortion(
+            self.intrinsics,
+            self.distortion.clone(),
+            self.sensor,
+            camera_se3_target,
+        )
     }
 }
 
@@ -182,6 +244,27 @@ pub struct ScheimpflugIntrinsicsEstimate {
     pub mean_reproj_error: f64,
 }
 
+/// Select the Scheimpflug-sensor [`CameraModelDesc`] for a distortion kind.
+///
+/// Brown-Conrady5 maps to `PINHOLE4_DIST5_SCHEIMPFLUG2` (byte-identical to the
+/// pre-M-WIRE path); the extended models map to their Scheimpflug siblings.
+/// The identity-distortion `None` kind has no Scheimpflug descriptor and is
+/// rejected — a Scheimpflug intrinsics solve always carries a distortion model.
+fn scheimpflug_model_desc(kind: DistortionKind) -> Result<CameraModelDesc, Error> {
+    Ok(match kind {
+        DistortionKind::BrownConrady5 => CameraModelDesc::PINHOLE4_DIST5_SCHEIMPFLUG2,
+        DistortionKind::Rational8 => CameraModelDesc::PINHOLE4_RATIONAL8_SCHEIMPFLUG2,
+        DistortionKind::ThinPrism9 => CameraModelDesc::PINHOLE4_THINPRISM9_SCHEIMPFLUG2,
+        DistortionKind::Division1 => CameraModelDesc::PINHOLE4_DIVISION1_SCHEIMPFLUG2,
+        DistortionKind::None => {
+            return Err(Error::invalid_input(
+                "Scheimpflug intrinsics requires a distortion model (identity distortion \
+                 is not supported)",
+            ));
+        }
+    })
+}
+
 fn build_scheimpflug_intrinsics_ir(
     dataset: &PlanarDataset,
     initial: &ScheimpflugIntrinsicsParams,
@@ -193,6 +276,19 @@ fn build_scheimpflug_intrinsics_ir(
     ),
     Error,
 > {
+    let kind = distortion_kind(&initial.distortion);
+    let model = scheimpflug_model_desc(kind)?;
+
+    // For Brown-Conrady5 the `fix_distortion` mask indexes `[k1, k2, k3, p1, p2]`
+    // and applies as-is (byte-identical to the pre-M-WIRE path). For the extended
+    // models the mask is Brown-Conrady-shaped and does not translate to their
+    // orderings, so every distortion coefficient is left free.
+    let fix_distortion_indices = if kind == DistortionKind::BrownConrady5 {
+        opts.fix_distortion.to_indices()
+    } else {
+        Vec::new()
+    };
+
     build_planar_reprojection_ir(
         dataset,
         &initial.intrinsics,
@@ -201,13 +297,13 @@ fn build_scheimpflug_intrinsics_ir(
         &PlanarReprojectionIrOptions {
             robust_loss: opts.robust_loss,
             fix_intrinsics_indices: opts.fix_intrinsics.to_indices(),
-            fix_distortion_indices: opts.fix_distortion.to_indices(),
+            fix_distortion_indices,
             fix_pose_indices: opts.fix_poses.clone(),
             sensor: Some(PlanarSensorIrOptions {
                 params: initial.sensor,
                 fix_indices: opts.fix_scheimpflug.as_flags(),
             }),
-            model: crate::ir::CameraModelDesc::PINHOLE4_DIST5_SCHEIMPFLUG2,
+            model,
             intrinsics_bounds: opts
                 .bounds
                 .as_ref()
@@ -252,6 +348,7 @@ pub fn optimize_scheimpflug_intrinsics_with_backend(
     backend: BackendKind,
     backend_opts: BackendSolveOptions,
 ) -> Result<ScheimpflugIntrinsicsEstimate, Error> {
+    let kind = distortion_kind(&initial.distortion);
     let (ir, initial_map) = build_scheimpflug_intrinsics_ir(dataset, initial, &opts)?;
     let solution = solve_with_backend(backend, &ir, &initial_map, &backend_opts)?;
 
@@ -262,7 +359,8 @@ pub fn optimize_scheimpflug_intrinsics_with_backend(
             .ok_or_else(|| Error::numerical("missing intrinsics solution block"))?
             .as_view(),
     )?;
-    let distortion = unpack_distortion(
+    let distortion = unpack_distortion_params(
+        kind,
         solution
             .params
             .get("dist")
@@ -288,7 +386,7 @@ pub fn optimize_scheimpflug_intrinsics_with_backend(
     }
 
     let mean_reproj_error =
-        compute_mean_reproj_error(dataset, intrinsics, distortion, sensor, &optimized_poses);
+        compute_mean_reproj_error(dataset, intrinsics, &distortion, sensor, &optimized_poses);
 
     Ok(ScheimpflugIntrinsicsEstimate {
         params: ScheimpflugIntrinsicsParams {
@@ -604,11 +702,19 @@ fn unpack_scheimpflug(values: DVectorView<'_, f64>) -> Result<ScheimpflugParams,
 fn compute_mean_reproj_error(
     dataset: &PlanarDataset,
     intrinsics: FxFyCxCySkew<f64>,
-    distortion: BrownConrady5<f64>,
+    distortion: &DistortionParams,
     sensor: ScheimpflugParams,
     poses: &[Iso3],
 ) -> f64 {
-    let camera = Camera::new(Pinhole, distortion, sensor.compile(), intrinsics);
+    // Build the runtime camera model from parameters so every distortion model
+    // (Brown-Conrady5 and the extended ones) reprojects through the same path.
+    let camera = CameraParams {
+        projection: ProjectionParams::Pinhole,
+        distortion: distortion.clone(),
+        sensor: SensorParams::Scheimpflug { params: sensor },
+        intrinsics: IntrinsicsParams::FxFyCxCySkew { params: intrinsics },
+    }
+    .build();
     let mut sum = 0.0;
     let mut count = 0usize;
 
@@ -637,7 +743,7 @@ fn compute_mean_reproj_error(
 mod tests {
     use super::*;
     use nalgebra::{Translation3, UnitQuaternion};
-    use vision_calibration_core::{CorrespondenceView, Pt2, Pt3, View};
+    use vision_calibration_core::{Camera, CorrespondenceView, Pinhole, Pt2, Pt3, View};
 
     fn gt_camera() -> (FxFyCxCySkew<f64>, BrownConrady5<f64>, ScheimpflugParams) {
         // Principal point intentionally off image center, a large ~-5.7° tilt
@@ -771,14 +877,15 @@ mod tests {
         .unwrap();
 
         let r = &est.params;
+        let r_dist = r.distortion_bc5();
         eprintln!(
             "recovered: fx={:.1} fy={:.1} cx={:.1} cy={:.1} k1={:.3} k2={:.3} tau=({:.4},{:.4}) reproj={:.4}px",
             r.intrinsics.fx,
             r.intrinsics.fy,
             r.intrinsics.cx,
             r.intrinsics.cy,
-            r.distortion.k1,
-            r.distortion.k2,
+            r_dist.k1,
+            r_dist.k2,
             r.sensor.tilt_x,
             r.sensor.tilt_y,
             est.mean_reproj_error,

--- a/crates/vision-calibration-optim/src/problems/scheimpflug_intrinsics.rs
+++ b/crates/vision-calibration-optim/src/problems/scheimpflug_intrinsics.rs
@@ -3,7 +3,7 @@
 use crate::Error;
 use crate::backend::{BackendKind, BackendSolveOptions, SolveReport, solve_with_backend};
 use crate::ir::{Bound, CameraModelDesc, DistortionKind, RobustLoss};
-use crate::params::distortion::{distortion_kind, unpack_distortion_params};
+use crate::params::distortion::{distortion_kind, fix_mask_indices, unpack_distortion_params};
 use crate::params::intrinsics::unpack_intrinsics;
 use crate::params::pose_se3::se3_dvec_to_iso3;
 use crate::problems::planar_family_shared::{
@@ -279,15 +279,13 @@ fn build_scheimpflug_intrinsics_ir(
     let kind = distortion_kind(&initial.distortion);
     let model = scheimpflug_model_desc(kind)?;
 
-    // For Brown-Conrady5 the `fix_distortion` mask indexes `[k1, k2, k3, p1, p2]`
-    // and applies as-is (byte-identical to the pre-M-WIRE path). For the extended
-    // models the mask is Brown-Conrady-shaped and does not translate to their
-    // orderings, so every distortion coefficient is left free.
-    let fix_distortion_indices = if kind == DistortionKind::BrownConrady5 {
-        opts.fix_distortion.to_indices()
-    } else {
-        Vec::new()
-    };
+    // Translate the Brown-Conrady-shaped `fix_distortion` mask onto the packed
+    // layout of the active model. `fix_mask_indices` is the single name-based
+    // mechanism shared with the pipeline's staging masks; for Brown-Conrady5 it
+    // is exactly `mask.to_indices()` (byte-identical to the pre-M-WIRE path),
+    // and it carries the same "which coefficients are free" invariants onto the
+    // extended models (see `fix_mask_indices`).
+    let fix_distortion_indices = fix_mask_indices(&opts.fix_distortion, kind);
 
     build_planar_reprojection_ir(
         dataset,

--- a/crates/vision-calibration-optim/tests/scheimpflug_distortion_models.rs
+++ b/crates/vision-calibration-optim/tests/scheimpflug_distortion_models.rs
@@ -1,0 +1,396 @@
+//! Synthetic ground-truth round-trip tests for the Scheimpflug intrinsics path
+//! across every distortion model (BrownConrady5, Rational8, ThinPrism9,
+//! Division1).
+//!
+//! Each test builds a Scheimpflug-tilted GT camera (a modest tilt so all board
+//! points stay in-frame), generates noiseless observations, seeds near GT with
+//! the extended distortion coefficients zeroed, runs
+//! [`optimize_scheimpflug_intrinsics`], and asserts a tight reprojection RMS
+//! (~1e-2 px) plus recovery of the leading barrel coefficient. Brown-Conrady5 is
+//! included as an explicit regression of the default path.
+
+#![allow(missing_docs)]
+
+use nalgebra::{Translation3, UnitQuaternion};
+use vision_calibration_core::{
+    BrownConrady5, Camera, CameraModel, CameraParams, CameraProject, CorrespondenceView,
+    DistortionParams, Division, FxFyCxCySkew, IntrinsicsParams, Iso3, Pinhole, PlanarDataset,
+    ProjectionParams, Pt2, Pt3, RationalPolynomial, ScheimpflugParams, SensorParams, ThinPrism,
+    View,
+};
+use vision_calibration_optim::{
+    BackendSolveOptions, ScheimpflugIntrinsicsParams, ScheimpflugIntrinsicsSolveOptions,
+    optimize_scheimpflug_intrinsics,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared GT infrastructure
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn gt_intrinsics() -> FxFyCxCySkew<f64> {
+    FxFyCxCySkew {
+        fx: 1150.0,
+        fy: 1155.0,
+        cx: 372.0,
+        cy: 258.0,
+        skew: 0.0,
+    }
+}
+
+/// Modest Scheimpflug tilt (~3° / ~1°) — observable but small enough that the
+/// projected board stays inside the image at every pose.
+fn gt_sensor() -> ScheimpflugParams {
+    ScheimpflugParams {
+        tilt_x: 0.05,
+        tilt_y: -0.02,
+    }
+}
+
+fn make_pose(rx: f64, ry: f64, rz: f64, tx: f64, ty: f64, tz: f64) -> Iso3 {
+    Iso3::from_parts(
+        Translation3::new(tx, ty, tz),
+        UnitQuaternion::from_euler_angles(rx, ry, rz),
+    )
+}
+
+fn gt_poses() -> Vec<Iso3> {
+    vec![
+        make_pose(0.0, 0.0, 0.0, -0.01, -0.01, 0.45),
+        make_pose(0.20, 0.0, 0.0, -0.02, 0.0, 0.50),
+        make_pose(-0.20, 0.0, 0.0, 0.01, -0.02, 0.48),
+        make_pose(0.0, 0.20, 0.0, -0.01, 0.01, 0.52),
+        make_pose(0.0, -0.20, 0.0, 0.02, -0.01, 0.47),
+        make_pose(0.15, 0.15, 0.0, -0.02, -0.02, 0.55),
+        make_pose(-0.15, 0.15, 0.05, 0.01, 0.0, 0.49),
+        make_pose(0.15, -0.15, -0.05, -0.01, 0.02, 0.53),
+        make_pose(-0.15, -0.15, 0.0, 0.0, -0.01, 0.46),
+        make_pose(0.10, -0.10, 0.10, -0.02, 0.01, 0.51),
+    ]
+}
+
+fn board_points() -> Vec<Pt3> {
+    let mut pts = Vec::new();
+    for iy in 0..9 {
+        for ix in 0..9 {
+            pts.push(Pt3::new(
+                (ix as f64 - 4.0) * 0.02,
+                (iy as f64 - 4.0) * 0.02,
+                0.0,
+            ));
+        }
+    }
+    pts
+}
+
+/// Build a noiseless dataset from a generic Scheimpflug camera model.
+fn make_dataset<C: CameraProject>(camera: &C, poses: &[Iso3]) -> PlanarDataset {
+    let object = board_points();
+    let views: Vec<_> = poses
+        .iter()
+        .map(|pose| {
+            let (p3, p2): (Vec<Pt3>, Vec<Pt2>) = object
+                .iter()
+                .filter_map(|o| {
+                    let p_cam = pose.transform_point(o);
+                    camera
+                        .project_camera_point(&p_cam.coords)
+                        .map(|uv| (*o, uv))
+                })
+                .unzip();
+            View::without_meta(CorrespondenceView::new(p3, p2).expect("non-empty view"))
+        })
+        .collect();
+    PlanarDataset::new(views).expect("valid dataset")
+}
+
+/// Build the runtime Scheimpflug camera model from a refined parameter pack.
+fn built_camera(params: &ScheimpflugIntrinsicsParams) -> CameraModel {
+    CameraParams {
+        projection: ProjectionParams::Pinhole,
+        distortion: params.distortion.clone(),
+        sensor: SensorParams::Scheimpflug {
+            params: params.sensor,
+        },
+        intrinsics: IntrinsicsParams::FxFyCxCySkew {
+            params: params.intrinsics,
+        },
+    }
+    .build()
+}
+
+/// Mean reprojection RMS for a built camera over the dataset.
+fn reproj_rms<C: CameraProject>(camera: &C, dataset: &PlanarDataset, poses: &[Iso3]) -> f64 {
+    let mut sum_sq = 0.0;
+    let mut n = 0usize;
+    for (view, pose) in dataset.views.iter().zip(poses.iter()) {
+        for (p3, p2) in view.obs.points_3d.iter().zip(view.obs.points_2d.iter()) {
+            let p_cam = pose.transform_point(p3);
+            if let Some(proj) = camera.project_camera_point(&p_cam.coords) {
+                sum_sq += (proj - *p2).norm_squared();
+                n += 1;
+            }
+        }
+    }
+    if n == 0 {
+        f64::INFINITY
+    } else {
+        (sum_sq / n as f64).sqrt()
+    }
+}
+
+/// A slightly perturbed intrinsics seed (2% focal error, a few px on the pp).
+fn seed_intrinsics() -> FxFyCxCySkew<f64> {
+    let k = gt_intrinsics();
+    FxFyCxCySkew {
+        fx: k.fx * 1.02,
+        fy: k.fy * 1.02,
+        cx: k.cx + 4.0,
+        cy: k.cy - 4.0,
+        skew: 0.0,
+    }
+}
+
+/// Run the direct joint Scheimpflug solve seeded at GT poses (view 0 fixed for
+/// gauge) and return the refined camera + poses as a built model.
+fn run_solve(
+    dataset: &PlanarDataset,
+    seed_distortion: DistortionParams,
+    poses: &[Iso3],
+) -> (ScheimpflugIntrinsicsParams, f64) {
+    let initial = ScheimpflugIntrinsicsParams::new_with_distortion(
+        seed_intrinsics(),
+        seed_distortion,
+        // Seed the tilt near GT (mount angle is known on the supported path).
+        ScheimpflugParams {
+            tilt_x: 0.04,
+            tilt_y: -0.015,
+        },
+        poses.to_vec(),
+    )
+    .expect("valid seed");
+
+    let opts = ScheimpflugIntrinsicsSolveOptions {
+        fix_poses: vec![0],
+        ..Default::default()
+    };
+    let backend_opts = BackendSolveOptions {
+        max_iters: 200,
+        verbosity: 0,
+        min_abs_decrease: Some(1e-14),
+        min_rel_decrease: Some(1e-14),
+        min_error: Some(1e-16),
+        ..Default::default()
+    };
+    let est = optimize_scheimpflug_intrinsics(dataset, &initial, opts, backend_opts)
+        .expect("scheimpflug solve must succeed");
+    let rms = est.mean_reproj_error;
+    (est.params, rms)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Brown-Conrady5 (default path — regression)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn scheimpflug_bc5_round_trip() {
+    let k = gt_intrinsics();
+    let sensor = gt_sensor();
+    let dist_gt = BrownConrady5 {
+        k1: -0.10,
+        k2: 0.03,
+        k3: 0.0,
+        p1: 0.0,
+        p2: 0.0,
+        iters: 8,
+    };
+    let camera_gt = Camera::new(Pinhole, dist_gt, sensor.compile(), k);
+    let poses = gt_poses();
+    let dataset = make_dataset(&camera_gt, &poses);
+
+    let seed = DistortionParams::BrownConrady5 {
+        params: BrownConrady5 {
+            k1: -0.05,
+            ..BrownConrady5::default()
+        },
+    };
+    let (params, rms) = run_solve(&dataset, seed, &poses);
+    println!("[scheimpflug BC5] rms={rms:.4e} px");
+    assert!(rms < 1e-2, "BC5 reprojection RMS too large: {rms:.4e}");
+
+    let d = params.distortion_bc5();
+    assert!(
+        (d.k1 - dist_gt.k1).abs() < 1e-2,
+        "k1 not recovered: {}",
+        d.k1
+    );
+    assert!(
+        (params.sensor.tilt_x - sensor.tilt_x).abs() < 1e-2,
+        "tilt_x not recovered: {}",
+        params.sensor.tilt_x
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rational-8
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn scheimpflug_rational8_round_trip() {
+    let k = gt_intrinsics();
+    let sensor = gt_sensor();
+    let dist_gt = RationalPolynomial {
+        k1: -0.12,
+        k2: 0.04,
+        k3: 0.0,
+        k4: 0.008,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.0006,
+        p2: -0.0004,
+        iters: 10,
+    };
+    let camera_gt = Camera::new(Pinhole, dist_gt, sensor.compile(), k);
+    let poses = gt_poses();
+    let dataset = make_dataset(&camera_gt, &poses);
+
+    // Seed near GT with the extra denominator coefficients (k4..k6) zeroed.
+    let seed = DistortionParams::Rational {
+        params: RationalPolynomial {
+            k1: -0.08,
+            k2: 0.0,
+            k3: 0.0,
+            k4: 0.0,
+            k5: 0.0,
+            k6: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+            iters: 10,
+        },
+    };
+    let (params, rms) = run_solve(&dataset, seed, &poses);
+    println!("[scheimpflug Rational8] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Rational8 reprojection RMS too large: {rms:.4e}"
+    );
+
+    let cam = built_camera(&params);
+    let rms_check = reproj_rms(&cam, &dataset, &params.camera_se3_target);
+    assert!(
+        rms_check < 1e-2,
+        "Rational8 direct reproj RMS: {rms_check:.4e}"
+    );
+
+    if let DistortionParams::Rational { params: p } = &params.distortion {
+        assert!(
+            (p.k1 - dist_gt.k1).abs() < 5e-2,
+            "k1 not recovered: {}",
+            p.k1
+        );
+    } else {
+        panic!("expected Rational distortion, got {:?}", params.distortion);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ThinPrism-9
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn scheimpflug_thinprism9_round_trip() {
+    let k = gt_intrinsics();
+    let sensor = gt_sensor();
+    let dist_gt = ThinPrism {
+        k1: -0.11,
+        k2: 0.03,
+        k3: 0.0,
+        p1: 0.0006,
+        p2: -0.0004,
+        s1: 0.0003,
+        s2: -0.0002,
+        s3: 0.0002,
+        s4: 0.0,
+        iters: 8,
+    };
+    let camera_gt = Camera::new(Pinhole, dist_gt, sensor.compile(), k);
+    let poses = gt_poses();
+    let dataset = make_dataset(&camera_gt, &poses);
+
+    // Seed near GT with the thin-prism terms (s1..s4) zeroed.
+    let seed = DistortionParams::ThinPrism {
+        params: ThinPrism {
+            k1: -0.08,
+            k2: 0.0,
+            k3: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+            s1: 0.0,
+            s2: 0.0,
+            s3: 0.0,
+            s4: 0.0,
+            iters: 8,
+        },
+    };
+    let (params, rms) = run_solve(&dataset, seed, &poses);
+    println!("[scheimpflug ThinPrism9] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "ThinPrism9 reprojection RMS too large: {rms:.4e}"
+    );
+
+    let cam = built_camera(&params);
+    let rms_check = reproj_rms(&cam, &dataset, &params.camera_se3_target);
+    assert!(
+        rms_check < 1e-2,
+        "ThinPrism9 direct reproj RMS: {rms_check:.4e}"
+    );
+
+    if let DistortionParams::ThinPrism { params: p } = &params.distortion {
+        assert!(
+            (p.k1 - dist_gt.k1).abs() < 5e-2,
+            "k1 not recovered: {}",
+            p.k1
+        );
+    } else {
+        panic!("expected ThinPrism distortion, got {:?}", params.distortion);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Division-1 (moderate barrel)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn scheimpflug_division1_round_trip() {
+    let k = gt_intrinsics();
+    let sensor = gt_sensor();
+    let lambda_gt = -0.20_f64;
+    let camera_gt = Camera::new(Pinhole, Division { lambda: lambda_gt }, sensor.compile(), k);
+    let poses = gt_poses();
+    let dataset = make_dataset(&camera_gt, &poses);
+
+    // lambda=0 is a valid seed (rationalized formula is analytic there).
+    let seed = DistortionParams::Division { lambda: 0.0 };
+    let (params, rms) = run_solve(&dataset, seed, &poses);
+    println!("[scheimpflug Division1] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Division1 reprojection RMS too large: {rms:.4e}"
+    );
+
+    let cam = built_camera(&params);
+    let rms_check = reproj_rms(&cam, &dataset, &params.camera_se3_target);
+    assert!(
+        rms_check < 1e-2,
+        "Division1 direct reproj RMS: {rms_check:.4e}"
+    );
+
+    if let DistortionParams::Division { lambda } = &params.distortion {
+        assert!(
+            (lambda - lambda_gt).abs() < 1e-2,
+            "lambda not recovered: {lambda}"
+        );
+    } else {
+        panic!("expected Division distortion, got {:?}", params.distortion);
+    }
+}

--- a/crates/vision-calibration-optim/tests/scheimpflug_distortion_models.rs
+++ b/crates/vision-calibration-optim/tests/scheimpflug_distortion_models.rs
@@ -14,9 +14,9 @@
 use nalgebra::{Translation3, UnitQuaternion};
 use vision_calibration_core::{
     BrownConrady5, Camera, CameraModel, CameraParams, CameraProject, CorrespondenceView,
-    DistortionParams, Division, FxFyCxCySkew, IntrinsicsParams, Iso3, Pinhole, PlanarDataset,
-    ProjectionParams, Pt2, Pt3, RationalPolynomial, ScheimpflugParams, SensorParams, ThinPrism,
-    View,
+    DistortionFixMask, DistortionParams, Division, FxFyCxCySkew, IntrinsicsParams, Iso3, Pinhole,
+    PlanarDataset, ProjectionParams, Pt2, Pt3, RationalPolynomial, ScheimpflugParams, SensorParams,
+    ThinPrism, View,
 };
 use vision_calibration_optim::{
     BackendSolveOptions, ScheimpflugIntrinsicsParams, ScheimpflugIntrinsicsSolveOptions,
@@ -152,9 +152,15 @@ fn seed_intrinsics() -> FxFyCxCySkew<f64> {
 
 /// Run the direct joint Scheimpflug solve seeded at GT poses (view 0 fixed for
 /// gauge) and return the refined camera + poses as a built model.
+///
+/// `fix_distortion` selects which distortion coefficients are free: BC5 uses the
+/// production default (`radial_only`), while the extended-model round trips free
+/// every coefficient (`all_free`) because their GT carries nonzero higher-order
+/// radial / tangential / prism terms that must be recovered.
 fn run_solve(
     dataset: &PlanarDataset,
     seed_distortion: DistortionParams,
+    fix_distortion: DistortionFixMask,
     poses: &[Iso3],
 ) -> (ScheimpflugIntrinsicsParams, f64) {
     let initial = ScheimpflugIntrinsicsParams::new_with_distortion(
@@ -171,6 +177,7 @@ fn run_solve(
 
     let opts = ScheimpflugIntrinsicsSolveOptions {
         fix_poses: vec![0],
+        fix_distortion,
         ..Default::default()
     };
     let backend_opts = BackendSolveOptions {
@@ -213,7 +220,7 @@ fn scheimpflug_bc5_round_trip() {
             ..BrownConrady5::default()
         },
     };
-    let (params, rms) = run_solve(&dataset, seed, &poses);
+    let (params, rms) = run_solve(&dataset, seed, DistortionFixMask::radial_only(), &poses);
     println!("[scheimpflug BC5] rms={rms:.4e} px");
     assert!(rms < 1e-2, "BC5 reprojection RMS too large: {rms:.4e}");
 
@@ -267,7 +274,7 @@ fn scheimpflug_rational8_round_trip() {
             iters: 10,
         },
     };
-    let (params, rms) = run_solve(&dataset, seed, &poses);
+    let (params, rms) = run_solve(&dataset, seed, DistortionFixMask::all_free(), &poses);
     println!("[scheimpflug Rational8] rms={rms:.4e} px");
     assert!(
         rms < 1e-2,
@@ -331,7 +338,7 @@ fn scheimpflug_thinprism9_round_trip() {
             iters: 8,
         },
     };
-    let (params, rms) = run_solve(&dataset, seed, &poses);
+    let (params, rms) = run_solve(&dataset, seed, DistortionFixMask::all_free(), &poses);
     println!("[scheimpflug ThinPrism9] rms={rms:.4e} px");
     assert!(
         rms < 1e-2,
@@ -371,7 +378,7 @@ fn scheimpflug_division1_round_trip() {
 
     // lambda=0 is a valid seed (rationalized formula is analytic there).
     let seed = DistortionParams::Division { lambda: 0.0 };
-    let (params, rms) = run_solve(&dataset, seed, &poses);
+    let (params, rms) = run_solve(&dataset, seed, DistortionFixMask::all_free(), &poses);
     println!("[scheimpflug Division1] rms={rms:.4e} px");
     assert!(
         rms < 1e-2,

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
@@ -11,7 +11,7 @@ use vision_calibration_core::{
     compute_rig_target_residuals,
 };
 use vision_calibration_optim::{
-    RigExtrinsicsEstimate as PinholeRigExtrinsicsEstimate,
+    DistortionKind, RigExtrinsicsEstimate as PinholeRigExtrinsicsEstimate,
     RigExtrinsicsScheimpflugEstimate as ScheimpflugRigExtrinsicsEstimate, RobustLoss,
 };
 
@@ -338,6 +338,18 @@ impl ProblemType for RigExtrinsicsProblem {
             return Err(Error::invalid_input(
                 "intrinsics_init_iterations must be positive",
             ));
+        }
+        // The joint rig bundle adjustment is Brown-Conrady-typed; reject other
+        // Scheimpflug distortion models up front (ADR 0019) rather than deep in
+        // the solver. Use the single-camera Scheimpflug problem type for
+        // extended distortion models.
+        if let Some(model) = config.sensor.scheimpflug_distortion_model()
+            && model != DistortionKind::BrownConrady5
+        {
+            return Err(Error::invalid_input(format!(
+                "rig Scheimpflug calibration supports only the BrownConrady5 distortion \
+                 model, got {model:?}"
+            )));
         }
         Ok(())
     }

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/steps.rs
@@ -441,7 +441,7 @@ pub fn step_intrinsics_optimize_all(
 
                 optimized_cameras.push(make_pinhole_camera(
                     result.params.intrinsics,
-                    result.params.distortion,
+                    result.params.distortion_bc5(),
                 ));
                 optimized_sensors
                     .as_mut()

--- a/crates/vision-calibration-pipeline/src/rig_family.rs
+++ b/crates/vision-calibration-pipeline/src/rig_family.rs
@@ -31,7 +31,7 @@ use vision_calibration_linear::scheimpflug_init::{
     ScheimpflugIntrinsicsInitOptions as LinearScheimpflugIntrinsicsInitOptions,
     ScheimpflugIntrinsicsLinearInit, estimate_scheimpflug_intrinsics_iterative,
 };
-use vision_calibration_optim::ScheimpflugFixMask;
+use vision_calibration_optim::{DistortionKind, ScheimpflugFixMask};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Sensor mode (public — re-exported by rig_extrinsics and rig_handeye)
@@ -80,6 +80,15 @@ pub enum SensorMode {
         /// Re-refine Scheimpflug parameters in rig BA (default: false).
         #[serde(default)]
         refine_scheimpflug_in_rig_ba: bool,
+        /// Distortion model for the per-camera Scheimpflug intrinsics.
+        ///
+        /// Only [`DistortionKind::BrownConrady5`] (the default) is supported:
+        /// the joint rig bundle adjustment is Brown-Conrady-typed. Non-BC5
+        /// models are rejected up front by the rig `validate_config` (ADR 0019)
+        /// rather than deep in the solver. The field exists for schema
+        /// symmetry with the single-camera Scheimpflug path.
+        #[serde(default = "default_scheimpflug_distortion_kind")]
+        distortion_model: DistortionKind,
     },
 }
 
@@ -87,10 +96,28 @@ fn default_scheimpflug_percam_distortion_mask() -> DistortionFixMask {
     DistortionFixMask::radial_only()
 }
 
+fn default_scheimpflug_distortion_kind() -> DistortionKind {
+    DistortionKind::BrownConrady5
+}
+
 impl SensorMode {
     /// `true` when the mode is the Scheimpflug variant.
     pub fn is_scheimpflug(&self) -> bool {
         matches!(self, Self::Scheimpflug { .. })
+    }
+
+    /// The configured Scheimpflug distortion model, or `None` for pinhole rigs.
+    ///
+    /// Used by the rig `validate_config` implementations to reject non-BC5
+    /// distortion models before any solve begins — the joint rig bundle
+    /// adjustment is Brown-Conrady-typed.
+    pub fn scheimpflug_distortion_model(&self) -> Option<DistortionKind> {
+        match self {
+            Self::Scheimpflug {
+                distortion_model, ..
+            } => Some(*distortion_model),
+            Self::Pinhole => None,
+        }
     }
 }
 

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -11,7 +11,7 @@ use vision_calibration_core::{
     build_feature_histogram, compute_rig_target_residuals,
 };
 use vision_calibration_optim::{
-    HandEyeEstimate as PinholeHandEyeEstimate, HandEyeMode,
+    DistortionKind, HandEyeEstimate as PinholeHandEyeEstimate, HandEyeMode,
     HandEyeScheimpflugEstimate as ScheimpflugHandEyeEstimate, RobotPoseMeta, RobustLoss,
     handeye_observer_se3_target,
 };
@@ -506,6 +506,18 @@ impl ProblemType for RigHandeyeProblem {
         }
         if config.handeye_ba.robot_trans_sigma <= 0.0 {
             return Err(Error::invalid_input("robot_trans_sigma must be positive"));
+        }
+        // The joint rig hand-eye bundle adjustment is Brown-Conrady-typed; reject
+        // other Scheimpflug distortion models up front (ADR 0019) rather than deep
+        // in the solver. Use the single-camera Scheimpflug problem type for
+        // extended distortion models.
+        if let Some(model) = config.sensor.scheimpflug_distortion_model()
+            && model != DistortionKind::BrownConrady5
+        {
+            return Err(Error::invalid_input(format!(
+                "rig Scheimpflug hand-eye calibration supports only the BrownConrady5 \
+                 distortion model, got {model:?}"
+            )));
         }
         Ok(())
     }

--- a/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/steps.rs
@@ -513,7 +513,7 @@ pub fn step_intrinsics_optimize_all(
 
                 optimized_cameras.push(make_pinhole_camera(
                     result.params.intrinsics,
-                    result.params.distortion,
+                    result.params.distortion_bc5(),
                 ));
                 optimized_sensors
                     .as_mut()
@@ -750,8 +750,10 @@ fn recover_bad_scheimpflug_cameras_from_nominal(
         if candidate.mean_reproj_error.is_finite()
             && (!current.is_finite() || candidate.mean_reproj_error < current)
         {
-            cameras[cam_idx] =
-                make_pinhole_camera(candidate.params.intrinsics, candidate.params.distortion);
+            cameras[cam_idx] = make_pinhole_camera(
+                candidate.params.intrinsics,
+                candidate.params.distortion_bc5(),
+            );
             sensors[cam_idx] = candidate.params.sensor;
             per_cam_reproj_errors[cam_idx] = candidate.mean_reproj_error;
             for (local_idx, &global_idx) in item.valid_indices.iter().enumerate() {
@@ -1008,7 +1010,7 @@ fn score_bad_scheimpflug_seed_against_good_rig(
     let cam_from_rig = cam_to_rig.inverse();
     let camera = Camera::new(
         Pinhole,
-        params.distortion,
+        params.distortion_bc5(),
         params.sensor.compile(),
         params.intrinsics,
     );
@@ -1058,8 +1060,10 @@ fn optimize_bad_scheimpflug_camera_against_good_rig(
     let dataset = bad_camera_only_scheimpflug_rig_dataset(item, cameras.len(), num_views)?;
 
     let mut rig_cameras = cameras.to_vec();
-    rig_cameras[item.cam_idx] =
-        make_pinhole_camera(candidate_params.intrinsics, candidate_params.distortion);
+    rig_cameras[item.cam_idx] = make_pinhole_camera(
+        candidate_params.intrinsics,
+        candidate_params.distortion_bc5(),
+    );
     let mut rig_sensors = sensors.to_vec();
     rig_sensors[item.cam_idx] = candidate_params.sensor;
     let mut cam_to_rig = context.cam_to_rig.clone();
@@ -1241,7 +1245,7 @@ fn score_nominal_scheimpflug_seeds(
                 if dk1 == 0.0 && dk2 == 0.0 {
                     continue;
                 }
-                let mut dist = base.params.distortion;
+                let mut dist = base.params.distortion_bc5();
                 dist.k1 += dk1;
                 dist.k2 += dk2;
                 score_scheimpflug_seed_parts(
@@ -1294,13 +1298,10 @@ fn score_scheimpflug_seed(
     params: &ScheimpflugIntrinsicsParams,
     scored: &mut Vec<ScoredScheimpflugSeed>,
 ) {
-    if let Ok(poses) = recover_scheimpflug_poses_for_seed(
-        dataset,
-        &params.intrinsics,
-        &params.distortion,
-        params.sensor,
-    ) && let Ok(params) =
-        ScheimpflugIntrinsicsParams::new(params.intrinsics, params.distortion, params.sensor, poses)
+    let dist = params.distortion_bc5();
+    if let Ok(poses) =
+        recover_scheimpflug_poses_for_seed(dataset, &params.intrinsics, &dist, params.sensor)
+        && let Ok(params) = params.with_poses(poses)
     {
         let score = mean_scheimpflug_reproj(dataset, &params);
         if score.is_finite() {
@@ -1388,7 +1389,7 @@ fn scheimpflug_estimate_from_scored_seed(
 fn mean_scheimpflug_reproj(dataset: &PlanarDataset, params: &ScheimpflugIntrinsicsParams) -> f64 {
     let camera = Camera::new(
         Pinhole,
-        params.distortion,
+        params.distortion_bc5(),
         params.sensor.compile(),
         params.intrinsics,
     );

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
@@ -6,7 +6,7 @@ use vision_calibration_core::{
     CameraParams, DistortionFixMask, ImageManifest, IntrinsicsFixMask, Iso3, PerFeatureResiduals,
     PlanarDataset, build_feature_histogram, compute_planar_target_residuals,
 };
-use vision_calibration_optim::{RobustLoss, SolveReport};
+use vision_calibration_optim::{DistortionKind, RobustLoss, SolveReport};
 
 use crate::session::{InvalidationPolicy, ProblemState, ProblemType};
 
@@ -68,6 +68,20 @@ pub struct ScheimpflugIntrinsicsConfig {
     pub fix_scheimpflug: ScheimpflugFixMask,
     /// Keep the first pose fixed to remove gauge ambiguity.
     pub fix_first_pose: bool,
+    /// Distortion model refined during optimization.
+    ///
+    /// Brown-Conrady5 is the default and is byte-identical to the pre-M-WIRE
+    /// path. The extended models (Rational8, ThinPrism9, Division1) are wired
+    /// through the single-camera Scheimpflug path; the linear init always
+    /// produces Brown-Conrady coefficients, which are embedded into the chosen
+    /// model with any extra degrees of freedom zeroed before the non-linear
+    /// refine. Rig Scheimpflug pipelines remain Brown-Conrady only.
+    #[serde(default = "default_distortion_kind")]
+    pub distortion_model: DistortionKind,
+}
+
+fn default_distortion_kind() -> DistortionKind {
+    DistortionKind::BrownConrady5
 }
 
 impl Default for ScheimpflugIntrinsicsConfig {
@@ -83,6 +97,7 @@ impl Default for ScheimpflugIntrinsicsConfig {
             fix_distortion: DistortionFixMask::radial_only(),
             fix_scheimpflug: ScheimpflugFixMask::default(),
             fix_first_pose: true,
+            distortion_model: DistortionKind::BrownConrady5,
         }
     }
 }

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/state.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/state.rs
@@ -1,9 +1,7 @@
 //! Intermediate state for Scheimpflug intrinsics calibration.
 
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{
-    BrownConrady5, DistortionParams, FxFyCxCySkew, Iso3, Real, ScheimpflugParams,
-};
+use vision_calibration_core::{BrownConrady5, FxFyCxCySkew, Iso3, Real, ScheimpflugParams};
 
 /// Initial parameter bundle consumed by the optimization step.
 pub type ScheimpflugInitialValues = (
@@ -20,14 +18,12 @@ pub(crate) struct ScheimpflugIntrinsicsState {
     pub initial_intrinsics: Option<FxFyCxCySkew<Real>>,
 
     /// Initial distortion estimated from iterative linear initialization.
+    ///
+    /// Always Brown-Conrady coefficients: this is the linear-init seed. The
+    /// active distortion **model** lives in the config, not in state, so a
+    /// `set_config(model)` between init and optimize is honoured; `step_optimize`
+    /// embeds these coefficients into the configured model on demand.
     pub initial_distortion: Option<BrownConrady5<Real>>,
-
-    /// Model-agnostic initial distortion for extended distortion models
-    /// (Rational8, ThinPrism9, Division1). `None` for the Brown-Conrady5 default,
-    /// which is carried by `initial_distortion` and wrapped on demand. When set,
-    /// the optimization step seeds this directly via `new_with_distortion`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub initial_distortion_params: Option<DistortionParams>,
 
     /// Initial Scheimpflug sensor parameters.
     pub initial_sensor: Option<ScheimpflugParams>,
@@ -109,7 +105,6 @@ mod tests {
                 skew: 0.0,
             }),
             initial_distortion: Some(BrownConrady5::default()),
-            initial_distortion_params: None,
             initial_sensor: Some(ScheimpflugParams::default()),
             initial_sensor_manual: false,
             initial_poses: Some(vec![Iso3::identity()]),
@@ -145,7 +140,6 @@ mod tests {
                 p2: 0.0,
                 iters: 8,
             }),
-            initial_distortion_params: None,
             initial_sensor: Some(ScheimpflugParams {
                 tilt_x: 0.01,
                 tilt_y: -0.008,

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/state.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/state.rs
@@ -1,7 +1,9 @@
 //! Intermediate state for Scheimpflug intrinsics calibration.
 
 use serde::{Deserialize, Serialize};
-use vision_calibration_core::{BrownConrady5, FxFyCxCySkew, Iso3, Real, ScheimpflugParams};
+use vision_calibration_core::{
+    BrownConrady5, DistortionParams, FxFyCxCySkew, Iso3, Real, ScheimpflugParams,
+};
 
 /// Initial parameter bundle consumed by the optimization step.
 pub type ScheimpflugInitialValues = (
@@ -19,6 +21,13 @@ pub(crate) struct ScheimpflugIntrinsicsState {
 
     /// Initial distortion estimated from iterative linear initialization.
     pub initial_distortion: Option<BrownConrady5<Real>>,
+
+    /// Model-agnostic initial distortion for extended distortion models
+    /// (Rational8, ThinPrism9, Division1). `None` for the Brown-Conrady5 default,
+    /// which is carried by `initial_distortion` and wrapped on demand. When set,
+    /// the optimization step seeds this directly via `new_with_distortion`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_distortion_params: Option<DistortionParams>,
 
     /// Initial Scheimpflug sensor parameters.
     pub initial_sensor: Option<ScheimpflugParams>,
@@ -100,6 +109,7 @@ mod tests {
                 skew: 0.0,
             }),
             initial_distortion: Some(BrownConrady5::default()),
+            initial_distortion_params: None,
             initial_sensor: Some(ScheimpflugParams::default()),
             initial_sensor_manual: false,
             initial_poses: Some(vec![Iso3::identity()]),
@@ -135,6 +145,7 @@ mod tests {
                 p2: 0.0,
                 iters: 8,
             }),
+            initial_distortion_params: None,
             initial_sensor: Some(ScheimpflugParams {
                 tilt_x: 0.01,
                 tilt_y: -0.008,

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
@@ -4,8 +4,8 @@ use crate::Error;
 use serde::{Deserialize, Serialize};
 use vision_calibration_core::{
     BrownConrady5, CameraParams, DistortionFixMask, DistortionParams, FxFyCxCySkew,
-    IntrinsicsFixMask, IntrinsicsParams, Iso3, ProjectionParams, Real, ScheimpflugParams,
-    SensorParams,
+    IntrinsicsFixMask, IntrinsicsParams, Iso3, ProjectionParams, RationalPolynomial, Real,
+    ScheimpflugParams, SensorParams, ThinPrism,
 };
 use vision_calibration_linear::distortion_fit::DistortionFitOptions;
 use vision_calibration_linear::scheimpflug_init::{
@@ -13,11 +13,12 @@ use vision_calibration_linear::scheimpflug_init::{
     estimate_scheimpflug_intrinsics_iterative,
 };
 use vision_calibration_optim::{
-    BackendSolveOptions, ScheimpflugBounds, ScheimpflugFixMask as OptimScheimpflugFixMask,
-    ScheimpflugIntrinsicsEstimate, ScheimpflugIntrinsicsParams as OptimScheimpflugIntrinsicsParams,
+    BackendSolveOptions, DistortionKind, ScheimpflugBounds,
+    ScheimpflugFixMask as OptimScheimpflugFixMask, ScheimpflugIntrinsicsEstimate,
+    ScheimpflugIntrinsicsParams as OptimScheimpflugIntrinsicsParams,
     ScheimpflugIntrinsicsSolveOptions as OptimScheimpflugIntrinsicsSolveOptions,
     ScheimpflugStagedInitOptions, optimize_scheimpflug_intrinsics,
-    optimize_scheimpflug_intrinsics_staged,
+    optimize_scheimpflug_intrinsics_staged, with_leading_radial,
 };
 
 use crate::planar_family::{estimate_view_homographies, recover_planar_poses_from_homographies};
@@ -130,6 +131,10 @@ pub fn step_init_with_seed(
     // Capture before `manual` is destructured below: a user-provided tilt seed is
     // trusted directly by `step_optimize` (ADR 0022).
     let sensor_manual = manual.sensor.is_some();
+    // A manual Brown-Conrady distortion seed combined with a non-BC5 model is
+    // embedded (k1,k2,k3,p1,p2) with the extra coefficients starting at zero;
+    // warn so the user knows the extras are not taken from their seed.
+    let distortion_manual = manual.distortion.is_some();
     // From-scratch (no intrinsics seed) Scheimpflug auto-init is experimental — it
     // can land in a wrong tilt/focal basin under the tilt↔focal↔distortion
     // degeneracy. The supported path seeds a coarse focal + nominal mount tilt.
@@ -278,8 +283,14 @@ pub fn step_init_with_seed(
         (bootstrap.camera.k, dist, sensor, poses)
     };
 
+    // Embed the Brown-Conrady linear-init seed into the configured distortion
+    // model (None for the BC5 default, which is carried by `initial_distortion`).
+    let model = session.config.distortion_model;
+    let initial_distortion_params = build_initial_distortion_params(&distortion, model);
+
     session.state.initial_intrinsics = Some(intrinsics);
     session.state.initial_distortion = Some(distortion);
+    session.state.initial_distortion_params = initial_distortion_params;
     session.state.initial_sensor = Some(sensor);
     session.state.initial_sensor_manual = sensor_manual;
     session.state.initial_poses = Some(poses.clone());
@@ -293,15 +304,23 @@ pub fn step_init_with_seed(
          converge to a wrong tilt/focal basin; seed a coarse focal + nominal mount \
          tilt via step_init_with_seed for stable results (ADR 0022)"
     };
+    let distortion_note = if distortion_manual && model != DistortionKind::BrownConrady5 {
+        " — WARNING: a manual Brown-Conrady distortion seed was combined with a \
+         non-BrownConrady5 distortion_model; only (k1,k2,k3,p1,p2) are embedded and \
+         the extra coefficients start at zero"
+    } else {
+        ""
+    };
     session.log_success_with_notes(
         "init",
         format!(
-            "fx={:.1}, fy={:.1}, views={} {}{}",
+            "fx={:.1}, fy={:.1}, views={} {}{}{}",
             intrinsics.fx,
             intrinsics.fy,
             dataset.num_views(),
             source,
-            experimental
+            experimental,
+            distortion_note
         ),
     );
 
@@ -352,6 +371,13 @@ pub fn step_optimize(
         .initial_values()
         .ok_or_else(|| Error::not_available("initial params (call step_init first)"))?;
     let trust_seed_tilt = session.state.initial_sensor_manual;
+    // Extended distortion models carry their own seed (BC5 linear coefficients
+    // embedded, extras zeroed); the BC5 default wraps `initial_distortion`.
+    let initial_distortion_params = session.state.initial_distortion_params.clone().unwrap_or(
+        DistortionParams::BrownConrady5 {
+            params: initial_distortion,
+        },
+    );
 
     let opts = opts.unwrap_or_default();
     let mut max_iters = session.config.max_iters;
@@ -366,9 +392,9 @@ pub fn step_optimize(
         return Err(Error::invalid_input("max_iters must be positive"));
     }
 
-    let initial = OptimScheimpflugIntrinsicsParams::new(
+    let initial = OptimScheimpflugIntrinsicsParams::new_with_distortion(
         initial_intrinsics,
-        initial_distortion,
+        initial_distortion_params,
         initial_sensor,
         initial_poses,
     )?;
@@ -457,11 +483,11 @@ pub fn step_optimize(
         let pose_adapt_iters = pre_iters.min(20);
         let mut best_prefit: Option<ScheimpflugIntrinsicsEstimate> = None;
         for &k1_seed in &k1_seeds {
-            let seed_dist = BrownConrady5 {
-                k1: k1_seed,
-                ..initial.distortion
-            };
-            let seed_initial = OptimScheimpflugIntrinsicsParams::new(
+            // Sweep the leading barrel coefficient (k1 for BC5/Rational8/ThinPrism9,
+            // lambda for Division1). For BC5 this is `BrownConrady5 { k1: k1_seed,
+            // ..initial.distortion }` exactly, keeping the default path unchanged.
+            let seed_dist = with_leading_radial(&initial.distortion, k1_seed);
+            let seed_initial = OptimScheimpflugIntrinsicsParams::new_with_distortion(
                 initial.intrinsics,
                 seed_dist,
                 initial.sensor,
@@ -484,7 +510,7 @@ pub fn step_optimize(
                 Ok(r) => r,
                 Err(_) => continue,
             };
-            let a0_initial = match OptimScheimpflugIntrinsicsParams::new(
+            let a0_initial = match OptimScheimpflugIntrinsicsParams::new_with_distortion(
                 a0.params.intrinsics,
                 a0.params.distortion,
                 a0.params.sensor,
@@ -536,7 +562,7 @@ pub fn step_optimize(
             bounds: Some(joint_bounds),
             ..solve_opts
         };
-        let joint_initial = OptimScheimpflugIntrinsicsParams::new(
+        let joint_initial = OptimScheimpflugIntrinsicsParams::new_with_distortion(
             prefit.params.intrinsics,
             prefit.params.distortion,
             prefit.params.sensor,
@@ -610,14 +636,61 @@ fn to_optim_scheimpflug_fix_mask(
 
 fn scheimpflug_camera_params(
     intrinsics: FxFyCxCySkew<f64>,
-    distortion: BrownConrady5<f64>,
+    distortion: DistortionParams,
     sensor: ScheimpflugParams,
 ) -> CameraParams {
     CameraParams {
         projection: ProjectionParams::Pinhole,
-        distortion: DistortionParams::BrownConrady5 { params: distortion },
+        distortion,
         sensor: SensorParams::Scheimpflug { params: sensor },
         intrinsics: IntrinsicsParams::FxFyCxCySkew { params: intrinsics },
+    }
+}
+
+/// Embed the Brown-Conrady linear-init coefficients into the configured
+/// distortion model, zeroing any extra degrees of freedom.
+///
+/// Returns `None` for [`DistortionKind::BrownConrady5`] — the default path
+/// carries the Brown-Conrady seed directly and wraps it on demand, keeping the
+/// numerics byte-identical to the pre-M-WIRE code.
+///
+/// [`DistortionKind::None`] is rejected by the optimizer (a Scheimpflug solve
+/// always carries distortion); it is mapped to `None` here so the default path
+/// surfaces that error rather than this helper.
+fn build_initial_distortion_params(
+    bc5: &BrownConrady5<Real>,
+    model: DistortionKind,
+) -> Option<DistortionParams> {
+    match model {
+        DistortionKind::BrownConrady5 | DistortionKind::None => None,
+        DistortionKind::Rational8 => Some(DistortionParams::Rational {
+            params: RationalPolynomial {
+                k1: bc5.k1,
+                k2: bc5.k2,
+                k3: bc5.k3,
+                k4: 0.0,
+                k5: 0.0,
+                k6: 0.0,
+                p1: bc5.p1,
+                p2: bc5.p2,
+                iters: 8,
+            },
+        }),
+        DistortionKind::ThinPrism9 => Some(DistortionParams::ThinPrism {
+            params: ThinPrism {
+                k1: bc5.k1,
+                k2: bc5.k2,
+                k3: bc5.k3,
+                p1: bc5.p1,
+                p2: bc5.p2,
+                s1: 0.0,
+                s2: 0.0,
+                s3: 0.0,
+                s4: 0.0,
+                iters: 8,
+            },
+        }),
+        DistortionKind::Division1 => Some(DistortionParams::Division { lambda: 0.0 }),
     }
 }
 

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/steps.rs
@@ -283,14 +283,15 @@ pub fn step_init_with_seed(
         (bootstrap.camera.k, dist, sensor, poses)
     };
 
-    // Embed the Brown-Conrady linear-init seed into the configured distortion
-    // model (None for the BC5 default, which is carried by `initial_distortion`).
+    // The distortion model is NOT baked into state here: `on_config_change`
+    // keeps state, so a `set_config(model)` between init and optimize must take
+    // effect. `step_optimize` derives the model-specific seed from the current
+    // config via `build_initial_distortion_params`. `model` is read only for the
+    // manual-seed warning below.
     let model = session.config.distortion_model;
-    let initial_distortion_params = build_initial_distortion_params(&distortion, model);
 
     session.state.initial_intrinsics = Some(intrinsics);
     session.state.initial_distortion = Some(distortion);
-    session.state.initial_distortion_params = initial_distortion_params;
     session.state.initial_sensor = Some(sensor);
     session.state.initial_sensor_manual = sensor_manual;
     session.state.initial_poses = Some(poses.clone());
@@ -371,13 +372,16 @@ pub fn step_optimize(
         .initial_values()
         .ok_or_else(|| Error::not_available("initial params (call step_init first)"))?;
     let trust_seed_tilt = session.state.initial_sensor_manual;
-    // Extended distortion models carry their own seed (BC5 linear coefficients
-    // embedded, extras zeroed); the BC5 default wraps `initial_distortion`.
-    let initial_distortion_params = session.state.initial_distortion_params.clone().unwrap_or(
-        DistortionParams::BrownConrady5 {
-            params: initial_distortion,
-        },
-    );
+    // Derive the model-specific distortion seed from the CURRENT config (not a
+    // cache built at init time): `on_config_change` keeps state, so a
+    // `set_config(model)` after init must be honoured here. The BC5 default (and
+    // the `None` kind, which the optimizer rejects downstream) wraps the linear
+    // Brown-Conrady seed; the extended models embed it with the extras zeroed.
+    let initial_distortion_params =
+        build_initial_distortion_params(&initial_distortion, session.config.distortion_model)
+            .unwrap_or(DistortionParams::BrownConrady5 {
+                params: initial_distortion,
+            });
 
     let opts = opts.unwrap_or_default();
     let mut max_iters = session.config.max_iters;

--- a/crates/vision-calibration-pipeline/tests/rig_scheimpflug_extrinsics.rs
+++ b/crates/vision-calibration-pipeline/tests/rig_scheimpflug_extrinsics.rs
@@ -125,6 +125,7 @@ fn scheimpflug_config() -> RigExtrinsicsConfig {
         fix_scheimpflug_in_intrinsics: Default::default(),
         distortion_mask_in_percam_ba: vision_calibration_core::DistortionFixMask::radial_only(),
         refine_scheimpflug_in_rig_ba: false,
+        distortion_model: vision_calibration_optim::DistortionKind::BrownConrady5,
     };
     cfg.max_iters = 80;
     cfg

--- a/crates/vision-calibration-pipeline/tests/rig_scheimpflug_handeye.rs
+++ b/crates/vision-calibration-pipeline/tests/rig_scheimpflug_handeye.rs
@@ -130,6 +130,7 @@ fn scheimpflug_handeye_config() -> RigHandeyeConfig {
         fix_scheimpflug_in_intrinsics: Default::default(),
         distortion_mask_in_percam_ba: vision_calibration_core::DistortionFixMask::radial_only(),
         refine_scheimpflug_in_rig_ba: false,
+        distortion_model: vision_calibration_optim::DistortionKind::BrownConrady5,
     };
     cfg
 }

--- a/crates/vision-calibration-pipeline/tests/scheimpflug_distortion_models.rs
+++ b/crates/vision-calibration-pipeline/tests/scheimpflug_distortion_models.rs
@@ -12,8 +12,9 @@
 
 use nalgebra::{Translation3, UnitQuaternion};
 use vision_calibration_core::{
-    BrownConrady5, Camera, CameraProject, CorrespondenceView, Division, FxFyCxCySkew, Iso3,
-    Pinhole, PlanarDataset, Pt2, Pt3, RationalPolynomial, ScheimpflugParams, ThinPrism, View,
+    BrownConrady5, Camera, CameraProject, CorrespondenceView, DistortionFixMask, DistortionParams,
+    Division, FxFyCxCySkew, Iso3, Pinhole, PlanarDataset, Pt2, Pt3, RationalPolynomial,
+    ScheimpflugParams, ThinPrism, View,
 };
 use vision_calibration_optim::DistortionKind;
 use vision_calibration_pipeline::scheimpflug_intrinsics::{
@@ -123,9 +124,14 @@ fn reproj_rms(export: &ScheimpflugIntrinsicsExport, dataset: &PlanarDataset) -> 
 /// Seed the pipeline near GT (manual intrinsics + manual sensor tilt), which
 /// takes the trusted warm-start path (exercising the leading-radial multi-start),
 /// then optimize and export.
+///
+/// `fix_distortion` selects the solve mask: BC5 uses the production default
+/// (`radial_only`); the extended-model round trips free every coefficient
+/// (`all_free`) because their GT carries nonzero higher-order / prism terms.
 fn run_pipeline(
     dataset: &PlanarDataset,
     model: DistortionKind,
+    fix_distortion: DistortionFixMask,
     manual: ScheimpflugManualInit,
 ) -> (
     ScheimpflugIntrinsicsExport,
@@ -133,6 +139,7 @@ fn run_pipeline(
 ) {
     let mut config = ScheimpflugIntrinsicsConfig::default();
     config.distortion_model = model;
+    config.fix_distortion = fix_distortion;
     config.max_iters = 200;
     // Free k3 so the mask does not clamp a coefficient the extended models want.
     config.fix_k3_in_init = false;
@@ -180,7 +187,12 @@ fn bc5_pipeline_round_trip() {
     let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
     let dataset = make_dataset(&cam_gt, &gt_poses());
 
-    let (export, _s) = run_pipeline(&dataset, DistortionKind::BrownConrady5, near_gt_manual());
+    let (export, _s) = run_pipeline(
+        &dataset,
+        DistortionKind::BrownConrady5,
+        DistortionFixMask::radial_only(),
+        near_gt_manual(),
+    );
     let rms = reproj_rms(&export, &dataset);
     println!("[BC5 pipeline] rms={rms:.4e} px");
     assert!(rms < 1e-2, "BC5 pipeline reproj RMS too large: {rms:.4e}");
@@ -202,7 +214,12 @@ fn rational8_pipeline_round_trip() {
     let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
     let dataset = make_dataset(&cam_gt, &gt_poses());
 
-    let (export, _s) = run_pipeline(&dataset, DistortionKind::Rational8, near_gt_manual());
+    let (export, _s) = run_pipeline(
+        &dataset,
+        DistortionKind::Rational8,
+        DistortionFixMask::all_free(),
+        near_gt_manual(),
+    );
     let rms = reproj_rms(&export, &dataset);
     println!("[Rational8 pipeline] rms={rms:.4e} px");
     assert!(
@@ -228,7 +245,12 @@ fn thinprism9_pipeline_round_trip() {
     let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
     let dataset = make_dataset(&cam_gt, &gt_poses());
 
-    let (export, _s) = run_pipeline(&dataset, DistortionKind::ThinPrism9, near_gt_manual());
+    let (export, _s) = run_pipeline(
+        &dataset,
+        DistortionKind::ThinPrism9,
+        DistortionFixMask::all_free(),
+        near_gt_manual(),
+    );
     let rms = reproj_rms(&export, &dataset);
     println!("[ThinPrism9 pipeline] rms={rms:.4e} px");
     assert!(
@@ -247,7 +269,12 @@ fn division1_pipeline_round_trip() {
     );
     let dataset = make_dataset(&cam_gt, &gt_poses());
 
-    let (export, _s) = run_pipeline(&dataset, DistortionKind::Division1, near_gt_manual());
+    let (export, _s) = run_pipeline(
+        &dataset,
+        DistortionKind::Division1,
+        DistortionFixMask::all_free(),
+        near_gt_manual(),
+    );
     let rms = reproj_rms(&export, &dataset);
     println!("[Division1 pipeline] rms={rms:.4e} px");
     assert!(
@@ -284,7 +311,12 @@ fn manual_bc5_seed_with_extended_model_warns_and_converges() {
         ..BrownConrady5::default()
     });
 
-    let (export, session) = run_pipeline(&dataset, DistortionKind::Rational8, manual);
+    let (export, session) = run_pipeline(
+        &dataset,
+        DistortionKind::Rational8,
+        DistortionFixMask::all_free(),
+        manual,
+    );
     let rms = reproj_rms(&export, &dataset);
     println!("[manual-BC5 + Rational8] rms={rms:.4e} px");
     assert!(
@@ -300,6 +332,67 @@ fn manual_bc5_seed_with_extended_model_warns_and_converges() {
     assert!(
         warned,
         "init log must warn about manual BC5 seed + non-BC5 model"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cache-free model selection: a set_config(model) BETWEEN init and optimize
+// must be honoured (on_config_change keeps state, so a stale init-time cache
+// would silently use the wrong model — regression for that defect).
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_config_model_after_init_is_honoured() {
+    let dist_gt = RationalPolynomial {
+        k1: -0.12,
+        k2: 0.04,
+        k3: 0.0,
+        k4: 0.008,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.0006,
+        p2: -0.0004,
+        iters: 10,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
+    let dataset = make_dataset(&cam_gt, &gt_poses());
+
+    // Init with BrownConrady5 …
+    let mut cfg_bc5 = ScheimpflugIntrinsicsConfig::default();
+    cfg_bc5.distortion_model = DistortionKind::BrownConrady5;
+    cfg_bc5.max_iters = 200;
+    cfg_bc5.fix_k3_in_init = false;
+
+    let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+    session.set_config(cfg_bc5).unwrap();
+    session.set_input(dataset.clone()).unwrap();
+    step_init_with_seed(&mut session, near_gt_manual(), None).expect("seeded init (BC5)");
+
+    // … then swap to Rational8 AFTER init (state is kept by on_config_change).
+    let mut cfg_rational = ScheimpflugIntrinsicsConfig::default();
+    cfg_rational.distortion_model = DistortionKind::Rational8;
+    // Free every coefficient so the nonzero GT k4 is recoverable.
+    cfg_rational.fix_distortion = DistortionFixMask::all_free();
+    cfg_rational.max_iters = 200;
+    cfg_rational.fix_k3_in_init = false;
+    session.set_config(cfg_rational).unwrap();
+
+    step_optimize(&mut session, None).expect("optimize (Rational8)");
+    let export = session.export().expect("export");
+
+    assert!(
+        matches!(
+            export.params.camera.distortion,
+            DistortionParams::Rational { .. }
+        ),
+        "export must reflect the post-init Rational8 config, got {:?}",
+        export.params.camera.distortion
+    );
+    let rms = reproj_rms(&export, &dataset);
+    println!("[set_config-after-init] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Rational8-after-swap reproj RMS too large: {rms:.4e}"
     );
 }
 

--- a/crates/vision-calibration-pipeline/tests/scheimpflug_distortion_models.rs
+++ b/crates/vision-calibration-pipeline/tests/scheimpflug_distortion_models.rs
@@ -1,0 +1,345 @@
+//! End-to-end synthetic GT round-trip tests for the Scheimpflug intrinsics
+//! pipeline across every distortion model:
+//!
+//!   config.distortion_model = X  →  seeded step_init  →  step_optimize  →  export
+//!
+//! All scenarios use noiseless synthetic data (modest Scheimpflug tilt) so the
+//! reprojection RMS through the exported camera must be below 1e-2 px.
+//! Brown-Conrady5 is the default-path regression. Config JSON roundtrip (incl.
+//! `None`) and missing-field back-compat guard the serde contract.
+
+#![allow(missing_docs)]
+
+use nalgebra::{Translation3, UnitQuaternion};
+use vision_calibration_core::{
+    BrownConrady5, Camera, CameraProject, CorrespondenceView, Division, FxFyCxCySkew, Iso3,
+    Pinhole, PlanarDataset, Pt2, Pt3, RationalPolynomial, ScheimpflugParams, ThinPrism, View,
+};
+use vision_calibration_optim::DistortionKind;
+use vision_calibration_pipeline::scheimpflug_intrinsics::{
+    ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsExport, ScheimpflugIntrinsicsProblem,
+    ScheimpflugManualInit, step_init_with_seed, step_optimize,
+};
+use vision_calibration_pipeline::session::CalibrationSession;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared GT infrastructure
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn gt_intrinsics() -> FxFyCxCySkew<f64> {
+    FxFyCxCySkew {
+        fx: 1150.0,
+        fy: 1155.0,
+        cx: 372.0,
+        cy: 258.0,
+        skew: 0.0,
+    }
+}
+
+fn gt_sensor() -> ScheimpflugParams {
+    ScheimpflugParams {
+        tilt_x: 0.05,
+        tilt_y: -0.02,
+    }
+}
+
+fn make_pose(rx: f64, ry: f64, rz: f64, tx: f64, ty: f64, tz: f64) -> Iso3 {
+    Iso3::from_parts(
+        Translation3::new(tx, ty, tz),
+        UnitQuaternion::from_euler_angles(rx, ry, rz),
+    )
+}
+
+fn gt_poses() -> Vec<Iso3> {
+    vec![
+        make_pose(0.0, 0.0, 0.0, -0.01, -0.01, 0.45),
+        make_pose(0.20, 0.0, 0.0, -0.02, 0.0, 0.50),
+        make_pose(-0.20, 0.0, 0.0, 0.01, -0.02, 0.48),
+        make_pose(0.0, 0.20, 0.0, -0.01, 0.01, 0.52),
+        make_pose(0.0, -0.20, 0.0, 0.02, -0.01, 0.47),
+        make_pose(0.15, 0.15, 0.0, -0.02, -0.02, 0.55),
+        make_pose(-0.15, 0.15, 0.05, 0.01, 0.0, 0.49),
+        make_pose(0.15, -0.15, -0.05, -0.01, 0.02, 0.53),
+        make_pose(-0.15, -0.15, 0.0, 0.0, -0.01, 0.46),
+        make_pose(0.10, -0.10, 0.10, -0.02, 0.01, 0.51),
+    ]
+}
+
+fn board_points() -> Vec<Pt3> {
+    let mut pts = Vec::new();
+    for iy in 0..9 {
+        for ix in 0..9 {
+            pts.push(Pt3::new(
+                (ix as f64 - 4.0) * 0.02,
+                (iy as f64 - 4.0) * 0.02,
+                0.0,
+            ));
+        }
+    }
+    pts
+}
+
+fn make_dataset<C: CameraProject>(camera: &C, poses: &[Iso3]) -> PlanarDataset {
+    let object = board_points();
+    let views: Vec<_> = poses
+        .iter()
+        .map(|pose| {
+            let (p3, p2): (Vec<Pt3>, Vec<Pt2>) = object
+                .iter()
+                .filter_map(|o| {
+                    let p_cam = pose.transform_point(o);
+                    camera
+                        .project_camera_point(&p_cam.coords)
+                        .map(|uv| (*o, uv))
+                })
+                .unzip();
+            View::without_meta(CorrespondenceView::new(p3, p2).expect("non-empty view"))
+        })
+        .collect();
+    PlanarDataset::new(views).expect("valid dataset")
+}
+
+fn reproj_rms(export: &ScheimpflugIntrinsicsExport, dataset: &PlanarDataset) -> f64 {
+    let camera = export.params.camera.build();
+    let poses = &export.params.camera_se3_target;
+    let mut sum_sq = 0.0;
+    let mut n = 0usize;
+    for (view, pose) in dataset.views.iter().zip(poses.iter()) {
+        for (p3, p2) in view.obs.points_3d.iter().zip(view.obs.points_2d.iter()) {
+            let p_cam = pose.transform_point(p3);
+            if let Some(proj) = camera.project_camera_point(&p_cam.coords) {
+                sum_sq += (proj - *p2).norm_squared();
+                n += 1;
+            }
+        }
+    }
+    if n == 0 {
+        f64::INFINITY
+    } else {
+        (sum_sq / n as f64).sqrt()
+    }
+}
+
+/// Seed the pipeline near GT (manual intrinsics + manual sensor tilt), which
+/// takes the trusted warm-start path (exercising the leading-radial multi-start),
+/// then optimize and export.
+fn run_pipeline(
+    dataset: &PlanarDataset,
+    model: DistortionKind,
+    manual: ScheimpflugManualInit,
+) -> (
+    ScheimpflugIntrinsicsExport,
+    CalibrationSession<ScheimpflugIntrinsicsProblem>,
+) {
+    let mut config = ScheimpflugIntrinsicsConfig::default();
+    config.distortion_model = model;
+    config.max_iters = 200;
+    // Free k3 so the mask does not clamp a coefficient the extended models want.
+    config.fix_k3_in_init = false;
+
+    let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
+    session.set_config(config).unwrap();
+    session.set_input(dataset.clone()).unwrap();
+
+    step_init_with_seed(&mut session, manual, None).expect("seeded init");
+    step_optimize(&mut session, None).expect("optimize");
+    let export = session.export().expect("export");
+    (export, session)
+}
+
+fn near_gt_manual() -> ScheimpflugManualInit {
+    let mut manual = ScheimpflugManualInit::default();
+    manual.intrinsics = Some(FxFyCxCySkew {
+        fx: gt_intrinsics().fx * 1.01,
+        fy: gt_intrinsics().fy * 1.01,
+        cx: gt_intrinsics().cx + 3.0,
+        cy: gt_intrinsics().cy - 3.0,
+        skew: 0.0,
+    });
+    manual.sensor = Some(ScheimpflugParams {
+        tilt_x: 0.04,
+        tilt_y: -0.015,
+    });
+    manual
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-model round trips
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bc5_pipeline_round_trip() {
+    let dist_gt = BrownConrady5 {
+        k1: -0.10,
+        k2: 0.03,
+        k3: 0.0,
+        p1: 0.0,
+        p2: 0.0,
+        iters: 8,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
+    let dataset = make_dataset(&cam_gt, &gt_poses());
+
+    let (export, _s) = run_pipeline(&dataset, DistortionKind::BrownConrady5, near_gt_manual());
+    let rms = reproj_rms(&export, &dataset);
+    println!("[BC5 pipeline] rms={rms:.4e} px");
+    assert!(rms < 1e-2, "BC5 pipeline reproj RMS too large: {rms:.4e}");
+}
+
+#[test]
+fn rational8_pipeline_round_trip() {
+    let dist_gt = RationalPolynomial {
+        k1: -0.12,
+        k2: 0.04,
+        k3: 0.0,
+        k4: 0.008,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.0006,
+        p2: -0.0004,
+        iters: 10,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
+    let dataset = make_dataset(&cam_gt, &gt_poses());
+
+    let (export, _s) = run_pipeline(&dataset, DistortionKind::Rational8, near_gt_manual());
+    let rms = reproj_rms(&export, &dataset);
+    println!("[Rational8 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Rational8 pipeline reproj RMS too large: {rms:.4e}"
+    );
+}
+
+#[test]
+fn thinprism9_pipeline_round_trip() {
+    let dist_gt = ThinPrism {
+        k1: -0.11,
+        k2: 0.03,
+        k3: 0.0,
+        p1: 0.0006,
+        p2: -0.0004,
+        s1: 0.0003,
+        s2: -0.0002,
+        s3: 0.0002,
+        s4: 0.0,
+        iters: 8,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
+    let dataset = make_dataset(&cam_gt, &gt_poses());
+
+    let (export, _s) = run_pipeline(&dataset, DistortionKind::ThinPrism9, near_gt_manual());
+    let rms = reproj_rms(&export, &dataset);
+    println!("[ThinPrism9 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "ThinPrism9 pipeline reproj RMS too large: {rms:.4e}"
+    );
+}
+
+#[test]
+fn division1_pipeline_round_trip() {
+    let cam_gt = Camera::new(
+        Pinhole,
+        Division { lambda: -0.20 },
+        gt_sensor().compile(),
+        gt_intrinsics(),
+    );
+    let dataset = make_dataset(&cam_gt, &gt_poses());
+
+    let (export, _s) = run_pipeline(&dataset, DistortionKind::Division1, near_gt_manual());
+    let rms = reproj_rms(&export, &dataset);
+    println!("[Division1 pipeline] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "Division1 pipeline reproj RMS too large: {rms:.4e}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rider: a manual Brown-Conrady seed combined with a non-BC5 model embeds
+// (k1,k2,k3,p1,p2) and zeroes the extras; the fit must still converge and the
+// init log must carry the warning.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn manual_bc5_seed_with_extended_model_warns_and_converges() {
+    let dist_gt = RationalPolynomial {
+        k1: -0.12,
+        k2: 0.04,
+        k3: 0.0,
+        k4: 0.008,
+        k5: 0.0,
+        k6: 0.0,
+        p1: 0.0006,
+        p2: -0.0004,
+        iters: 10,
+    };
+    let cam_gt = Camera::new(Pinhole, dist_gt, gt_sensor().compile(), gt_intrinsics());
+    let dataset = make_dataset(&cam_gt, &gt_poses());
+
+    let mut manual = near_gt_manual();
+    manual.distortion = Some(BrownConrady5 {
+        k1: -0.08,
+        ..BrownConrady5::default()
+    });
+
+    let (export, session) = run_pipeline(&dataset, DistortionKind::Rational8, manual);
+    let rms = reproj_rms(&export, &dataset);
+    println!("[manual-BC5 + Rational8] rms={rms:.4e} px");
+    assert!(
+        rms < 1e-2,
+        "manual-seed + Rational8 reproj RMS too large: {rms:.4e}"
+    );
+
+    let warned = session.log().iter().any(|e| {
+        e.notes
+            .as_deref()
+            .is_some_and(|n| n.contains("manual Brown-Conrady distortion seed"))
+    });
+    assert!(
+        warned,
+        "init log must warn about manual BC5 seed + non-BC5 model"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config serde contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn config_distortion_model_json_roundtrip() {
+    for model in [
+        DistortionKind::BrownConrady5,
+        DistortionKind::Rational8,
+        DistortionKind::ThinPrism9,
+        DistortionKind::Division1,
+        DistortionKind::None,
+    ] {
+        let mut config = ScheimpflugIntrinsicsConfig::default();
+        config.distortion_model = model;
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: ScheimpflugIntrinsicsConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.distortion_model, model,
+            "distortion_model roundtrip failed for {model:?}"
+        );
+    }
+}
+
+#[test]
+fn config_missing_distortion_model_defaults_to_bc5() {
+    // A pre-M-WIRE config JSON has no `distortion_model` field: it must
+    // deserialize to BrownConrady5 via #[serde(default = ...)].
+    let default_config = ScheimpflugIntrinsicsConfig::default();
+    let mut json_val: serde_json::Value = serde_json::to_value(&default_config).unwrap();
+    json_val.as_object_mut().unwrap().remove("distortion_model");
+    let json_without_field = serde_json::to_string(&json_val).unwrap();
+
+    let config: ScheimpflugIntrinsicsConfig = serde_json::from_str(&json_without_field).unwrap();
+    assert_eq!(
+        config.distortion_model,
+        DistortionKind::BrownConrady5,
+        "missing field must default to BrownConrady5"
+    );
+}

--- a/docs/adrs/0020-camera-model-as-data-factor-ir.md
+++ b/docs/adrs/0020-camera-model-as-data-factor-ir.md
@@ -9,6 +9,14 @@
   convention gaps made bridging not worth it (Track O closed won't-do
   2026-07-04, see the ADR 0008 note). The accepted trade stands: generic
   `residual<T: RealField>` kernels over hand-derived Jacobians.
+- Note (2026-07-04): Q4-MWIRE-SCHEIMPFLUG extended the Scheimpflug path past
+  the `None | BrownConrady5` distortion pair shown in the `CameraModelDesc`
+  snippet below — `ScheimpflugIntrinsicsConfig::distortion_model`
+  (`vision-calibration-pipeline`) now selects any `DistortionKind` (None,
+  BrownConrady5, Rational8, ThinPrism9, Division1) for the single-camera
+  seeded route, exercising exactly the descriptor-as-data dispatch this ADR
+  describes. Rig `SensorMode::Scheimpflug` stays BC5-typed and fails fast on
+  other models. See ADR 0022's 2026-07-04 note for the optim-side mechanics.
 
 ## Context
 

--- a/docs/adrs/0022-scheimpflug-intrinsics-seeded-default.md
+++ b/docs/adrs/0022-scheimpflug-intrinsics-seeded-default.md
@@ -15,10 +15,20 @@
   through `with_leading_radial`, which sweeps the **leading radial term** —
   `k1` for BrownConrady5/Rational8/ThinPrism9, `lambda` for Division1 — and is
   a no-op for `DistortionKind::None`. The `fix_distortion`
-  (`DistortionFixMask`) mask only applies to BrownConrady5's `[k1, k2, k3, p1,
-  p2]` ordering; for the extended models every distortion coefficient is left
-  free, since the mask does not translate to their orderings. Rigs are
-  unaffected: `SensorMode::Scheimpflug::distortion_model` remains BC5-typed
+  (`DistortionFixMask`) mask — five named bits `{k1, k2, k3, p1, p2}` — is
+  translated **by name** onto each model's packed layout by
+  `fix_mask_indices` (the single mechanism used for both user masks and the
+  A0/A1 staging masks). For BrownConrady5 it is exactly
+  `DistortionFixMask::to_indices()` (byte-identical to the pre-M-WIRE path).
+  For the extended models the shared coefficients map by name and each model's
+  extra coefficients follow the mask bit of the family they belong to:
+  Rational8's higher-order radial block `k4,k5,k6` follows the `k3` bit;
+  ThinPrism9's prism block `s1..s4` is fixed iff **both** `p1` and `p2` are
+  fixed; Division1's single `lambda` follows the leading-radial `k1` bit
+  (consistent with `with_leading_radial`). This keeps the staging invariants —
+  A0 all-fixed, A1 `{k1,k2 free; k3/p1/p2 fixed}` and the default `fix_k3`
+  semantics — intact across every model. Rigs are unaffected:
+  `SensorMode::Scheimpflug::distortion_model` remains BC5-typed
   and is rejected up front for non-BC5 values in `validate_config` (ADR
   0019) — the joint rig bundle adjustment stays Brown-Conrady-only.
 

--- a/docs/adrs/0022-scheimpflug-intrinsics-seeded-default.md
+++ b/docs/adrs/0022-scheimpflug-intrinsics-seeded-default.md
@@ -8,6 +8,19 @@
   planned), and **Q6** adds the convergence-basin study quantifying how much
   spec error the seeded route tolerates (the empirical evidence backing this
   ADR). See `docs/backlog.md` Tracks S/Q.
+- Note (2026-07-04): Q4-MWIRE-SCHEIMPFLUG generalized the seeded route beyond
+  Brown-Conrady-5. `ScheimpflugIntrinsicsConfig::distortion_model` (default
+  `DistortionKind::BrownConrady5`) now selects the model `step_optimize`
+  refines. The Phase A `k1` multi-start grid `{0, −0.20, −0.40}` generalizes
+  through `with_leading_radial`, which sweeps the **leading radial term** —
+  `k1` for BrownConrady5/Rational8/ThinPrism9, `lambda` for Division1 — and is
+  a no-op for `DistortionKind::None`. The `fix_distortion`
+  (`DistortionFixMask`) mask only applies to BrownConrady5's `[k1, k2, k3, p1,
+  p2]` ordering; for the extended models every distortion coefficient is left
+  free, since the mask does not translate to their orderings. Rigs are
+  unaffected: `SensorMode::Scheimpflug::distortion_model` remains BC5-typed
+  and is rejected up front for non-BC5 values in `validate_config` (ADR
+  0019) — the joint rig bundle adjustment stays Brown-Conrady-only.
 
 ## Context
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -128,13 +128,32 @@ two-view/triangulation.
   (S3 spec seeds may expose the cause); ringgrid math note (the bias mechanism
   is its proof). Target: median ≤ 1.0 px; cam5 fixed or excluded with a
   documented physical cause; regression record updated.
-- [ ] Q4-MWIRE-SCHEIMPFLUG - Distortion-model selection on the Scheimpflug
-  path: add `distortion_model: DistortionKind` to `ScheimpflugIntrinsicsConfig`
-  + the rig configs, mirroring the PlanarIntrinsics M-WIRE slice (minimal flat
-  shape — R2/R3 normalizes placement later). Measure the effect on the seeded
-  fits (gated: rtv3d_ref still ≤ 0.5 px) and on the from-scratch floor
-  (informational — this is the suspected V7 factor). App selector → B-QUAL2,
-  Python field → R5.
+- [x] Q4-MWIRE-SCHEIMPFLUG - **Done 2026-07-04.** `distortion_model:
+  DistortionKind` added to `ScheimpflugIntrinsicsConfig` (serde-default
+  BrownConrady5) and to rig `SensorMode::Scheimpflug` (BC5-typed for schema
+  symmetry; non-BC5 rejected up front in both rig `validate_config`s — the
+  joint rig BA stays Brown-Conrady). Optim
+  `ScheimpflugIntrinsicsParams.distortion` generalized to `DistortionParams`
+  with `new_with_distortion`/`distortion_bc5()`/`with_poses()` keeping rig
+  call sites stable; the BC5 packed vector and
+  `PINHOLE4_DIST5_SCHEIMPFLUG2` descriptor are byte-identical to the
+  pre-Q4 path (all pin tests unchanged). The Phase A k1 multi-start
+  generalizes via `with_leading_radial` (k1 for BC5/Rational8/ThinPrism9, λ
+  for Division1); `fix_distortion` masks apply to BC5 only (extended models
+  all-free). New synthetic-GT suites: optim (4 tests) + pipeline (7 tests,
+  incl. JSON roundtrip + missing-field→BC5 + manual-seed-warning). Schemas
+  regenerated; dated notes on ADR 0020 + 0022. **Measurement**
+  (`Q4_DISTORTION_SWEEP=1`, env-gated sweep in the two private intrinsics
+  examples; mean-reproj medians, ±~1e-3 px backend jitter): rtv3d_ref BC5
+  0.3316 / Rational8 0.3400 / ThinPrism9 0.3369 / Division1 0.3507 px —
+  extended models diverge on thin-data cams 3/4 (Rational8 cam4 ~7990 px:
+  extra DOF zero-seeded on a BC5-only linear init are under-constrained
+  there; promotion beyond informational needs a proper warm start).
+  ringgrid BC5 0.4739 / Rational8 0.4698 / ThinPrism9 0.4651 / Division1
+  0.4745 px — richer radial terms nudge the marginal cam1 from 0.5008 to
+  0.4988 px, evidence the suspected V7 floor is partly a
+  distortion-model-order effect on this rig. Committed bench defaults stay
+  BC5, zero baseline drift. App selector → B-QUAL2, Python field → R5.
 - [ ] Q5-RTV3D-SCALE - (absorbs V6-SCALE) Settle the rtv3d absolute scale
   (hexagon 90.1 mm at 5.2 mm cells vs oracle-implied ~98.5 mm; if 98.5 mm is
   right the true cell is ≈ 5.69 mm and both shipped board specs are wrong).

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -139,21 +139,28 @@ two-view/triangulation.
   `PINHOLE4_DIST5_SCHEIMPFLUG2` descriptor are byte-identical to the
   pre-Q4 path (all pin tests unchanged). The Phase A k1 multi-start
   generalizes via `with_leading_radial` (k1 for BC5/Rational8/ThinPrism9, λ
-  for Division1); `fix_distortion` masks apply to BC5 only (extended models
-  all-free). New synthetic-GT suites: optim (4 tests) + pipeline (7 tests,
-  incl. JSON roundtrip + missing-field→BC5 + manual-seed-warning). Schemas
-  regenerated; dated notes on ADR 0020 + 0022. **Measurement**
-  (`Q4_DISTORTION_SWEEP=1`, env-gated sweep in the two private intrinsics
-  examples; mean-reproj medians, ±~1e-3 px backend jitter): rtv3d_ref BC5
-  0.3316 / Rational8 0.3400 / ThinPrism9 0.3369 / Division1 0.3507 px —
-  extended models diverge on thin-data cams 3/4 (Rational8 cam4 ~7990 px:
-  extra DOF zero-seeded on a BC5-only linear init are under-constrained
-  there; promotion beyond informational needs a proper warm start).
-  ringgrid BC5 0.4739 / Rational8 0.4698 / ThinPrism9 0.4651 / Division1
-  0.4745 px — richer radial terms nudge the marginal cam1 from 0.5008 to
-  0.4988 px, evidence the suspected V7 floor is partly a
-  distortion-model-order effect on this rig. Committed bench defaults stay
-  BC5, zero baseline drift. App selector → B-QUAL2, Python field → R5.
+  for Division1); `fix_distortion` masks translate **by name** onto each
+  model's packed layout via `fix_mask_indices` (BC5 identity; k4–k6 follow
+  the k3 bit, s1–s4 fixed iff both p bits, λ follows k1 — so the A0/A1
+  staging invariants and the default fix-k3 semantics hold for every model;
+  codex-review fix, the first sweep's cams-3/4 divergence was exactly the
+  dropped mask). `step_optimize` derives the model seed from the *current*
+  config (no state cache), so `set_config` between init and optimize is
+  honored. New synthetic-GT suites: optim (4 tests) + pipeline (8 tests,
+  incl. JSON roundtrip + missing-field→BC5 + manual-seed-warning +
+  config-change-after-init). Schemas regenerated; dated notes on ADR 0020
+  + 0022. **Measurement** (`Q4_DISTORTION_SWEEP=1`, env-gated sweep in the
+  two private intrinsics examples; mean-reproj medians, ±~1e-3 px backend
+  jitter): under the production `radial_only` mask the model choice alone
+  does not move the seeded floor — rtv3d_ref BC5 = Rational8 = ThinPrism9
+  at 0.3316 px (extras are held at their zero seeds), Division1 0.3358 px
+  (stable but cam3 0.8378); ringgrid likewise 0.4739 px for the three
+  polynomial models, Division1 0.4745 px. An earlier all-free run (the
+  pre-fix bug configuration) hinted extra DOF can nudge the ringgrid
+  knife-edge cam1 0.5008 → 0.4988 px but diverged on rtv3d_ref's thin-data
+  cams 3/4 — a *controlled* all-free sweep with a proper warm start is the
+  V7-floor follow-up if wanted. Committed bench defaults stay BC5, zero
+  baseline drift. App selector → B-QUAL2, Python field → R5.
 - [ ] Q5-RTV3D-SCALE - (absorbs V6-SCALE) Settle the rtv3d absolute scale
   (hexagon 90.1 mm at 5.2 mm cells vs oracle-implied ~98.5 mm; if 98.5 mm is
   right the true cell is ≈ 5.69 mm and both shipped board specs are wrong).


### PR DESCRIPTION
## Summary

Q4-MWIRE-SCHEIMPFLUG (backlog Track Q): mirror the planar M-WIRE slice (PR #79) on the Scheimpflug path.

- `distortion_model: DistortionKind` on `ScheimpflugIntrinsicsConfig` (serde-default `BrownConrady5`) and on rig `SensorMode::Scheimpflug` (BC5-typed for schema symmetry; non-BC5 rejected up front in both rig `validate_config`s per ADR 0019 — the joint rig BA stays Brown-Conrady).
- Optim `ScheimpflugIntrinsicsParams.distortion` generalizes `BrownConrady5` → `DistortionParams`, one code path for BC5/Rational8/ThinPrism9/Division1. `new_with_distortion` / `distortion_bc5()` / `with_poses()` keep rig call sites stable; `new(…)` signature unchanged.
- **BC5 numerics cannot move**: packed vector `[k1,k2,k3,p1,p2]` + `PINHOLE4_DIST5_SCHEIMPFLUG2` descriptor are byte-identical to the pre-Q4 path; all pin tests pass unchanged, and the frozen Q2 baselines reproduce exactly (e.g. ringgrid cam1 `0.5008210444579918`).
- Phase A k1 multi-start generalizes via `with_leading_radial` (k1 for BC5/Rational8/ThinPrism9, λ for Division1; no-op for None).
- `fix_distortion` masks translate **by name** onto each model's packed layout via `fix_mask_indices` (post-review, 7e1c968): BC5 identity; Rational8 k4–k6 follow the k3 bit; ThinPrism9 s1–s4 fixed iff both p1/p2; Division1 λ follows k1. One mechanism for user masks and the A0/A1 staging masks, so the trusted-seed staging invariants and default fix-k3 semantics hold for every model.
- `step_optimize` derives the model seed from the current config (no state cache; post-review, 7e1c968) — `set_config` between init and optimize is honored.
- New synthetic-GT suites: `optim/tests/scheimpflug_distortion_models.rs` (4) + `pipeline/tests/scheimpflug_distortion_models.rs` (8: per-model E2E, JSON roundtrip, missing-field→BC5 back-compat, manual-BC5-seed warning, config-change-after-init).
- Schemas regenerated (4 files); dated notes on ADR 0020 + ADR 0022; backlog completion note with measurements.

## Measurement (the V7-floor question, informational)

Env-gated `Q4_DISTORTION_SWEEP=1` in the two private intrinsics examples (mean-reproj medians, ±~1e-3 px backend jitter), under the production `radial_only` fix mask:

| dataset | BC5 | Rational8 | ThinPrism9 | Division1 |
|---|---|---|---|---|
| rtv3d_ref | 0.3316 | 0.3316 | 0.3316 | 0.3358 |
| rtv3d_ringgrid | 0.4739 | 0.4739 | 0.4739 | 0.4745 |

Model choice alone does not move the seeded floor under production defaults: with the mask correctly translated, Rational8/ThinPrism9 hold their extra coefficients at the zero seed and reduce exactly to BC5; Division1 is marginally worse, as expected for a one-parameter model. An earlier all-free run (the pre-fix bug configuration) hinted extra DOF can nudge the ringgrid knife-edge cam1 from 0.5008 → 0.4988 px but diverged on rtv3d_ref's thin-data cams 3/4 — a controlled all-free sweep with a proper warm start is the V7-floor follow-up if wanted. (The standalone ringgrid example's internal 0.5 px gate failure at cam1 is pre-existing — that exact value is the frozen Q2 baseline.)

## Verification

- fmt / clippy `-D warnings` (all features) / `cargo test --workspace --all-features` (0 failures) / doc warning-free / `cargo xtask emit-schemas --check` clean.
- `calib-bench accept` (tier-b + laser): **19 passed, 0 failed, 2 unavailable, 0 ungated — zero baseline drift, no refreeze** (full run on 5bdd3bf; post-fix spot-check on the touched path reproduces identical numbers).
- Codex review: findings 1–2 fixed in 7e1c968 (see thread replies); finding 3 declined with rationale (deliberate pre-1.0 config-parity decision).

App selector → B-QUAL2; Python field → R5 (per backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ren7uj7tk5MnCtuDZgytut