### PR TITLE
Q7 (re-scoped): make the layering docs tell the truth

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,7 +67,17 @@ better than it found them.
 
 ## Architecture
 
-6-crate workspace (~24k LoC Rust). See ADR 0006.
+Workspace of 11 crates + `xtask` (dev tooling). Nine ship to crates.io in
+dependency order — `vision-calibration-core` → `vision-geometry` →
+`vision-calibration-dataset`/`vision-calibration-detect` →
+`vision-calibration-linear`/`vision-calibration-optim` → `vision-mvg` →
+`vision-calibration-pipeline` → `vision-calibration` (facade — see
+`release.yml`'s publish DAG). `vision-calibration-py` ships to PyPI instead
+(crates.io `publish = false`); `vision-calibration-bench` is
+workspace-internal (`publish = false`); `vision-calibration-examples-private`
+lives *outside* this workspace entirely (its own `[workspace]`), path-pinning
+the published crates for private end-to-end examples. See ADR 0006 (amended
+2026-07-04 for the geometry/mvg edges below).
 
 ```
 vision-calibration (facade) → vision-calibration-pipeline (sessions, workflows)
@@ -75,6 +85,11 @@ vision-calibration (facade) → vision-calibration-pipeline (sessions, workflows
                     vision-calibration-optim + vision-calibration-linear  (peers, no cross-dep)
                                     ↓
                             vision-calibration-core (types, models, RANSAC)
+
+vision-geometry (two-view solvers: homography, epipolar, camera_matrix,
+triangulation) ← depended on by linear, pipeline, and the facade
+        ↓
+vision-mvg (N-view MVG: bundle adjust, rectification, dense stereo) ← facade
 ```
 
 Plus `vision-calibration-py` (PyO3 bindings, depends on facade only).
@@ -177,12 +192,15 @@ in CI:
    version + 4 path-dep pins). Out of the publish set but still
    compiled in CI.
 
-**Publish set (2026-06-17):** `vision-geometry` and `vision-mvg` joined the
-publish set — nine publishable crates total. Crates.io publish order follows
-the dependency DAG: `vision-calibration-core` → `vision-geometry` →
+**Publish set (2026-06-17; DAG corrected 2026-07-04 to match
+`release.yml`):** `vision-geometry` and `vision-mvg` joined the publish
+set — nine publishable crates total. Crates.io publish order follows the
+dependency DAG: `vision-calibration-core` → `vision-geometry` →
+`vision-calibration-dataset` → `vision-calibration-detect` →
 `vision-calibration-linear` → `vision-calibration-optim` →
-`vision-mvg` → `vision-calibration-pipeline` → `vision-calibration` →
-`vision-calibration-py`. `vision-geometry`/`vision-mvg` have never been
+`vision-mvg` → `vision-calibration-pipeline` → `vision-calibration`.
+(`vision-calibration-py` is `publish = false` on crates.io — it ships to
+PyPI via `release-pypi.yml`.) `vision-geometry`/`vision-mvg` have never been
 published, so their first crates.io version is the current workspace version
 (a fresh `0.x` crate may be published at `0.6.0`); the already-published crates
 only need re-publishing on the next workspace-wide version bump.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,7 +92,9 @@ machinery. Init routines additionally get a **convergence-basin study**
 behind ADR 0022. Q2 (regression wiring) lands deliberately early so every
 later algorithm change is guarded. Absorbs: V6 scale (→ Q5), ringgrid
 ellipse-center bias (→ Q3), M-WIRE's Scheimpflug distortion-model wiring
-(→ Q4), C1-FOLLOWUP solver dedup (→ Q7).
+(→ Q4), C1-FOLLOWUP solver dedup (→ Q7). **Q7 resolved-as-already-done
+2026-07-04:** the dedup it was meant to do had already landed in PR #72
+(2026-06-21); see `docs/backlog.md` Q7-SOLVER-DEDUP.
 
 ### Track R — API/config/design revision
 
@@ -421,7 +423,11 @@ dense matcher, no full SfM.
   `vision-calibration-linear` refactor), the two crates were **ported fresh and
   additively** onto `main`: `vision-geometry` (20 tests) + `vision-mvg` (31
   tests), both `publish = false`, no change to `vision-calibration-linear`. The
