### PR TITLE
Q6: convergence-basin study for the seeded Scheimpflug init

### DIFF
--- a/crates/vision-calibration-bench/src/basin.rs
+++ b/crates/vision-calibration-bench/src/basin.rs
@@ -1,0 +1,403 @@
+//! Convergence-basin study for the seeded Scheimpflug initialization
+//! (Q6-BASIN-STUDY; the quantitative evidence behind ADR 0022/0023).
+//!
+//! `calib-bench basin` answers: *how much spec error can the ADR
+//! 0022/0023 seeded route absorb before it stops converging?* For every
+//! registered `scheimpflug_intrinsics` entry it:
+//!
+//! 1. derives the device-spec seed and detects the camera's views once
+//!    (`run::detect_scheimpflug_seeded_input` — detection is the
+//!    expensive step, so it is never repeated per cell);
+//! 2. perturbs the seed over a structured per-axis grid (focal
+//!    multiplier / tilt offset / principal-point offset — never a full
+//!    cross-product) and re-runs `run::solve_scheimpflug_seeded`
+//!    for each cell, reusing the detected dataset;
+//! 3. records whether the cell clears the entry's `accept` gate.
+//!
+//! Entries are grouped into dataset **families** by their shared
+//! `data_root` (the 6 `rtv3d_ref_cam*` entries are one family, the 6
+//! `rtv3d_ringgrid_cam*` entries are another); the report is one
+//! pass-rate table per family plus the widest all-camera-pass interval
+//! per perturbation axis. This subcommand is never wired into CI — it is
+//! a standing diagnostic, run on demand against the private datasets.
+
+#[cfg(feature = "tier-b")]
+pub use tier_b::run_basin_study;
+
+#[cfg(feature = "tier-b")]
+mod tier_b {
+    use std::collections::BTreeMap;
+    use std::fmt::Write as _;
+    use std::path::PathBuf;
+
+    use anyhow::{Context, Result};
+    use vision_calibration::scheimpflug_intrinsics::ScheimpflugManualInit;
+    use vision_calibration_core::{PlanarDataset, ReprojectionStats};
+
+    use crate::registry::{AcceptGate, BenchEntry, ProblemKind};
+    use crate::run::{detect_scheimpflug_seeded_input, progress_label, solve_scheimpflug_seeded};
+
+    /// Focal-length multiplier sweep, applied to both `fx` and `fy`.
+    const FOCAL_MULTIPLIERS: [f64; 9] = [0.50, 0.70, 0.85, 0.95, 1.05, 1.15, 1.30, 1.50, 2.00];
+    /// Scheimpflug tilt offset sweep in degrees, added to both `tilt_x`
+    /// and `tilt_y` (converted to radians before perturbing the seed).
+    const TILT_OFFSETS_DEG: [f64; 8] = [-4.0, -2.0, -1.0, -0.5, 0.5, 1.0, 2.0, 4.0];
+    /// Principal-point offset sweep in pixels, applied to both `cx` and `cy`.
+    const PP_OFFSETS_PX: [f64; 6] = [-100.0, -50.0, -20.0, 20.0, 50.0, 100.0];
+
+    /// A single perturbation of the device-spec seed along one axis, or
+    /// the unperturbed baseline.
+    #[derive(Debug, Clone, Copy)]
+    enum Cell {
+        /// The spec seed exactly as derived — no perturbation.
+        Baseline,
+        /// Multiply `fx`/`fy` by this factor.
+        Focal(f64),
+        /// Add this many degrees to `tilt_x`/`tilt_y`.
+        TiltDeg(f64),
+        /// Add this many pixels to `cx`/`cy`.
+        PrincipalPointPx(f64),
+    }
+
+    impl Cell {
+        fn label(&self) -> String {
+            match self {
+                Cell::Baseline => "baseline (unperturbed spec seed)".to_string(),
+                Cell::Focal(m) => format!("focal ×{m:.2}"),
+                Cell::TiltDeg(d) => format!("tilt {d:+.2}°"),
+                Cell::PrincipalPointPx(p) => format!("pp {p:+.0} px"),
+            }
+        }
+
+        /// Apply this perturbation to a clone of `seed`. `scheimpflug_seed`
+        /// always populates `intrinsics` and `sensor` (ADR 0022: both are
+        /// load-bearing), so the `if let Some` guards are defensive, not
+        /// load-bearing themselves.
+        fn apply(&self, seed: &ScheimpflugManualInit) -> ScheimpflugManualInit {
+            let mut out = seed.clone();
+            match *self {
+                Cell::Baseline => {}
+                Cell::Focal(mult) => {
+                    if let Some(k) = out.intrinsics.as_mut() {
+                        k.fx *= mult;
+                        k.fy *= mult;
+                    }
+                }
+                Cell::TiltDeg(deg) => {
+                    if let Some(s) = out.sensor.as_mut() {
+                        s.tilt_x += deg.to_radians();
+                        s.tilt_y += deg.to_radians();
+                    }
+                }
+                Cell::PrincipalPointPx(px) => {
+                    if let Some(k) = out.intrinsics.as_mut() {
+                        k.cx += px;
+                        k.cy += px;
+                    }
+                }
+            }
+            out
+        }
+    }
+
+    /// The full per-axis sweep: baseline, then focal, then tilt, then
+    /// principal point. ~25-35 solves per camera, never a cross-product.
+    fn all_cells() -> Vec<Cell> {
+        let mut cells = vec![Cell::Baseline];
+        cells.extend(FOCAL_MULTIPLIERS.iter().map(|&m| Cell::Focal(m)));
+        cells.extend(TILT_OFFSETS_DEG.iter().map(|&d| Cell::TiltDeg(d)));
+        cells.extend(PP_OFFSETS_PX.iter().map(|&p| Cell::PrincipalPointPx(p)));
+        cells
+    }
+
+    /// Per-cell pass/fail for one camera, aligned index-for-index with
+    /// [`all_cells`].
+    struct CameraBasinResult {
+        camera_id: String,
+        cells: Vec<bool>,
+    }
+
+    /// A cell "passes" iff the solve succeeds and its bench-recomputed mean
+    /// reprojection error (the same statistic `calib-bench accept` gates
+    /// on) is finite and at or under the entry's gate. A solve error
+    /// (extreme perturbations can knock the non-linear solve over) is
+    /// always a fail, never an operational abort of the whole study.
+    fn cell_passes(
+        dataset: &PlanarDataset,
+        cell: Cell,
+        seed: &ScheimpflugManualInit,
+        gate: AcceptGate,
+        label: &str,
+    ) -> bool {
+        let seeded = cell.apply(seed);
+        match solve_scheimpflug_seeded(dataset.clone(), seeded, label) {
+            Ok(solve) => {
+                let errors: Vec<f64> = solve
+                    .export
+                    .per_feature_residuals
+                    .target
+                    .iter()
+                    .filter_map(|r| r.error_px)
+                    .collect();
+                let mean = ReprojectionStats::from_errors(&errors).mean;
+                mean.is_finite() && mean <= gate.max_per_cam_mean_px
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Widest contiguous interval around `center` (walking outward on each
+    /// side of the axis) for which every cell passed on **all** cameras.
+    /// Stops at the first failing cell in each direction — the basin is
+    /// assumed contiguous, so a pass past a failure is not counted. If the
+    /// baseline itself does not pass on every camera, the interval
+    /// collapses to `(center, center)`, which is itself the loud signal
+    /// (the printed bounds degenerate to a point).
+    fn axis_bounds(
+        cells: &[Cell],
+        all_pass: &[bool],
+        center: f64,
+        project: impl Fn(&Cell) -> Option<f64>,
+    ) -> (f64, f64) {
+        let baseline_idx = cells
+            .iter()
+            .position(|c| matches!(c, Cell::Baseline))
+            .expect("all_cells always includes Baseline");
+        if !all_pass[baseline_idx] {
+            return (center, center);
+        }
+
+        let mut values: Vec<(f64, bool)> = cells
+            .iter()
+            .zip(all_pass)
+            .filter_map(|(c, &pass)| project(c).map(|v| (v, pass)))
+            .collect();
+        values.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+        let mut lower = center;
+        for &(v, pass) in values.iter().filter(|(v, _)| *v < center).rev() {
+            if !pass {
+                break;
+            }
+            lower = v;
+        }
+        let mut upper = center;
+        for &(v, pass) in values.iter().filter(|(v, _)| *v > center) {
+            if !pass {
+                break;
+            }
+            upper = v;
+        }
+        (lower, upper)
+    }
+
+    /// Run the Q6 convergence-basin study over `entries` (already
+    /// filesystem-resolved, i.e. `data_root` absolute) and render the
+    /// markdown report. Returns `Err` only for operational failures
+    /// (bad registry data, a family with zero available cameras across
+    /// the whole run); a narrow basin is reported loudly in the text but
+    /// never turned into an `Err`.
+    pub fn run_basin_study(entries: &[BenchEntry]) -> Result<String> {
+        anyhow::ensure!(
+            !entries.is_empty(),
+            "no scheimpflug_intrinsics entries provided to the basin study"
+        );
+        for entry in entries {
+            anyhow::ensure!(
+                entry.problem == ProblemKind::ScheimpflugIntrinsics,
+                "basin study only supports scheimpflug_intrinsics entries, got `{}` ({:?})",
+                entry.id,
+                entry.problem
+            );
+        }
+
+        let mut families: BTreeMap<PathBuf, Vec<&BenchEntry>> = BTreeMap::new();
+        for entry in entries {
+            families
+                .entry(entry.data_root.clone())
+                .or_default()
+                .push(entry);
+        }
+
+        let cells = all_cells();
+        let mut out = String::new();
+        out.push_str("# Q6 Convergence-Basin Study — Seeded Scheimpflug Intrinsics\n\n");
+        out.push_str(
+            "Perturbs the ADR 0023 device-spec seed over a structured per-axis \
+             grid and re-runs the ADR 0022 seeded route, gating each cell on \
+             the entry's `accept.max_per_cam_mean_px`. See \
+             `docs/notes/scheimpflug-intrinsics.md`.\n\n",
+        );
+
+        let mut envelope_violations: Vec<String> = Vec::new();
+
+        for (data_root, mut family_entries) in families {
+            family_entries.sort_by(|a, b| a.id.cmp(&b.id));
+            let family_name = data_root
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| data_root.display().to_string());
+
+            let mut camera_results: Vec<CameraBasinResult> = Vec::new();
+            for entry in &family_entries {
+                if !entry.data_root.is_dir() {
+                    let _ = writeln!(
+                        out,
+                        "UNAVAILABLE  {} ({} not on disk — skipped, not passed)\n",
+                        entry.id,
+                        entry.data_root.display()
+                    );
+                    continue;
+                }
+                let Some(gate) = entry.accept else {
+                    let _ = writeln!(
+                        out,
+                        "NO-GATE      {} (no `accept` gate — skipped in the basin study)\n",
+                        entry.id
+                    );
+                    continue;
+                };
+                progress_label(&entry.id, "basin: detecting views (once)");
+                let detected = detect_scheimpflug_seeded_input(entry)
+                    .with_context(|| format!("entry `{}`: detection failed", entry.id))?;
+                progress_label(&entry.id, format!("basin: sweeping {} cells", cells.len()));
+                let cell_pass: Vec<bool> = cells
+                    .iter()
+                    .map(|&cell| {
+                        let label = format!("{}/{}", entry.id, cell.label());
+                        cell_passes(&detected.dataset, cell, &detected.seed, gate, &label)
+                    })
+                    .collect();
+                camera_results.push(CameraBasinResult {
+                    camera_id: detected.camera_id,
+                    cells: cell_pass,
+                });
+            }
+
+            if camera_results.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "## {family_name}\n\nNo cameras available for this family — skipped.\n"
+                );
+                continue;
+            }
+
+            render_family(
+                &mut out,
+                &family_name,
+                &cells,
+                &camera_results,
+                &mut envelope_violations,
+            );
+        }
+
+        render_decision_rule(&mut out, &envelope_violations);
+        Ok(out)
+    }
+
+    fn render_family(
+        out: &mut String,
+        family_name: &str,
+        cells: &[Cell],
+        cameras: &[CameraBasinResult],
+        envelope_violations: &mut Vec<String>,
+    ) {
+        let n_cams = cameras.len();
+        let camera_ids = cameras
+            .iter()
+            .map(|c| c.camera_id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(
+            out,
+            "## {family_name} ({n_cams} camera{}: {camera_ids})\n",
+            if n_cams == 1 { "" } else { "s" }
+        );
+        let _ = writeln!(out, "| cell | pass-rate |");
+        let _ = writeln!(out, "|---|---:|");
+        let mut all_pass: Vec<bool> = Vec::with_capacity(cells.len());
+        for (idx, cell) in cells.iter().enumerate() {
+            let pass_count = cameras.iter().filter(|c| c.cells[idx]).count();
+            all_pass.push(pass_count == n_cams);
+            let _ = writeln!(out, "| {} | {}/{} |", cell.label(), pass_count, n_cams);
+        }
+        out.push('\n');
+
+        if !all_pass[0] {
+            let fail_count = n_cams - cameras.iter().filter(|c| c.cells[0]).count();
+            let _ = writeln!(
+                out,
+                "**baseline (unperturbed spec seed) FAILED on {fail_count}/{n_cams} camera(s)** \
+                 — the axis bounds below collapse to the center and should not be trusted.\n"
+            );
+        }
+
+        let focal_bounds = axis_bounds(cells, &all_pass, 1.0, |c| match c {
+            Cell::Focal(m) => Some(*m),
+            _ => None,
+        });
+        let tilt_bounds = axis_bounds(cells, &all_pass, 0.0, |c| match c {
+            Cell::TiltDeg(d) => Some(*d),
+            _ => None,
+        });
+        let pp_bounds = axis_bounds(cells, &all_pass, 0.0, |c| match c {
+            Cell::PrincipalPointPx(p) => Some(*p),
+            _ => None,
+        });
+
+        let _ = writeln!(
+            out,
+            "- focal basin: ×[{:.2}, {:.2}] all-pass",
+            focal_bounds.0, focal_bounds.1
+        );
+        let _ = writeln!(
+            out,
+            "- tilt basin: [{:+.2}°, {:+.2}°] all-pass",
+            tilt_bounds.0, tilt_bounds.1
+        );
+        let _ = writeln!(
+            out,
+            "- principal-point basin: [{:+.0}, {:+.0}] px all-pass\n",
+            pp_bounds.0, pp_bounds.1
+        );
+
+        // Decision rule (ADR 0022/0023, Q6): the basin must comfortably
+        // contain realistic spec error — focal ±5 %, tilt ±2°.
+        if focal_bounds.0 > 0.95 || focal_bounds.1 < 1.05 {
+            envelope_violations.push(format!(
+                "{family_name}: focal basin ×[{:.2}, {:.2}] does not cover ±5% (needs ⊇ [0.95, 1.05])",
+                focal_bounds.0, focal_bounds.1
+            ));
+        }
+        if tilt_bounds.0 > -2.0 || tilt_bounds.1 < 2.0 {
+            envelope_violations.push(format!(
+                "{family_name}: tilt basin [{:+.2}°, {:+.2}°] does not cover ±2° (needs ⊇ [-2°, +2°])",
+                tilt_bounds.0, tilt_bounds.1
+            ));
+        }
+    }
+
+    fn render_decision_rule(out: &mut String, violations: &[String]) {
+        out.push_str("## Decision Rule\n\n");
+        out.push_str(
+            "The seeded route's basin must comfortably contain realistic spec \
+             error: focal ±5 % and tilt ±2° (ADR 0022/0023). Basin narrowness \
+             never fails this command's exit code — only operational errors do.\n\n",
+        );
+        if violations.is_empty() {
+            out.push_str(
+                "RESULT: PASS — every family's focal and tilt basin covers the \
+                 ±5 % / ±2° envelope on all its cameras.\n",
+            );
+            return;
+        }
+        out.push_str("================================================================\n");
+        out.push_str("WARNING: the seeded-init basin does NOT cover the realistic\n");
+        out.push_str("spec-error envelope (focal ±5%, tilt ±2°) on every camera.\n");
+        out.push_str("This finding REOPENS the Phase A sweep design (docs/backlog.md Q6).\n");
+        out.push_str("================================================================\n\n");
+        for v in violations {
+            let _ = writeln!(out, "- {v}");
+        }
+    }
+}

--- a/crates/vision-calibration-bench/src/basin.rs
+++ b/crates/vision-calibration-bench/src/basin.rs
@@ -230,6 +230,7 @@ mod tier_b {
         );
 
         let mut envelope_violations: Vec<String> = Vec::new();
+        let mut swept_cameras = 0usize;
 
         for (data_root, mut family_entries) in families {
             family_entries.sort_by(|a, b| a.id.cmp(&b.id));
@@ -281,6 +282,7 @@ mod tier_b {
                 );
                 continue;
             }
+            swept_cameras += camera_results.len();
 
             render_family(
                 &mut out,
@@ -290,6 +292,14 @@ mod tier_b {
                 &mut envelope_violations,
             );
         }
+
+        // A study that swept nothing has produced no basin evidence; printing
+        // the decision rule would be a vacuous PASS (never a silent pass — S4).
+        anyhow::ensure!(
+            swept_cameras > 0,
+            "basin study swept zero cameras — every selected entry is absent \
+             from disk or has no `accept` gate; no basin evidence produced"
+        );
 
         render_decision_rule(&mut out, &envelope_violations);
         Ok(out)
@@ -398,6 +408,52 @@ mod tier_b {
         out.push_str("================================================================\n\n");
         for v in violations {
             let _ = writeln!(out, "- {v}");
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::registry::{Tier, Visibility};
+
+        /// A registered entry whose data is absent from disk (the state of any
+        /// machine without the private datasets). Sweeping it must not produce
+        /// a vacuous PASS.
+        fn absent_entry() -> BenchEntry {
+            BenchEntry {
+                id: "absent_scheimpflug".into(),
+                visibility: Visibility::Private,
+                tiers: vec![Tier::B],
+                problem: ProblemKind::ScheimpflugIntrinsics,
+                data_root: PathBuf::from("/nonexistent/basin-test-data"),
+                spec: None,
+                detector: None,
+                laser: None,
+                board: None,
+                cameras: Vec::new(),
+                robot_poses: None,
+                prior_export: None,
+                fixture: None,
+                seed: None,
+                device_spec: None,
+                accept: Some(AcceptGate {
+                    max_per_cam_mean_px: 0.5,
+                }),
+                single_cam_handeye: None,
+                rig_handeye: None,
+                stability: Default::default(),
+                crossval: Default::default(),
+                notes: None,
+            }
+        }
+
+        #[test]
+        fn zero_swept_cameras_is_an_operational_error() {
+            let err = run_basin_study(&[absent_entry()]).unwrap_err();
+            assert!(
+                err.to_string().contains("zero cameras"),
+                "expected the vacuous-pass guard, got: {err}"
+            );
         }
     }
 }

--- a/crates/vision-calibration-bench/src/bin/calib_bench.rs
+++ b/crates/vision-calibration-bench/src/bin/calib_bench.rs
@@ -43,6 +43,11 @@ enum Command {
     List(ListArgs),
     /// Run deterministic diagnostic sweeps.
     Diagnose(DiagnoseArgs),
+    /// Convergence-basin study for the seeded Scheimpflug init (Q6):
+    /// perturb every registered `scheimpflug_intrinsics` entry's
+    /// device-spec seed over a structured grid and report the gate
+    /// pass-rate per cell, per dataset family. Never wired into CI.
+    Basin(BasinArgs),
 }
 
 /// Arguments for the `run` subcommand.
@@ -84,6 +89,23 @@ struct AcceptArgs {
     /// to overall mean/RMS and every per-camera mean).
     #[arg(long, default_value_t = 0.05)]
     regression_tol: f64,
+}
+
+/// Arguments for the `basin` subcommand.
+#[derive(Parser)]
+struct BasinArgs {
+    /// Registry JSON path(s). May be repeated. Defaults to the crate's
+    /// `registry/public.json` plus `registry/private.json` when present.
+    #[arg(long)]
+    registry: Vec<PathBuf>,
+    /// Only sweep these `scheimpflug_intrinsics` dataset ids (repeat or
+    /// comma-separate). Defaults to every registered entry.
+    #[arg(long, value_delimiter = ',')]
+    only: Vec<String>,
+    /// Optional path to also write the markdown report to (in addition to
+    /// stdout).
+    #[arg(long)]
+    out: Option<PathBuf>,
 }
 
 /// Arguments for the `report` subcommand.
@@ -404,6 +426,79 @@ fn cmd_accept(args: &AcceptArgs) -> Result<()> {
         failed.join(", ")
     );
     Ok(())
+}
+
+/// Load, filter (`--only`), and filesystem-resolve the `scheimpflug_intrinsics`
+/// entries the `basin` subcommand sweeps. Mirrors `cmd_accept`'s registry
+/// loading + `--only` handling.
+fn load_basin_entries(args: &BasinArgs) -> Result<Vec<BenchEntry>> {
+    let registries = if args.registry.is_empty() {
+        default_accept_registries()
+    } else {
+        args.registry.clone()
+    };
+
+    let mut entries: Vec<BenchEntry> = Vec::new();
+    for path in &registries {
+        let registry =
+            load_registry(path).with_context(|| format!("load registry {}", path.display()))?;
+        entries.extend(registry.datasets);
+    }
+    entries.retain(|e| e.problem == ProblemKind::ScheimpflugIntrinsics);
+    anyhow::ensure!(
+        !entries.is_empty(),
+        "no scheimpflug_intrinsics datasets registered in {}",
+        registries
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    if !args.only.is_empty() {
+        let known: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        for id in &args.only {
+            anyhow::ensure!(
+                known.contains(&id.as_str()),
+                "--only id `{id}` is not a registered scheimpflug_intrinsics dataset (known: {})",
+                known.join(", ")
+            );
+        }
+        entries.retain(|e| args.only.iter().any(|id| id == &e.id));
+    }
+    anyhow::ensure!(
+        !entries.is_empty(),
+        "no scheimpflug_intrinsics datasets selected for the basin study"
+    );
+
+    Ok(entries.into_iter().map(resolve_entry_data_root).collect())
+}
+
+fn cmd_basin(args: &BasinArgs) -> Result<()> {
+    let entries = load_basin_entries(args)?;
+    let report = run_basin_study(&entries)?;
+    // `report` already ends with a newline (the last `writeln!` in the
+    // renderer); `print!` keeps stdout byte-identical to the `--out` file.
+    print!("{report}");
+    if let Some(path) = &args.out {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::write(path, &report)
+            .with_context(|| format!("write basin report {}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "tier-b")]
+fn run_basin_study(entries: &[BenchEntry]) -> Result<String> {
+    vision_calibration_bench::basin::run_basin_study(entries)
+}
+
+#[cfg(not(feature = "tier-b"))]
+fn run_basin_study(_entries: &[BenchEntry]) -> Result<String> {
+    anyhow::bail!("basin requires --features tier-b")
 }
 
 /// Evaluate the hard per-camera gate over a produced record.
@@ -1186,6 +1281,7 @@ fn main() -> Result<()> {
             println!("list: not implemented yet");
         }
         Command::Diagnose(args) => cmd_diagnose(&args)?,
+        Command::Basin(args) => cmd_basin(&args)?,
     }
     Ok(())
 }

--- a/crates/vision-calibration-bench/src/lib.rs
+++ b/crates/vision-calibration-bench/src/lib.rs
@@ -2,6 +2,7 @@
 //! records, stability testing, and cross-validation runners.
 
 pub mod baseline;
+pub mod basin;
 pub mod compare;
 pub mod crossval;
 pub mod dense;

--- a/crates/vision-calibration-bench/src/run.rs
+++ b/crates/vision-calibration-bench/src/run.rs
@@ -9,8 +9,9 @@
 
 #[cfg(feature = "tier-b")]
 pub use tier_b::{
-    diagnose_intrinsics, run_planar_intrinsics, run_rig_extrinsics, run_rig_handeye,
-    run_scheimpflug_intrinsics, run_single_cam_handeye,
+    DetectedScheimpflugCamera, ScheimpflugSeededSolve, detect_scheimpflug_seeded_input,
+    diagnose_intrinsics, progress_label, run_planar_intrinsics, run_rig_extrinsics,
+    run_rig_handeye, run_scheimpflug_intrinsics, run_single_cam_handeye, solve_scheimpflug_seeded,
 };
 
 #[cfg(feature = "tier-b")]
@@ -49,6 +50,15 @@ pub mod tier_b {
     use vision_calibration::rig_laserline_device::{
         RigLaserlineDeviceConfig, RigLaserlineDeviceInput, RigLaserlineDeviceProblem,
         run_calibration as run_rig_laserline_device_calibration,
+    };
+    // Named at module scope so `DetectedScheimpflugCamera` /
+    // `ScheimpflugSeededSolve` can carry them as struct fields; the rest of
+    // the seeded-route surface (`ScheimpflugIntrinsicsConfig`,
+    // `step_init_with_seed`, `step_optimize`, …) stays function-local and
+    // aliased in `solve_scheimpflug_seeded` to avoid colliding with the
+    // identically-named planar-intrinsics steps imported above.
+    use vision_calibration::scheimpflug_intrinsics::{
+        ScheimpflugIntrinsicsExport, ScheimpflugManualInit,
     };
     use vision_calibration::session::CalibrationSession;
     use vision_calibration::single_cam_handeye::{
@@ -584,36 +594,49 @@ pub mod tier_b {
         })
     }
 
-    /// Run the seeded single-camera Scheimpflug intrinsics **acceptance
-    /// route** (ADR 0022/0023) for `entry` and build a [`BenchRecord`].
+    /// Detected views + device-spec-derived seed for a single-camera
+    /// Scheimpflug intrinsics entry (ADR 0022/0023) — the seed-independent
+    /// half of [`run_scheimpflug_intrinsics`].
     ///
     /// Manifest-driven: the entry's `spec` must be a single-camera
     /// `ScheimpflugIntrinsics` dataset manifest (inline or by path —
     /// relative paths resolve against `data_root`) describing the image
     /// glob, ROI tile, and target; the entry's `device_spec` (the ADR 0023
     /// `spec.json` sidecar) provides the seed via
-    /// `device_seed::scheimpflug_seed`. The solve configuration mirrors the
-    /// hard-gated private examples: both tilts free, `k3` + tangential
-    /// fixed (default), Huber(1.0), 120 iterations.
+    /// `device_seed::scheimpflug_seed`.
     ///
-    /// The from-scratch multistart stays in [`diagnose_intrinsics`]
-    /// (informational — V7 is parked); this seeded path is what
-    /// `calib-bench accept` gates on.
-    pub fn run_scheimpflug_intrinsics(entry: &BenchEntry) -> Result<BenchRecord> {
+    /// Detection is the expensive step. [`run_scheimpflug_intrinsics`] calls
+    /// this once and immediately solves; the Q6 convergence-basin study
+    /// (`vision_calibration_bench::basin`) calls this once per camera and
+    /// replays [`solve_scheimpflug_seeded`] over many perturbed copies of
+    /// `seed` without re-detecting.
+    #[derive(Debug, Clone)]
+    pub struct DetectedScheimpflugCamera {
+        /// Camera id (the manifest's single camera).
+        pub camera_id: String,
+        /// Detected planar dataset. Cheap to clone across seed variants.
+        pub dataset: PlanarDataset,
+        /// Device-spec-derived seed. `intrinsics` and `sensor` are always
+        /// `Some` — see `device_seed::scheimpflug_seed`.
+        pub seed: ScheimpflugManualInit,
+        /// Detection stats for the `BenchRecord`.
+        pub detection: Detection,
+        /// Wall-clock detection time in milliseconds.
+        pub detection_ms: u64,
+    }
+
+    /// Detect `entry`'s single camera and derive its ADR 0023 seed. See
+    /// [`DetectedScheimpflugCamera`].
+    pub fn detect_scheimpflug_seeded_input(
+        entry: &BenchEntry,
+    ) -> Result<DetectedScheimpflugCamera> {
         use vision_calibration::device_seed::{DeviceSpec, scheimpflug_seed};
-        // The pipeline-level fix mask, distinct from the optim-level
-        // `ScheimpflugFixMask` imported at module scope (R1 tracks the rename).
-        use vision_calibration::scheimpflug_intrinsics::ScheimpflugFixMask as SchFixMask;
-        use vision_calibration::scheimpflug_intrinsics::{
-            ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsProblem,
-            step_init_with_seed as sch_step_init_with_seed, step_optimize as sch_step_optimize,
-        };
         use vision_calibration_detect::FsDetectionCache;
         use vision_calibration_pipeline::dataset_runner::build_planar_input;
 
         anyhow::ensure!(
             entry.problem == ProblemKind::ScheimpflugIntrinsics,
-            "run_scheimpflug_intrinsics called for {:?}",
+            "detect_scheimpflug_seeded_input called for {:?}",
             entry.problem
         );
         let spec = resolve_dataset_spec(entry)?;
@@ -643,7 +666,7 @@ pub mod tier_b {
         let detect_start = Instant::now();
         let planar = build_planar_input(&spec, &entry.data_root, &cache, false)
             .with_context(|| format!("entry `{}`: manifest detection failed", entry.id))?;
-        let detection_ms = detect_start.elapsed().as_millis() as u64;
+        let detection_ms = ms_since(detect_start);
         let features_detected: usize = planar
             .dataset
             .views
@@ -664,11 +687,50 @@ pub mod tier_b {
             total_expected: 0,
         };
 
-        // ── Seeded calibration (the ADR 0022 supported route) ──────────────
+        Ok(DetectedScheimpflugCamera {
+            camera_id,
+            dataset: planar.dataset,
+            seed,
+            detection,
+            detection_ms,
+        })
+    }
+
+    /// Result of [`solve_scheimpflug_seeded`].
+    #[derive(Debug, Clone)]
+    pub struct ScheimpflugSeededSolve {
+        /// Session export.
+        pub export: ScheimpflugIntrinsicsExport,
+        /// Seeded-init wall-clock time in milliseconds.
+        pub init_ms: u64,
+        /// Optimize wall-clock time in milliseconds.
+        pub optimize_ms: u64,
+    }
+
+    /// Run the seeded Scheimpflug intrinsics init + optimize route (ADR
+    /// 0022) on an already-detected `dataset` with the given `seed`. The
+    /// solve configuration mirrors the hard-gated private examples: both
+    /// tilts free, `k3` + tangential fixed (default), Huber(1.0), 120
+    /// iterations.
+    ///
+    /// `label` only affects progress logging (`entry.id` from
+    /// [`run_scheimpflug_intrinsics`], or a per-cell label from the Q6
+    /// basin study).
+    pub fn solve_scheimpflug_seeded(
+        dataset: PlanarDataset,
+        seed: ScheimpflugManualInit,
+        label: &str,
+    ) -> Result<ScheimpflugSeededSolve> {
+        // The pipeline-level fix mask, distinct from the optim-level
+        // `ScheimpflugFixMask` imported at module scope (R1 tracks the rename).
+        use vision_calibration::scheimpflug_intrinsics::ScheimpflugFixMask as SchFixMask;
+        use vision_calibration::scheimpflug_intrinsics::{
+            ScheimpflugIntrinsicsConfig, ScheimpflugIntrinsicsProblem,
+            step_init_with_seed as sch_step_init_with_seed, step_optimize as sch_step_optimize,
+        };
+
         let mut session = CalibrationSession::<ScheimpflugIntrinsicsProblem>::new();
-        session
-            .set_input(planar.dataset)
-            .context("set_input failed")?;
+        session.set_input(dataset).context("set_input failed")?;
         let mut config = ScheimpflugIntrinsicsConfig::default();
         config.max_iters = 120;
         config.fix_scheimpflug = SchFixMask {
@@ -678,19 +740,44 @@ pub mod tier_b {
         config.robust_loss = RobustLoss::Huber { scale: 1.0 };
         session.set_config(config).context("set_config failed")?;
 
-        progress(entry, "seeded scheimpflug init");
+        progress_label(label, "seeded scheimpflug init");
         let init_start = Instant::now();
-        sch_step_init_with_seed(&mut session, seed, None)
-            .with_context(|| format!("entry `{}`: seeded init failed", entry.id))?;
-        let init_ms = init_start.elapsed().as_millis() as u64;
+        sch_step_init_with_seed(&mut session, seed, None).context("seeded init failed")?;
+        let init_ms = ms_since(init_start);
 
-        progress(entry, "optimizing scheimpflug intrinsics");
+        progress_label(label, "optimizing scheimpflug intrinsics");
         let opt_start = Instant::now();
-        sch_step_optimize(&mut session, None)
-            .with_context(|| format!("entry `{}`: optimize failed", entry.id))?;
-        let optimize_ms = opt_start.elapsed().as_millis() as u64;
+        sch_step_optimize(&mut session, None).context("optimize failed")?;
+        let optimize_ms = ms_since(opt_start);
 
         let export = session.export().context("session.export failed")?;
+        Ok(ScheimpflugSeededSolve {
+            export,
+            init_ms,
+            optimize_ms,
+        })
+    }
+
+    /// Run the seeded single-camera Scheimpflug intrinsics **acceptance
+    /// route** (ADR 0022/0023) for `entry` and build a [`BenchRecord`].
+    ///
+    /// Detects via [`detect_scheimpflug_seeded_input`] and solves via
+    /// [`solve_scheimpflug_seeded`] — see both for the manifest/seed and
+    /// solve-configuration details.
+    ///
+    /// The from-scratch multistart stays in [`diagnose_intrinsics`]
+    /// (informational — V7 is parked); this seeded path is what
+    /// `calib-bench accept` gates on.
+    pub fn run_scheimpflug_intrinsics(entry: &BenchEntry) -> Result<BenchRecord> {
+        anyhow::ensure!(
+            entry.problem == ProblemKind::ScheimpflugIntrinsics,
+            "run_scheimpflug_intrinsics called for {:?}",
+            entry.problem
+        );
+        let detected = detect_scheimpflug_seeded_input(entry)?;
+        let solve = solve_scheimpflug_seeded(detected.dataset, detected.seed, &entry.id)
+            .with_context(|| format!("entry `{}`: seeded solve failed", entry.id))?;
+        let export = solve.export;
 
         // ── Fit metrics (bench-recomputed + export-reported) ───────────────
         let errors: Vec<f64> = export
@@ -719,14 +806,15 @@ pub mod tier_b {
             converged: true,
             report: export.report.clone(),
         };
-        let total_ms = init_ms
-            .saturating_add(optimize_ms)
-            .saturating_add(detection_ms);
+        let total_ms = solve
+            .init_ms
+            .saturating_add(solve.optimize_ms)
+            .saturating_add(detected.detection_ms);
         let timing = Timing {
-            init_ms,
-            optimize_ms,
+            init_ms: solve.init_ms,
+            optimize_ms: solve.optimize_ms,
             total_ms,
-            detection_ms,
+            detection_ms: detected.detection_ms,
             stages: None,
         };
 
@@ -736,7 +824,7 @@ pub mod tier_b {
             fit,
             generalization: None,
             stability: None,
-            detection: Some(detection),
+            detection: Some(detected.detection),
             laser: None,
             robot_corrections: None,
             // Single-camera Scheimpflug intrinsics emits Fit-only metrics and no
@@ -2557,8 +2645,16 @@ pub mod tier_b {
     }
 
     fn progress(entry: &BenchEntry, message: impl std::fmt::Display) {
+        progress_label(&entry.id, message);
+    }
+
+    /// Same as `progress` but keyed by an arbitrary label rather than a
+    /// [`BenchEntry`] — used by [`solve_scheimpflug_seeded`], whose caller
+    /// may be a plain dataset id (`run_scheimpflug_intrinsics`) or a
+    /// per-cell label (the Q6 convergence-basin study).
+    pub fn progress_label(label: &str, message: impl std::fmt::Display) {
         if std::env::var_os("CALIB_BENCH_QUIET").is_none() {
-            eprintln!("[calib-bench:{}] {message}", entry.id);
+            eprintln!("[calib-bench:{label}] {message}");
         }
     }
 

--- a/docs/adrs/0022-scheimpflug-intrinsics-seeded-default.md
+++ b/docs/adrs/0022-scheimpflug-intrinsics-seeded-default.md
@@ -31,6 +31,18 @@
   `SensorMode::Scheimpflug::distortion_model` remains BC5-typed
   and is rejected up front for non-BC5 values in `validate_config` (ADR
   0019) — the joint rig bundle adjustment stays Brown-Conrady-only.
+- Note (2026-07-04): **Q6-BASIN-STUDY closes the forward pointer above** —
+  `calib-bench basin` (`crates/vision-calibration-bench/src/basin.rs`)
+  perturbs the ADR 0023 device-spec seed over independent focal / tilt /
+  principal-point sweeps and re-runs the seeded route per cell, gated on
+  each entry's acceptance threshold. Measured on both private families
+  (`rtv3d_ref`, 6 cameras, gate ≤ 0.5 px; `rtv3d_ringgrid`, 6 cameras, gate
+  ≤ 1.0 px): the all-camera-pass basin is ×[0.85, 1.30] on focal and
+  ±4° on tilt (the full tested tilt sweep — no failure observed at any
+  offset) on **both** families, comfortably containing the decision
+  rule's realistic-spec-error envelope (focal ±5 %, tilt ±2°) with 2-3×
+  margin. See `docs/notes/scheimpflug-intrinsics.md` for the full tables
+  and `docs/backlog.md` Q6 for the completion note.
 
 ## Context
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -167,12 +167,34 @@ two-view/triangulation.
   With S1, the natural fix is a metric anchor in the device spec (known target
   dimension or baseline prior in the rig bundle). Math note states exactly
   which measurement pins scale and its sensitivity. Gate in `rtv3d_rig.rs`.
-- [ ] Q6-BASIN-STUDY - Convergence-basin study for seeded Scheimpflug init:
+- [x] Q6-BASIN-STUDY - Convergence-basin study for seeded Scheimpflug init:
   bench example perturbing spec seeds (focal ×[0.5..2], tilt ±, pp ±) over a
   grid; gate-pass rate per perturbation radius on rtv3d_ref + ringgrid; table
   committed into the Scheimpflug math note, linked from ADR 0022. If the basin
   does not comfortably contain realistic spec error (focal ±5 %, tilt ±2°),
   that finding reopens the Phase A sweep design.
+  **Done 2026-07-04.** Added `calib-bench basin` (`--only`/`--out`, follows
+  the `accept` registry/device-spec pattern; never wired into CI) which
+  detects each of the 12 registered `scheimpflug_intrinsics` cameras' views
+  once, derives the ADR 0023 spec seed once, then re-runs the ADR 0022
+  seeded route over three independent per-axis sweeps (24 solves/camera,
+  never a cross-product: focal ×{0.50, 0.70, 0.85, 0.95, 1.05, 1.15, 1.30,
+  1.50, 2.00}, tilt {±0.5°, ±1°, ±2°, ±4°} added to both axes, principal
+  point {±20, ±50, ±100} px added to both axes) and gates each cell on the
+  entry's `accept.max_per_cam_mean_px`. Measured on both private families
+  (12 cameras total, full run ~1.5 min): `rtv3d_ref` (gate ≤ 0.5 px) and
+  `rtv3d_ringgrid` (gate ≤ 1.0 px) both clear the all-camera-pass envelope
+  at focal ×[0.85, 1.30] and tilt [−4°, +4°] (the entire tested tilt sweep —
+  no failure observed at any offset), comfortably exceeding the decision
+  rule's focal ±5 % / tilt ±2° requirement (2-3× margin); principal point is
+  all-pass over the full ±100 px sweep on both families. **Decision rule
+  outcome: PASS — no reopening of the Phase A sweep design.** Refactored
+  `run_scheimpflug_intrinsics` (`vision-calibration-bench/src/run.rs`) into
+  `detect_scheimpflug_seeded_input` + `solve_scheimpflug_seeded` so the
+  basin study reuses the exact acceptance-route machinery instead of a
+  parallel copy; `calib-bench accept` behavior/output is unchanged (see
+  `docs/notes/scheimpflug-intrinsics.md` for the full tables and ADR 0022's
+  2026-07-04 note for the closed forward pointer).
 - [x] Q7-SOLVER-DEDUP - (absorbs the C1-FOLLOWUP remainder) Reconcile the
   diverged higher-level solvers (`homography`, `epipolar`, `camera_matrix`,
   `triangulation`) duplicated between `linear` and `geometry`: golden-pin

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -50,3 +50,7 @@ gate exists), two-view/triangulation.
 
 - [Planar intrinsics](planar-intrinsics.md) — Zhang init + Brown–Conrady
   refinement (the template pack).
+- [Scheimpflug intrinsics](scheimpflug-intrinsics.md) — stub pack (full
+  pack is Q8): model summary, the ADR 0022/0023 seeded route, and the Q6
+  convergence-basin study (`calib-bench basin`) with measured basins for
+  `rtv3d_ref` / `rtv3d_ringgrid`.

--- a/docs/notes/scheimpflug-intrinsics.md
+++ b/docs/notes/scheimpflug-intrinsics.md
@@ -1,0 +1,148 @@
+# Scheimpflug intrinsics — proof-pack stub
+
+Family: single-camera intrinsics from planar-target views on a tilted
+sensor (`ScheimpflugIntrinsicsProblem`; init in
+`vision-calibration-linear::scheimpflug_init`, refinement in
+`vision-calibration-optim::problems::scheimpflug_intrinsics`). This is a
+**stub** — the full proof pack (matrix test, identifiability/gauge
+analysis, noise sensitivity) is Q8; this note exists to close the loop on
+the basin-study evidence ADR 0022 promised (Q6), run 2026-07-04 against
+HEAD `q6-basin-study` (cut from `main` at `a974a48`).
+
+## Model
+
+Composable camera (ADR 0005), Scheimpflug specialization: `pixel =
+K(sensor(distortion(projection(dir))))`, i.e. pinhole projection, then
+Brown-Conrady radial/tangential distortion on normalized coordinates
+(same equations as the planar family — see
+`docs/notes/planar-intrinsics.md`), then an OpenCV-compatible
+`ScheimpflugParams { tilt_x, tilt_y }` homography sensor stage
+(`HomographySensor`, `vision_calibration_core::models::sensor`) that maps
+the tilted sensor plane back to the frontal normalized plane before the
+pinhole intrinsics `K` are applied. `tilt_x`/`tilt_y` couple with focal
+length and radial distortion — the classic tilt↔focal↔distortion
+degeneracy that motivates ADR 0022's seeded route (from-scratch init
+lands in the wrong basin; see ADR 0022's Context section for the
+measured evidence).
+
+## The seeded route (ADR 0022/0023)
+
+`step_init_with_seed` takes a spec-derived coarse prior — `fx = fy =
+focal_mm·1000/pixel_pitch_um`, principal point at the resolution center,
+and mount tilt in radians (`device_seed::scheimpflug_seed`, ADR 0023) —
+and refines it with bundle adjustment. The trusted-tilt solve is
+two-phase: **Phase A** sweeps `k1` (or the model's leading radial term,
+ADR 0022's 2026-07-04 note) start points `{0, −0.20, −0.40}` with
+intrinsics and tilt fixed, each preceded by a pose-only adaptation;
+**Phase B** is a bounded joint refine with tilt held to `seed ± 0.10
+rad`, focal to `[0.75, 1.5]×`, principal point free. Hard acceptance gate:
+mean reprojection ≤ 0.5 px per camera (`calib-bench accept`, S4).
+
+## The basin study (Q6)
+
+`calib-bench basin` (`crates/vision-calibration-bench/src/basin.rs`)
+quantifies how much spec error this route tolerates. For every registered
+`scheimpflug_intrinsics` entry it detects the camera's views once, derives
+the ADR 0023 seed once, then perturbs the seed over three independent
+per-axis sweeps (never a cross-product — 24 solves/camera) and re-runs
+the seeded route per cell, gating each on the entry's
+`accept.max_per_cam_mean_px`:
+
+- **focal multiplier** (`fx`, `fy` scaled together): ×{0.50, 0.70, 0.85,
+  0.95, 1.05, 1.15, 1.30, 1.50, 2.00}
+- **tilt offset** (added to both `tilt_x`, `tilt_y`): {−4°, −2°, −1°,
+  −0.5°, +0.5°, +1°, +2°, +4°}
+- **principal-point offset** (added to both `cx`, `cy`): {−100, −50, −20,
+  +20, +50, +100} px
+- plus the unperturbed baseline cell
+
+Run: `cargo run --release -p vision-calibration-bench --bin calib-bench
+--features "tier-b laser" -- basin`. Total wall time for all 12 registered
+cameras (`rtv3d_ref_cam0..5`, `rtv3d_ringgrid_cam0..5`): **~1.5 minutes**
+(well under the ~30-45 min budget) — each entry's 24-cell sweep reuses one
+detection pass, so the cost is dominated by 24 bundle-adjustment solves on
+a 20-22-view dataset, not detection.
+
+### Measured tables (2026-07-04)
+
+**`rtv3d_ref`** (6 cameras, gate ≤ 0.5 px/camera):
+
+| cell | pass-rate |
+|---|---:|
+| baseline (unperturbed spec seed) | 6/6 |
+| focal ×0.50 | 0/6 |
+| focal ×0.70 | 4/6 |
+| focal ×0.85 | 6/6 |
+| focal ×0.95 | 6/6 |
+| focal ×1.05 | 6/6 |
+| focal ×1.15 | 6/6 |
+| focal ×1.30 | 6/6 |
+| focal ×1.50 | 1/6 |
+| focal ×2.00 | 0/6 |
+| tilt −4.00° .. +4.00° (all 8 offsets) | 6/6 |
+| pp −100 .. +100 px (all 6 offsets) | 6/6 |
+
+- focal basin: ×[0.85, 1.30] all-pass
+- tilt basin: [−4.00°, +4.00°] all-pass (the full sweep — no failure observed)
+- principal-point basin: [−100, +100] px all-pass (the full sweep)
+
+**`rtv3d_ringgrid`** (6 cameras, gate ≤ 1.0 px/camera):
+
+| cell | pass-rate |
+|---|---:|
+| baseline (unperturbed spec seed) | 6/6 |
+| focal ×0.50 | 0/6 |
+| focal ×0.70 | 5/6 |
+| focal ×0.85 | 6/6 |
+| focal ×0.95 | 6/6 |
+| focal ×1.05 | 6/6 |
+| focal ×1.15 | 6/6 |
+| focal ×1.30 | 6/6 |
+| focal ×1.50 | 3/6 |
+| focal ×2.00 | 0/6 |
+| tilt −4.00° .. +4.00° (all 8 offsets) | 6/6 |
+| pp −100 .. +100 px (all 6 offsets) | 6/6 |
+
+- focal basin: ×[0.85, 1.30] all-pass
+- tilt basin: [−4.00°, +4.00°] all-pass (the full sweep)
+- principal-point basin: [−100, +100] px all-pass (the full sweep)
+
+(Full per-cell tables, rendered by the tool itself, are reproducible with
+the command above; these are the same numbers, condensed here for the
+tilt/pp axes since every tested offset passed on all cameras.)
+
+### Conclusion vs. the decision rule
+
+The decision rule (ADR 0022/0023, backlog Q6) is: the basin must
+comfortably contain realistic spec error — **focal ±5 %, tilt ±2°** —
+on every camera. Both families clear it with wide margin:
+
+- **Focal**: measured all-pass basin ×[0.85, 1.30] ⊃ the required
+  ×[0.95, 1.05] — **2-3× the required margin** in relative terms (15 %
+  below / 30 % above vs. the required 5 %).
+- **Tilt**: measured all-pass basin covers the *entire* tested sweep,
+  ±4° ⊃ the required ±2° — **2× the required margin**, and the true
+  basin may be wider still (the sweep did not find a tilt-axis failure
+  at any tested offset).
+- **Principal point** (not part of the decision rule, informational):
+  all-pass over the entire ±100 px sweep on both families.
+
+**RESULT: PASS.** The seeded route's basin comfortably contains
+realistic spec error on both private datasets; this closes the Q6 loop
+and is the quantitative evidence ADR 0022 forward-referenced. No
+reopening of the Phase A sweep design is warranted by this run.
+
+## Evidence
+
+- **Acceptance gates**: `calib-bench accept` — `rtv3d_ref_cam0..5` gated
+  at ≤ 0.5 px/camera, `rtv3d_ringgrid_cam0..5` at ≤ 1.0 px/camera (the
+  provisional pre-Q3 ringgrid bar), both against the ADR 0023 device-spec
+  seed (S4).
+- **Basin study**: `calib-bench basin` (this note), Q6.
+- **Related**: ADR 0022 (seeded init is the supported default — the
+  from-scratch fragility this decision steps around), ADR 0023
+  (`DeviceSpec` schema and seed derivation), `docs/notes/planar-intrinsics.md`
+  (the distortion/projection equations shared with this family).
+- **Follow-up (Q8)**: the full proof pack — synthetic-GT matrix test,
+  identifiability/gauge write-up (tilt↔focal↔distortion, `k1`'s spurious
+  zero-basin), and noise-sensitivity numbers.


### PR DESCRIPTION
## Summary

Q6-BASIN-STUDY (backlog Track Q): the quantitative evidence behind ADR 0022's seeded-init decision — how much device-spec error the seeded Scheimpflug route tolerates before missing its acceptance gate.

- New **`calib-bench basin`** subcommand (`--only`/`--out`, follows the `accept` registry/device-spec pattern; never wired into CI, prints `UNAVAILABLE` for absent datasets). Per registered `scheimpflug_intrinsics` camera: detect views once, derive the ADR 0023 `spec.json` seed once, then re-run the ADR 0022 seeded route over three independent per-axis sweeps (24 solves/camera, no cross-product): focal ×{0.50…2.00}, tilt ±{0.5°…4°}, principal point ±{20…100} px — each cell gated on the entry's `accept.max_per_cam_mean_px`.
- **DRY refactor**: `run_scheimpflug_intrinsics` is split into `detect_scheimpflug_seeded_input` + `solve_scheimpflug_seeded`, so `basin` replays the *exact* acceptance-route machinery instead of a parallel copy. `accept` is behaviorally unchanged — verified numerically (worst-per-cam means reproduce the committed ADR 0022 table exactly).
- New `docs/notes/scheimpflug-intrinsics.md` proof-pack stub (model summary, seeded route, basin method + tables; the full pack remains Q8), indexed in `docs/notes/README.md` and linked from ADR 0022's now-closed Q6 forward pointer. Backlog Q6 marked done.

## Results (2026-07-04, both private families, ~1.5 min wall)

| axis | rtv3d_ref (gate 0.5 px) | rtv3d_ringgrid (gate 1.0 px) |
|---|---|---|
| focal | ×[0.85, 1.30] all-pass | ×[0.85, 1.30] all-pass |
| tilt | ±4° all-pass (entire sweep) | ±4° all-pass (entire sweep) |
| principal point | ±100 px all-pass (entire sweep) | ±100 px all-pass (entire sweep) |

**Decision rule (focal ±5 %, tilt ±2°): PASS with 2–3× margin on every camera of both families — the Phase A sweep design stays closed.** Failure onset is where expected: focal ×0.70 and ×1.50 start dropping cameras; ×0.50/×2.00 fail everywhere.

## Verification

- fmt / clippy `-D warnings` (all features) / bench tests (41 passed) / full workspace tests / doc warning-free — all green.
- `calib-bench accept --only rtv3d_ref_cam0,rtv3d_ref_cam1,rtv3d_ringgrid_cam0` post-refactor reproduces `0.3728 / 0.2669 / 0.4601 px` — byte-identical acceptance behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ren7uj7tk5MnCtuDZgytut