-  `linear`→`vision-geometry` de-duplication is a deliberate follow-up; ADR 0015.
+  `linear`→`vision-geometry` de-duplication was a deliberate follow-up (ADR
+  0015) — **done, PR #72 (2026-06-21)**: `linear` now depends on
+  `vision-geometry` and its duplicate `homography`/`epipolar`/
+  `camera_matrix`/`triangulation` modules are gone (net −1811 LoC). See
+  `docs/backlog.md` Q7-SOLVER-DEDUP (resolved-as-already-done, 2026-07-04).
 - **C2** N-view triangulation + nonlinear refinement.
 - **C3** Bundle adjustment with frozen intrinsics, free poses, free structure.
 - **C4** Stereo rectification — including **Scheimpflug-aware rectification** (genuinely

--- a/docs/adrs/0006-layered-crate-architecture.md
+++ b/docs/adrs/0006-layered-crate-architecture.md
@@ -1,6 +1,6 @@
 # ADR 0006: Layered Crate Architecture
 
-- Status: Accepted
+- Status: Accepted (amended 2026-07-04)
 - Date: 2026-03-07 (retroactive)
 
 ## Context
@@ -35,3 +35,51 @@ Rules:
 - Users can depend on just `vision-calibration-core` for types, or just `vision-calibration-linear` for solvers, without pulling in optimization or pipeline machinery.
 - The facade crate is the stability boundary: lower crates may evolve faster.
 - Adding a new solver layer (e.g., a different optimizer backend) doesn't affect linear or core.
+
+## Amendments
+
+### 2026-07-04 — `vision-geometry` / `vision-mvg` join the DAG; peer rule intact
+
+[ADR 0015](0015-mvg-ceiling.md) (2026-06-14) added two crates the diagram
+above predates, and PR #72 (2026-06-21, the C1-FOLLOWUP solver dedup) wired
+them into the calibration chain. The original diagram is otherwise still
+accurate; this amendment records the crates and edges it omits, verified
+in-tree at HEAD (2026-07-04):
+
+- **`vision-geometry`** — deterministic two-view solvers (`homography`,
+  `epipolar`, `camera_matrix`, `triangulation`). Depends only on
+  `vision-calibration-core` (`crates/vision-geometry/Cargo.toml`
+  `[dependencies]`).
+- **`vision-mvg`** — pipelines over `vision-geometry` (robust estimation,
+  pose recovery, bundle adjustment, rectification, dense stereo). Depends on
+  `vision-calibration-core` + `vision-geometry`
+  (`crates/vision-mvg/Cargo.toml` `[dependencies]`).
+- Verified dependency edges (each crate's `[dependencies]` table read
+  directly):
+  - `vision-calibration-linear` → `vision-geometry`
+    (`crates/vision-calibration-linear/Cargo.toml`).
+  - `vision-calibration-pipeline` → `vision-geometry`
+    (`crates/vision-calibration-pipeline/Cargo.toml`).
+  - `vision-calibration` (facade) → `vision-geometry` **and** →
+    `vision-mvg` (`crates/vision-calibration/Cargo.toml`).
+- **The linear/optim peer rule above still holds.**
+  `vision-calibration-optim`'s `[dependencies]` list only
+  `vision-calibration-core` plus solver/serde deps (`tiny-solver`, `faer`,
+  `faer-ext`, `serde`, `schemars`) — no edge to `geometry`, `linear`, or
+  `mvg`.
+- **Decision: `dlt_homography` (and the rest of `vision-geometry`) stays in
+  `vision-geometry`, not `vision-calibration-core::linalg`.** `core::linalg`
+  already holds the *primitive* math shared by both crates
+  (`normalize_points_2d`/`_3d`, `null_space`, the polynomial solvers —
+  landed via C1-FOLLOWUP, 2026-06-17). The higher-level DLT/epipolar/
+  triangulation *solvers* have exactly one consumer family (`linear`,
+  `pipeline`, `mvg`, the facade), all of which already depend on
+  `geometry`; moving them into `core` would bloat the
+  zero-workspace-dependency foundation crate for no consumer that doesn't
+  already pull in `geometry`.
+- The "temporary duplication between `vision-calibration-linear` and
+  `vision-geometry`" that ADR 0015 flagged as a Consequence is resolved: PR
+  #72 deleted `linear`'s parallel `homography`/`epipolar`/`camera_matrix`/
+  `triangulation` modules in favor of the `vision-geometry` dependency
+  above (net −1811 LoC). See `docs/backlog.md` Q7-SOLVER-DEDUP
+  (resolved-as-already-done, 2026-07-04).

--- a/docs/adrs/0015-mvg-ceiling.md
+++ b/docs/adrs/0015-mvg-ceiling.md
@@ -1,6 +1,6 @@
 # ADR 0015: Multiple-View Geometry Crates and Scope Ceiling
 
-- Status: Accepted (amended 2026-06-21)
+- Status: Accepted (amended 2026-06-21, 2026-07-04)
 - Date: 2026-06-14
 - Amendment (2026-06-21, C5): the original ceiling "no in-house dense matcher;
   wrap `opencv-rust` SGBM behind a feature flag" is reversed — the dense
@@ -108,3 +108,14 @@ SGBM baseline — so the Rust matcher has a yardstick the moment it is written.
 This keeps the `vision-mvg` ceiling otherwise intact (no SfM / pose-graph / loop
 closure); it only moves the dense-matcher line from "wrap OpenCV" to "Rust in
 the library, OpenCV in the bench."
+
+### 2026-07-04 — C1-FOLLOWUP solver dedup landed (PR #72)
+
+The "temporary duplication between `vision-calibration-linear` and
+`vision-geometry`" noted under Consequences above is resolved. PR #72
+(2026-06-21) made `linear` depend on `vision-geometry` and deleted its
+parallel `homography`/`epipolar`/`camera_matrix`/`triangulation` modules
+(net −1811 LoC per the commit's own message). See
+[ADR 0006's amendment](0006-layered-crate-architecture.md#amendments) for
+the verified dependency edges and `docs/backlog.md` Q7-SOLVER-DEDUP for the
+disposition.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -173,10 +173,23 @@ two-view/triangulation.
   committed into the Scheimpflug math note, linked from ADR 0022. If the basin
   does not comfortably contain realistic spec error (focal ±5 %, tilt ±2°),
   that finding reopens the Phase A sweep design.
-- [ ] Q7-SOLVER-DEDUP - (absorbs the C1-FOLLOWUP remainder) Reconcile the
+- [x] Q7-SOLVER-DEDUP - (absorbs the C1-FOLLOWUP remainder) Reconcile the
   diverged higher-level solvers (`homography`, `epipolar`, `camera_matrix`,
   `triangulation`) duplicated between `linear` and `geometry`: golden-pin
   current outputs on both sides first, then dedup, then verify pins unchanged.
+  **Resolved-as-already-done 2026-07-04.** The premise was stale: this dedup
+  already landed in PR #72 on 2026-06-21 (commit `6818cde`, whose own message
+  reports "Net -1811 LoC of duplicated solver code"). Verified in-tree:
+  `vision-calibration-linear/src/` has no `homography`, `epipolar`,
+  `camera_matrix`, or `triangulation` modules left; `linear` now depends on
+  `vision-geometry` and calls `vision_geometry::homography::dlt_homography`
+  directly (re-exported from `linear::lib`, used by
+  `iterative_intrinsics.rs` and `scheimpflug_init.rs`). No new golden-pin
+  suite is warranted: the existing GT-relative
+  `vision-calibration-linear/tests/stereo_linear.rs` (exercises
+  `vision_geometry::{camera_matrix, epipolar, homography, triangulation}`
+  against ground truth) plus the Q2 committed bench baselines already gate
+  numeric drift end-to-end (YAGNI).
 - [ ] Q8-PROOF-PACKS - Remaining proof packs (batched): hand-eye, laserline
   bundle, rig extrinsics, two-view/triangulation; rectification gets the short
   note only (C4 gate already exists).
@@ -591,6 +604,13 @@ Systemic causes:
     drift**. Q7's plan: golden-pin both sides first, then dedup, then verify
     pins unchanged. Whether the shared home is `core`, `geometry`, or a new
     crate is part of that design.
+    **Correction (2026-07-04):** this bullet was already stale when written
+    2026-07-02 — the dedup it describes as outstanding had in fact landed
+    2026-06-21 in PR #72 (net −1811 LoC): `linear` now depends on `geometry`
+    and calls its `homography`/`epipolar`/`camera_matrix`/`triangulation`
+    directly; no parallel copies remain in `linear`. See the
+    resolved-as-already-done Q7-SOLVER-DEDUP entry above for the verified
+    detail.
   - [x] Promote `vision-geometry` / `vision-mvg` to the crates.io publish set.
     **Done 2026-06-17** (user call): `publish = false` removed from both; the
     `[workspace.dependencies]` version pins were already in place; release


### PR DESCRIPTION
## Summary

Q7-SOLVER-DEDUP's premise turned out to be stale: the `linear` ↔ `geometry` higher-level solver dedup it planned (golden-pin → dedup → verify) **already landed in PR #72 on 2026-06-21** (net −1811 LoC) — `vision-calibration-linear` has no `homography`/`epipolar`/`camera_matrix`/`triangulation` modules left and depends on `vision-geometry` directly. Per the 2026-07-04 planning session, Q7 re-scopes to a doc-only truth pass on the crate layering:

- **backlog**: Q7 marked resolved-as-already-done with in-tree verification; dated correction on the stale C1-FOLLOWUP "Remaining" sub-item that still claimed the duplication was outstanding. No new golden-pin suite (YAGNI): GT-relative `stereo_linear.rs` tests + Q2 committed bench baselines already gate numeric drift.
- **ADR 0006**: amendment (original body untouched) adding `vision-geometry`/`vision-mvg` and the dependency edges verified from each crate's `Cargo.toml` (`linear → geometry`, `pipeline → geometry`, `facade → geometry` + `facade → mvg`, `mvg → geometry/core`); linear↔optim peer rule confirmed intact (optim deps are core-only); decision recorded that `dlt_homography` stays in `vision-geometry` — `core::linalg` holds shared primitives, and the solvers' only consumers already depend on `geometry`.
- **ADR 0015**: dated note that the "temporary duplication" consequence is resolved (PR #72).
- **CLAUDE.md**: architecture section updated from the stale "6-crate workspace (~24k LoC)" to the current 11-crate workspace (+ separate-workspace `examples-private`) with the geometry/mvg edges; the Releasing section's publish DAG corrected to match `release.yml` — `dataset`/`detect` were missing and `vision-calibration-py` (crates.io `publish = false`, ships to PyPI) was wrongly listed.
- **ROADMAP**: Q7 line + Track C C1-FOLLOWUP note updated to match.

No code changes. Every claim was verified against HEAD before writing (crate `src/` listings, `Cargo.toml` dependency tables, `release.yml` publish list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ren7uj7tk5MnCtuDZgytut