### PR TITLE
Q3+Q5+Q8: Track Q soundness close-out — proof packs, ringgrid bias verdict, rtv3d scale settled

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
  "clap",
  "image",
  "nalgebra",
- "projective-grid 0.9.0",
+ "projective-grid",
  "thiserror 2.0.18",
 ]
 
@@ -530,7 +530,7 @@ dependencies = [
  "chess-corners",
  "log",
  "nalgebra",
- "projective-grid 0.9.0",
+ "projective-grid",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -546,7 +546,7 @@ dependencies = [
  "kiddo",
  "log",
  "nalgebra",
- "projective-grid 0.9.0",
+ "projective-grid",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -560,7 +560,7 @@ dependencies = [
  "chess-corners",
  "log",
  "nalgebra",
- "projective-grid 0.9.0",
+ "projective-grid",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -608,7 +608,7 @@ dependencies = [
  "calib-targets-core",
  "chess-corners",
  "nalgebra",
- "projective-grid 0.9.0",
+ "projective-grid",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4185,18 +4185,6 @@ dependencies = [
 
 [[package]]
 name = "projective-grid"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c309be7859234ef1fbe943e4be1af38062c60343e8e46989493a1d5a20fe72"
-dependencies = [
- "kiddo",
- "nalgebra",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "projective-grid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c6ff1a535e642c2e3729c31677556ec2351db090c685906f09da8b6b35790a"
@@ -4323,9 +4311,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radsym"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7a42afc1f831c6601e9a37a97b3f3a07529f074f771c23e68b9cbb66e9fd40"
+checksum = "a4d78cf67d536b598ea1679ceedc6153360c30ec6dbd40a0179bd2e2f366c08b"
 dependencies = [
  "box-image-pyramid 0.4.2",
  "nalgebra",
@@ -4680,15 +4668,15 @@ checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ringgrid"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165014cdd5129232f400ef26120def921c4f8e1ac7b7bb4a51da6ec788241e7"
+checksum = "feebd58c53849e9c954ac00d399a6ea992ccc8ac83aef15ee5f6b83d7e07f7f5"
 dependencies = [
  "approx",
  "image",
  "nalgebra",
  "png 0.18.1",
- "projective-grid 0.5.3",
+ "projective-grid",
  "radsym",
  "rand 0.10.1",
  "serde",

--- a/crates/vision-calibration-bench/src/lib.rs
+++ b/crates/vision-calibration-bench/src/lib.rs
@@ -12,5 +12,6 @@ pub mod fixtures;
 pub mod params;
 pub mod record;
 pub mod registry;
+pub mod ringgrid_bias;
 pub mod run;
 pub mod stability;

--- a/crates/vision-calibration-bench/src/ringgrid_bias.rs
+++ b/crates/vision-calibration-bench/src/ringgrid_bias.rs
@@ -1,0 +1,491 @@
+//! Closed-form ellipse-center (conic-center) bias for coded ring-grid markers.
+//!
+//! A coded ring marker is a pair of concentric circles on the board plane.
+//! Under perspective — and Scheimpflug tilt, which is a homography acting on
+//! normalized coordinates — a circle projects to a conic whose **ellipse
+//! center** is *not* the projection of the circle's 3D center. The offset is
+//! the ellipse-center bias this module quantifies.
+//!
+//! # Mechanism (why the closed form is exact for the no-distortion map)
+//!
+//! Board plane → pixel factors, when lens distortion is set aside, into a
+//! single homography
+//!
+//! ```text
+//! H = K · H_tilt · [r1 r2 t]
+//! ```
+//!
+//! (intrinsics `K`, Scheimpflug tilt `H_tilt`, and the planar-pose homography
+//! `[r1 r2 t]` from `camera_se3_target`). A circle with conic matrix `C` on
+//! the plane images to the conic `C' = H⁻ᵀ C H⁻¹`; the bias is
+//! `center(C') − H·center`. Distortion is *not* a homography, so it is
+//! excluded from `H` here — its contribution is treated separately in the
+//! math note (`docs/notes/ringgrid-bias.md`).
+//!
+//! # This module is a diagnostic, not a correction
+//!
+//! The `ringgrid` detector (≥ 0.7) already removes the *projective* part of
+//! this bias at the observation level, before calibration ever sees a center,
+//! via an intrinsics-free two-conic pencil
+//! (`CircleRefinementMethod::ProjectiveCenter`, on by default). The functions
+//! here recover the magnitude of the effect the detector cancels and let the
+//! diagnostic in [`diagnose`] check whether any of it survives into the
+//! calibration residual field. See `docs/notes/ringgrid-bias.md` for the
+//! evidence and the decision not to add a redundant pipeline-side correction.
+
+use nalgebra::{Matrix2, Matrix3, Vector2, Vector3};
+
+use vision_calibration::core::{IntrinsicsParams, SensorParams};
+use vision_calibration::scheimpflug_intrinsics::ScheimpflugIntrinsicsExport;
+
+/// Symmetric conic matrix of a circle of radius `r` centered at `(cx, cy)` on
+/// a plane. A homogeneous plane point `p = (x, y, 1)` lies on the circle iff
+/// `pᵀ C p = 0`.
+pub fn circle_conic(cx: f64, cy: f64, r: f64) -> Matrix3<f64> {
+    Matrix3::new(
+        1.0,
+        0.0,
+        -cx,
+        0.0,
+        1.0,
+        -cy,
+        -cx,
+        -cy,
+        cx * cx + cy * cy - r * r,
+    )
+}
+
+/// Push a plane conic `c` through the plane→image homography `h`:
+/// `C' = H⁻ᵀ C H⁻¹`. Returns `None` if `h` is singular.
+pub fn project_conic(c: &Matrix3<f64>, h: &Matrix3<f64>) -> Option<Matrix3<f64>> {
+    let h_inv = h.try_inverse()?;
+    Some(h_inv.transpose() * c * h_inv)
+}
+
+/// Inhomogeneous center `(u, v)` of a non-degenerate central conic `C`.
+///
+/// The center is the stationary point of the quadratic form, i.e. the
+/// solution of `[[C₀₀, C₀₁], [C₀₁, C₁₁]] · [u, v]ᵀ = −[C₀₂, C₁₂]ᵀ`. Returns
+/// `None` when the top-left 2×2 block is singular (parabolic / degenerate).
+pub fn conic_center(c: &Matrix3<f64>) -> Option<[f64; 2]> {
+    let a = Matrix2::new(c[(0, 0)], c[(0, 1)], c[(0, 1)], c[(1, 1)]);
+    let b = Vector2::new(-c[(0, 2)], -c[(1, 2)]);
+    let x = a.try_inverse()? * b;
+    Some([x.x, x.y])
+}
+
+/// Project the plane point `(x, y, 1)` through `h`, dehomogenizing. `None`
+/// when the image point is at infinity.
+pub fn project_point(h: &Matrix3<f64>, x: f64, y: f64) -> Option<[f64; 2]> {
+    let p = h * Vector3::new(x, y, 1.0);
+    if p.z.abs() < 1e-12 {
+        return None;
+    }
+    Some([p.x / p.z, p.y / p.z])
+}
+
+/// Predicted single-conic ellipse-center bias, in pixels, for a circle of
+/// radius `r` centered at `(cx, cy)` on the plane, imaged through the
+/// no-distortion homography `h`: `center(H⁻ᵀ C H⁻¹) − H·(cx, cy)`.
+pub fn predicted_center_bias(h: &Matrix3<f64>, cx: f64, cy: f64, r: f64) -> Option<[f64; 2]> {
+    let conic = project_conic(&circle_conic(cx, cy, r), h)?;
+    let ellipse_c = conic_center(&conic)?;
+    let true_c = project_point(h, cx, cy)?;
+    Some([ellipse_c[0] - true_c[0], ellipse_c[1] - true_c[1]])
+}
+
+/// Build the `3×3` intrinsics matrix `K` from serializable intrinsics.
+fn k_matrix(intr: &IntrinsicsParams) -> Matrix3<f64> {
+    let IntrinsicsParams::FxFyCxCySkew { params } = intr;
+    Matrix3::new(
+        params.fx,
+        params.skew,
+        params.cx,
+        0.0,
+        params.fy,
+        params.cy,
+        0.0,
+        0.0,
+        1.0,
+    )
+}
+
+/// The Scheimpflug tilt homography (normalized → sensor), or identity for a
+/// non-tilted sensor.
+fn tilt_homography(sensor: &SensorParams) -> Matrix3<f64> {
+    match sensor {
+        SensorParams::Scheimpflug { params } => params.compile().h,
+        SensorParams::Homography { h } => Matrix3::from_row_slice(&[
+            h[0][0], h[0][1], h[0][2], h[1][0], h[1][1], h[1][2], h[2][0], h[2][1], h[2][2],
+        ]),
+        SensorParams::Identity => Matrix3::identity(),
+    }
+}
+
+/// Summary statistics for a scalar sample (all in the sample's own units).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Stats {
+    /// Number of samples.
+    pub n: usize,
+    /// Arithmetic mean.
+    pub mean: f64,
+    /// Median (50th percentile).
+    pub median: f64,
+    /// 95th percentile.
+    pub p95: f64,
+    /// Maximum.
+    pub max: f64,
+}
+
+impl Stats {
+    /// Order statistics of `values` (consumed and sorted in place).
+    pub fn from_values(mut values: Vec<f64>) -> Self {
+        if values.is_empty() {
+            return Self::default();
+        }
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let n = values.len();
+        let mean = values.iter().sum::<f64>() / n as f64;
+        let pct = |q: f64| values[((q * (n - 1) as f64).round() as usize).min(n - 1)];
+        Self {
+            n,
+            mean,
+            median: pct(0.5),
+            p95: pct(0.95),
+            max: values[n - 1],
+        }
+    }
+}
+
+/// Result of [`diagnose`]: the closed-form bias distribution and how much of
+/// it survives into the calibration residual field.
+#[derive(Debug, Clone)]
+pub struct RinggridBiasReport {
+    /// Number of (view, marker) observations analyzed.
+    pub n_obs: usize,
+    /// `|bias|` of the outer-ring conic center, px.
+    pub bias_outer: Stats,
+    /// `|bias|` of the inner-ring conic center, px.
+    pub bias_inner: Stats,
+    /// `|bias|` of the mean of the two single-conic centers — a proxy for a
+    /// naive detector that averages the inner/outer ellipse centers, px.
+    pub bias_mean_conic: Stats,
+    /// `|observed − projected|`, the calibration residual actually seen, px.
+    pub residual: Stats,
+    /// `Σ(r·b) / Σ|b|²` with `b` the outer-conic bias vector and `r` the
+    /// residual vector. ≈ 1 if the residual field *is* the naive bias
+    /// (detector correction absent); ≈ 0 if the residual is orthogonal noise
+    /// (detector already removed the projective bias).
+    pub residual_bias_fraction: f64,
+    /// Mean cosine between residual and outer-bias vectors (−1..1).
+    pub mean_cosine: f64,
+    /// Pearson correlation between `|outer bias|` and pixel radius from the
+    /// principal point — positive if the bias grows toward the periphery.
+    pub bias_vs_radius_corr: f64,
+}
+
+/// Compute the closed-form ellipse-center bias distribution for a solved
+/// Scheimpflug ring-grid camera and compare it against the residual field.
+///
+/// `r_outer_m` / `r_inner_m` are the ring's outer / inner radii in metres
+/// (board spec). Per (view, marker) the bias uses the no-distortion
+/// homography `K · H_tilt · [r1 r2 t]` from the exported model and pose.
+pub fn diagnose(
+    export: &ScheimpflugIntrinsicsExport,
+    r_outer_m: f64,
+    r_inner_m: f64,
+) -> RinggridBiasReport {
+    let k = k_matrix(&export.params.camera.intrinsics);
+    let cx0 = k[(0, 2)];
+    let cy0 = k[(1, 2)];
+    let h_tilt = tilt_homography(&export.params.camera.sensor);
+    let poses = &export.params.camera_se3_target;
+
+    // Cache the no-distortion homography per view.
+    let h_nodistort: Vec<Matrix3<f64>> = poses
+        .iter()
+        .map(|iso| {
+            let rot = iso.rotation.to_rotation_matrix();
+            let r = rot.matrix();
+            let t = iso.translation.vector;
+            let h_pose = Matrix3::from_columns(&[r.column(0).into(), r.column(1).into(), t]);
+            k * h_tilt * h_pose
+        })
+        .collect();
+
+    let mut outer = Vec::new();
+    let mut inner = Vec::new();
+    let mut mean_conic = Vec::new();
+    let mut resid = Vec::new();
+    let mut radius = Vec::new();
+    let mut sum_dot = 0.0;
+    let mut sum_bb = 0.0;
+    let mut cos_acc = 0.0;
+    let mut cos_n = 0usize;
+
+    for rec in &export.per_feature_residuals.target {
+        let Some(projected) = rec.projected_px else {
+            continue;
+        };
+        let h = &h_nodistort[rec.pose];
+        let (cx, cy) = (rec.target_xyz_m[0], rec.target_xyz_m[1]);
+        let (Some(bo), Some(bi)) = (
+            predicted_center_bias(h, cx, cy, r_outer_m),
+            predicted_center_bias(h, cx, cy, r_inner_m),
+        ) else {
+            continue;
+        };
+
+        let bo_n = (bo[0] * bo[0] + bo[1] * bo[1]).sqrt();
+        let bi_n = (bi[0] * bi[0] + bi[1] * bi[1]).sqrt();
+        let bm = [(bo[0] + bi[0]) * 0.5, (bo[1] + bi[1]) * 0.5];
+        let bm_n = (bm[0] * bm[0] + bm[1] * bm[1]).sqrt();
+
+        let r_vec = [
+            rec.observed_px[0] - projected[0],
+            rec.observed_px[1] - projected[1],
+        ];
+        let r_n = (r_vec[0] * r_vec[0] + r_vec[1] * r_vec[1]).sqrt();
+
+        outer.push(bo_n);
+        inner.push(bi_n);
+        mean_conic.push(bm_n);
+        resid.push(r_n);
+        radius
+            .push(((rec.observed_px[0] - cx0).powi(2) + (rec.observed_px[1] - cy0).powi(2)).sqrt());
+
+        sum_dot += r_vec[0] * bo[0] + r_vec[1] * bo[1];
+        sum_bb += bo_n * bo_n;
+        if r_n > 1e-9 && bo_n > 1e-9 {
+            cos_acc += (r_vec[0] * bo[0] + r_vec[1] * bo[1]) / (r_n * bo_n);
+            cos_n += 1;
+        }
+    }
+
+    let bias_vs_radius_corr = pearson(&outer, &radius);
+
+    RinggridBiasReport {
+        n_obs: outer.len(),
+        bias_outer: Stats::from_values(outer),
+        bias_inner: Stats::from_values(inner),
+        bias_mean_conic: Stats::from_values(mean_conic),
+        residual: Stats::from_values(resid),
+        residual_bias_fraction: if sum_bb > 0.0 { sum_dot / sum_bb } else { 0.0 },
+        mean_cosine: if cos_n > 0 {
+            cos_acc / cos_n as f64
+        } else {
+            0.0
+        },
+        bias_vs_radius_corr,
+    }
+}
+
+/// Pearson correlation coefficient of two equal-length samples.
+fn pearson(a: &[f64], b: &[f64]) -> f64 {
+    let n = a.len();
+    if n < 2 || n != b.len() {
+        return 0.0;
+    }
+    let na = n as f64;
+    let ma = a.iter().sum::<f64>() / na;
+    let mb = b.iter().sum::<f64>() / na;
+    let mut sab = 0.0;
+    let mut saa = 0.0;
+    let mut sbb = 0.0;
+    for i in 0..n {
+        let da = a[i] - ma;
+        let db = b[i] - mb;
+        sab += da * db;
+        saa += da * da;
+        sbb += db * db;
+    }
+    if saa <= 0.0 || sbb <= 0.0 {
+        0.0
+    } else {
+        sab / (saa * sbb).sqrt()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, Matrix3};
+
+    /// Fit a conic `[a, b, c, d, e, f]` (for `a u² + b u v + c v² + d u + e v +
+    /// f = 0`) to sampled image points via the algebraic DLT null vector, and
+    /// return it as a symmetric `3×3` conic matrix.
+    fn fit_conic(points: &[[f64; 2]]) -> Matrix3<f64> {
+        let mut m = DMatrix::<f64>::zeros(points.len(), 6);
+        for (i, p) in points.iter().enumerate() {
+            let (u, v) = (p[0], p[1]);
+            m[(i, 0)] = u * u;
+            m[(i, 1)] = u * v;
+            m[(i, 2)] = v * v;
+            m[(i, 3)] = u;
+            m[(i, 4)] = v;
+            m[(i, 5)] = 1.0;
+        }
+        let svd = m.svd(false, true);
+        let v_t = svd.v_t.unwrap();
+        // Smallest singular value is last (nalgebra sorts descending).
+        let row = v_t.row(5);
+        let (a, b, c, d, e, f) = (row[0], row[1], row[2], row[3], row[4], row[5]);
+        Matrix3::new(
+            a,
+            b / 2.0,
+            d / 2.0,
+            b / 2.0,
+            c,
+            e / 2.0,
+            d / 2.0,
+            e / 2.0,
+            f,
+        )
+    }
+
+    fn synthetic_h() -> Matrix3<f64> {
+        // A perspective+tilt-like homography (non-affine bottom row).
+        Matrix3::new(
+            1100.0, 15.0, 360.0, -12.0, 1080.0, 270.0, 8.0e-4, -6.0e-4, 1.0,
+        )
+    }
+
+    #[test]
+    fn conic_center_matches_sampled_ellipse_fit() {
+        let h = synthetic_h();
+        let (cx, cy, r) = (0.012_f64, -0.008, 0.0048);
+
+        // Push the circle conic through H algebraically.
+        let conic_algebraic = project_conic(&circle_conic(cx, cy, r), &h).unwrap();
+        let center_algebraic = conic_center(&conic_algebraic).unwrap();
+
+        // Independently: sample the circle, project each point, fit a conic.
+        let pts: Vec<[f64; 2]> = (0..128)
+            .map(|i| {
+                let th = std::f64::consts::TAU * i as f64 / 128.0;
+                project_point(&h, cx + r * th.cos(), cy + r * th.sin()).unwrap()
+            })
+            .collect();
+        let center_fit = conic_center(&fit_conic(&pts)).unwrap();
+
+        let err = ((center_algebraic[0] - center_fit[0]).powi(2)
+            + (center_algebraic[1] - center_fit[1]).powi(2))
+        .sqrt();
+        assert!(
+            err < 1e-6,
+            "algebraic conic center vs sampled-ellipse-fit center disagree: {err:.3e} px"
+        );
+    }
+
+    #[test]
+    fn bias_is_nonzero_and_equals_center_minus_projection() {
+        let h = synthetic_h();
+        // Plane units chosen so the imaged marker has a realistic pixel extent
+        // under a strongly projective (non-affine) homography — the regime
+        // where the ellipse-center bias is clearly above numerical noise.
+        let (cx, cy, r) = (0.4_f64, -0.3, 0.25);
+
+        let bias = predicted_center_bias(&h, cx, cy, r).unwrap();
+        let bias_norm = (bias[0] * bias[0] + bias[1] * bias[1]).sqrt();
+        // Under a genuinely projective (non-affine) homography the conic
+        // center must differ from the projected circle center.
+        assert!(
+            bias_norm > 1e-2,
+            "expected a measurable ellipse-center bias, got {bias_norm:.3e} px"
+        );
+
+        // Cross-check the definition: bias = center(C') − H·c.
+        let conic = project_conic(&circle_conic(cx, cy, r), &h).unwrap();
+        let center = conic_center(&conic).unwrap();
+        let proj = project_point(&h, cx, cy).unwrap();
+        assert!((bias[0] - (center[0] - proj[0])).abs() < 1e-9);
+        assert!((bias[1] - (center[1] - proj[1])).abs() < 1e-9);
+    }
+
+    /// End-to-end diagnosis on the private ring-grid cameras (Q3-RINGGRID-BIAS).
+    ///
+    /// `#[ignore]`d: needs `--features tier-b` and the private dataset. Run
+    /// with `cargo test -p vision-calibration-bench --features tier-b
+    /// --lib ringgrid_bias::tests::diagnose_private_ringgrid -- --ignored
+    /// --nocapture`. Prints the closed-form bias distribution alongside the
+    /// calibration residual field per camera. The recorded numbers live in
+    /// `docs/notes/ringgrid-bias.md`.
+    #[cfg(feature = "tier-b")]
+    #[test]
+    #[ignore = "needs privatedata/rtv3d_ringgrid + tier-b"]
+    fn diagnose_private_ringgrid() {
+        use crate::registry::load_registry;
+        use crate::run::{detect_scheimpflug_seeded_input, solve_scheimpflug_seeded};
+        use std::path::PathBuf;
+
+        // Board spec (privatedata/rtv3d_ringgrid/board_ringgrid.json).
+        const R_OUTER_M: f64 = 0.0048;
+        const R_INNER_M: f64 = 0.0032;
+
+        // Registry `data_root`s are workspace-root-relative; `cargo test` runs
+        // with CWD = crate dir, so hop up to the workspace root first.
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..");
+        std::env::set_current_dir(&workspace_root).expect("chdir to workspace root");
+
+        let registry = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("registry")
+            .join("private.json");
+        let reg = load_registry(&registry).expect("load private registry");
+
+        println!(
+            "\n{:<20} {:>6}  {:>26}  {:>26}  {:>10}  {:>8}  {:>7}",
+            "camera",
+            "n_obs",
+            "outer-bias px (mean/med/p95/max)",
+            "residual px (mean/med/p95/max)",
+            "resid/bias",
+            "cos",
+            "r(rad)"
+        );
+        for id in [
+            "rtv3d_ringgrid_cam0",
+            "rtv3d_ringgrid_cam1",
+            "rtv3d_ringgrid_cam2",
+            "rtv3d_ringgrid_cam3",
+            "rtv3d_ringgrid_cam4",
+            "rtv3d_ringgrid_cam5",
+        ] {
+            let entry = reg.find(id).expect("entry present");
+            let detected = detect_scheimpflug_seeded_input(entry).expect("detect");
+            let solve =
+                solve_scheimpflug_seeded(detected.dataset, detected.seed, id).expect("solve");
+            let rep = diagnose(&solve.export, R_OUTER_M, R_INNER_M);
+            println!(
+                "{:<20} {:>6}  {:>6.3}/{:>6.3}/{:>6.3}/{:>6.3}  {:>6.3}/{:>6.3}/{:>6.3}/{:>6.3}  {:>10.3}  {:>8.3}  {:>7.3}",
+                id,
+                rep.n_obs,
+                rep.bias_outer.mean,
+                rep.bias_outer.median,
+                rep.bias_outer.p95,
+                rep.bias_outer.max,
+                rep.residual.mean,
+                rep.residual.median,
+                rep.residual.p95,
+                rep.residual.max,
+                rep.residual_bias_fraction,
+                rep.mean_cosine,
+                rep.bias_vs_radius_corr,
+            );
+        }
+    }
+
+    #[test]
+    fn affine_homography_has_no_bias() {
+        // An affine map (bottom row [0,0,1]) sends a circle to an ellipse
+        // whose center *is* the mapped circle center — zero bias.
+        let h = Matrix3::new(900.0, 40.0, 320.0, -30.0, 950.0, 240.0, 0.0, 0.0, 1.0);
+        let bias = predicted_center_bias(&h, 0.01, -0.02, 0.0048).unwrap();
+        let bias_norm = (bias[0] * bias[0] + bias[1] * bias[1]).sqrt();
+        assert!(
+            bias_norm < 1e-9,
+            "affine map must not bias the center: {bias_norm:.3e}"
+        );
+    }
+}

--- a/crates/vision-calibration-bench/src/ringgrid_bias.rs
+++ b/crates/vision-calibration-bench/src/ringgrid_bias.rs
@@ -97,17 +97,7 @@ pub fn predicted_center_bias(h: &Matrix3<f64>, cx: f64, cy: f64, r: f64) -> Opti
 /// Build the `3×3` intrinsics matrix `K` from serializable intrinsics.
 fn k_matrix(intr: &IntrinsicsParams) -> Matrix3<f64> {
     let IntrinsicsParams::FxFyCxCySkew { params } = intr;
-    Matrix3::new(
-        params.fx,
-        params.skew,
-        params.cx,
-        0.0,
-        params.fy,
-        params.cy,
-        0.0,
-        0.0,
-        1.0,
-    )
+    params.k_matrix()
 }
 
 /// The Scheimpflug tilt homography (normalized → sensor), or identity for a
@@ -227,7 +217,9 @@ pub fn diagnose(
         let Some(projected) = rec.projected_px else {
             continue;
         };
-        let h = &h_nodistort[rec.pose];
+        let Some(h) = h_nodistort.get(rec.pose) else {
+            continue;
+        };
         let (cx, cy) = (rec.target_xyz_m[0], rec.target_xyz_m[1]);
         let (Some(bo), Some(bi)) = (
             predicted_center_bias(h, cx, cy, r_outer_m),
@@ -422,12 +414,13 @@ mod tests {
         const R_OUTER_M: f64 = 0.0048;
         const R_INNER_M: f64 = 0.0032;
 
-        // Registry `data_root`s are workspace-root-relative; `cargo test` runs
-        // with CWD = crate dir, so hop up to the workspace root first.
+        // Registry `data_root`s are workspace-root-relative; resolve them
+        // against the workspace root explicitly rather than chdir'ing the
+        // test process (mirrors `resolve_entry_data_root` in
+        // `src/bin/calib_bench.rs`).
         let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("..");
-        std::env::set_current_dir(&workspace_root).expect("chdir to workspace root");
 
         let registry = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("registry")
@@ -452,8 +445,11 @@ mod tests {
             "rtv3d_ringgrid_cam4",
             "rtv3d_ringgrid_cam5",
         ] {
-            let entry = reg.find(id).expect("entry present");
-            let detected = detect_scheimpflug_seeded_input(entry).expect("detect");
+            let mut entry = reg.find(id).expect("entry present").clone();
+            if entry.data_root.is_relative() {
+                entry.data_root = workspace_root.join(&entry.data_root);
+            }
+            let detected = detect_scheimpflug_seeded_input(&entry).expect("detect");
             let solve =
                 solve_scheimpflug_seeded(detected.dataset, detected.seed, id).expect("solve");
             let rep = diagnose(&solve.export, R_OUTER_M, R_INNER_M);

--- a/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
@@ -319,6 +319,12 @@ fn main() -> Result<()> {
     let mut laser_planes_cam: Option<Vec<LaserPlane>> = None;
     let mut joint_stats_sigma_mm: Option<Vec<f64>> = None;
     let mut joint_reproj_px: Option<Vec<f64>> = None;
+    // `cam_se3_rig` refined by the joint (laser-informed) BA — the most
+    // metrically constrained extrinsics available. See Q5-RTV3D-SCALE:
+    // the hand-eye-stage `rig_export.cam_se3_rig` alone under-determines
+    // absolute scale by ~10 %; the joint BA (laser point-to-plane term)
+    // resolves it and matches the oracle's healthy cameras almost exactly.
+    let mut joint_cam_se3_rig: Option<Vec<Iso3>> = None;
     if detected.laserline_views.is_empty() {
         println!("stage 3 (rig laserline): skipped — no laser observations in this dataset");
     } else {
@@ -482,6 +488,14 @@ fn main() -> Result<()> {
             "  mean reproj after joint BA: {:.4} px",
             joint_est.mean_reproj_error_px
         );
+        joint_cam_se3_rig = Some(
+            joint_est
+                .params
+                .cam_to_rig
+                .iter()
+                .map(|t| t.inverse())
+                .collect(),
+        );
         let mut sigmas = Vec::with_capacity(NUM_CAMERAS);
         let mut reprojs = Vec::with_capacity(NUM_CAMERAS);
         for (i, s) in joint_est.per_cam_stats.iter().enumerate() {
@@ -510,6 +524,7 @@ fn main() -> Result<()> {
             joint_reproj_px.as_deref(),
             laser_planes_cam.as_deref(),
             joint_stats_sigma_mm.as_deref(),
+            joint_cam_se3_rig.as_deref(),
         );
     } else {
         println!("\nno oracle (artifacts.json) — skipping comparison");
@@ -847,6 +862,16 @@ fn load_oracle(path: &Path) -> Result<Oracle> {
 /// - laser σ: per-camera point-to-plane RMS < oracle `standard_deviation_mm`.
 ///   Plane normal/distance deltas are informational only (frame conventions
 ///   differ; σ is the physically meaningful fit quality).
+///
+/// The `|t| ours` column (and the printed neighbor-edge hexagon table, see
+/// Q5-RTV3D-SCALE) uses `joint_cam_se3_rig` — the laser-informed joint-BA
+/// extrinsics — when available, falling back to the hand-eye-stage
+/// `rig_export.cam_se3_rig` otherwise. The two disagree by a uniform ~10 %
+/// scale factor: the hand-eye stage alone under-determines absolute scale,
+/// and the joint BA's laser point-to-plane term resolves it. Comparing the
+/// oracle against the hand-eye-stage extrinsics (as earlier reports did)
+/// manufactures an apparent scale mismatch that isn't present once the
+/// laser-informed extrinsics are used — see `docs/notes/rtv3d-scale.md`.
 fn compare_to_oracle(
     oracle: &Oracle,
     rig_export: &vision_calibration::rig_handeye::RigHandeyeExport,
@@ -854,6 +879,7 @@ fn compare_to_oracle(
     joint_reproj: Option<&[f64]>,
     laser_planes_cam: Option<&[LaserPlane]>,
     laser_sigma_mm: Option<&[f64]>,
+    joint_cam_se3_rig: Option<&[Iso3]>,
 ) {
     println!("\n══════════ oracle comparison (artifacts.json) ══════════");
     println!("note: oracle cam 5 is degenerate (fx=51, reproj 127 px) — its deltas are nominal");
@@ -917,12 +943,23 @@ fn compare_to_oracle(
         );
     }
 
+    // Prefer the laser-informed joint-BA extrinsics (best available scale
+    // constraint); fall back to the hand-eye-stage export when no laser
+    // data was present. See Q5-RTV3D-SCALE.
+    let extrinsics_source = joint_cam_se3_rig.unwrap_or(&rig_export.cam_se3_rig);
     println!("\nextrinsics vs oracle camera_se3_sensor (rig frame = cam 0):");
-    println!("note: rot/trans deltas are informational — the legacy frame convention and");
-    println!("      the tilt↔pose parameter split differ; |t| norms carry the scale criterion");
+    println!(
+        "note: ours = {} extrinsics; rot/trans deltas are informational — the legacy",
+        if joint_cam_se3_rig.is_some() {
+            "joint-BA (laser-informed)"
+        } else {
+            "hand-eye-stage"
+        }
+    );
+    println!("      frame convention and the tilt↔pose parameter split differ; |t| norms carry the scale criterion");
     println!("  cam | rot Δ (deg) | trans Δ (mm) | |t| ours (mm) | |t| oracle (mm) | scale ok?");
     let mut extr_pass = true;
-    for (i, ours) in rig_export.cam_se3_rig.iter().enumerate() {
+    for (i, ours) in extrinsics_source.iter().enumerate() {
         let o = &oracle.cameras[i].cam_se3_rig;
         let delta = ours.inverse() * *o;
         let rot_deg = delta.rotation.angle().to_degrees();
@@ -952,6 +989,61 @@ fn compare_to_oracle(
             },
         );
     }
+
+    // ─── Hexagon neighbor-edge diagnostic (Q5-RTV3D-SCALE) ─────────────────
+    // The rig is a regular hexagon of 6 cameras: sum the |t| column above
+    // pairwise between mechanical *neighbors* (0-1-2-3-4-5-0), not just
+    // radially from cam 0, to get a rotation/parameterization-independent
+    // absolute-scale check with more edges than the 4 that touch cam 0.
+    let ours_positions: Vec<_> = extrinsics_source
+        .iter()
+        .map(|t| t.inverse().translation.vector)
+        .collect();
+    let oracle_positions: Vec<_> = oracle
+        .cameras
+        .iter()
+        .map(|c| c.cam_se3_rig.inverse().translation.vector)
+        .collect();
+    let hex_edges = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 0)];
+    println!("\nhexagon neighbor-edge lengths (mm) — ours vs oracle:");
+    println!("note: edges touching cam 5 are unreliable in the oracle (fx=51 degenerate)");
+    println!("  edge | ours (mm) | oracle (mm) | oracle/ours");
+    let mut ours_edges = Vec::with_capacity(hex_edges.len());
+    let mut oracle_clean_edges = Vec::with_capacity(hex_edges.len());
+    for &(i, j) in &hex_edges {
+        let d_ours = (ours_positions[i] - ours_positions[j]).norm() * 1e3;
+        let d_oracle = (oracle_positions[i] - oracle_positions[j]).norm() * 1e3;
+        let touches_cam5 = i == 5 || j == 5;
+        println!(
+            "  {i}-{j}   | {d_ours:9.2} | {d_oracle:10.2} | {:10.4}{}",
+            d_oracle / d_ours,
+            if touches_cam5 { "  (cam 5 edge)" } else { "" },
+        );
+        ours_edges.push(d_ours);
+        if !touches_cam5 {
+            oracle_clean_edges.push(d_oracle);
+        }
+    }
+    let mean_std = |v: &[f64]| -> (f64, f64) {
+        let mean = v.iter().sum::<f64>() / v.len() as f64;
+        let var = v.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / v.len() as f64;
+        (mean, var.sqrt())
+    };
+    let (ours_mean, ours_std) = mean_std(&ours_edges);
+    let (oracle_mean, oracle_std) = mean_std(&oracle_clean_edges);
+    println!(
+        "  ours (all 6 edges):        mean={ours_mean:.2} mm  std={ours_std:.2} mm ({:.2}% spread)",
+        100.0 * ours_std / ours_mean
+    );
+    println!(
+        "  oracle (4 clean edges, cams 0-4): mean={oracle_mean:.2} mm  std={oracle_std:.2} mm ({:.2}% spread)",
+        100.0 * oracle_std / oracle_mean
+    );
+    println!(
+        "  ratio oracle-clean/ours: {:.4} ({:+.2}%)",
+        oracle_mean / ours_mean,
+        100.0 * (oracle_mean / ours_mean - 1.0)
+    );
 
     let mut plane_pass = None;
     if let Some(planes) = laser_planes_cam {

--- a/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
+++ b/crates/vision-calibration-examples-private/examples/rtv3d_rig.rs
@@ -1009,6 +1009,7 @@ fn compare_to_oracle(
     println!("note: edges touching cam 5 are unreliable in the oracle (fx=51 degenerate)");
     println!("  edge | ours (mm) | oracle (mm) | oracle/ours");
     let mut ours_edges = Vec::with_capacity(hex_edges.len());
+    let mut ours_clean_edges = Vec::with_capacity(hex_edges.len());
     let mut oracle_clean_edges = Vec::with_capacity(hex_edges.len());
     for &(i, j) in &hex_edges {
         let d_ours = (ours_positions[i] - ours_positions[j]).norm() * 1e3;
@@ -1021,6 +1022,7 @@ fn compare_to_oracle(
         );
         ours_edges.push(d_ours);
         if !touches_cam5 {
+            ours_clean_edges.push(d_ours);
             oracle_clean_edges.push(d_oracle);
         }
     }
@@ -1030,10 +1032,15 @@ fn compare_to_oracle(
         (mean, var.sqrt())
     };
     let (ours_mean, ours_std) = mean_std(&ours_edges);
+    let (ours_clean_mean, ours_clean_std) = mean_std(&ours_clean_edges);
     let (oracle_mean, oracle_std) = mean_std(&oracle_clean_edges);
     println!(
-        "  ours (all 6 edges):        mean={ours_mean:.2} mm  std={ours_std:.2} mm ({:.2}% spread)",
+        "  ours mean (all 6):         mean={ours_mean:.2} mm  std={ours_std:.2} mm ({:.2}% spread)",
         100.0 * ours_std / ours_mean
+    );
+    println!(
+        "  ours mean (clean 4, cams 0-4): mean={ours_clean_mean:.2} mm  std={ours_clean_std:.2} mm ({:.2}% spread)",
+        100.0 * ours_clean_std / ours_clean_mean
     );
     println!(
         "  oracle (4 clean edges, cams 0-4): mean={oracle_mean:.2} mm  std={oracle_std:.2} mm ({:.2}% spread)",
@@ -1041,8 +1048,8 @@ fn compare_to_oracle(
     );
     println!(
         "  ratio oracle-clean/ours: {:.4} ({:+.2}%)",
-        oracle_mean / ours_mean,
-        100.0 * (oracle_mean / ours_mean - 1.0)
+        oracle_mean / ours_clean_mean,
+        100.0 * (oracle_mean / ours_clean_mean - 1.0)
     );
 
     let mut plane_pass = None;

--- a/crates/vision-calibration/tests/laserline_device_matrix.rs
+++ b/crates/vision-calibration/tests/laserline_device_matrix.rs
@@ -1,0 +1,397 @@
+//! Synthetic-GT matrix test for the laserline device family (Q8,
+//! `docs/notes/README.md`; math note: `docs/notes/laserline-bundle.md`).
+//!
+//! Ground-truth laser-plane grid (2 orientations × 2 working distances) ×
+//! pixel-noise levels. Every cell builds an exact synthetic laserline dataset
+//! (target corners + laser-stripe pixels), runs the standard
+//! `step_init → step_optimize` pipeline (`run_calibration`), and asserts
+//! laser-plane recovery — normal in degrees, signed distance in millimetres —
+//! plus a laser/reprojection residual floor consistent with the injected noise.
+//!
+//! No cargo feature gates the laserline math in the facade or pipeline (only
+//! the *bench* crate's `laser` feature pulls in the vision-metrology
+//! extractor), so this test runs under both plain `cargo test` and
+//! `cargo test --workspace --all-features`.
+
+#![allow(missing_docs)]
+
+use std::f64::consts::PI;
+
+use nalgebra::{Rotation3, Translation3, Vector2, Vector3};
+use vision_calibration::core::{
+    BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, PinholeCamera, Pt2, Pt3, Vec2, View,
+    make_pinhole_camera,
+};
+use vision_calibration::laserline_device::{
+    LaserlineDeviceConfig, LaserlineDeviceProblem, run_calibration,
+};
+use vision_calibration::optim::{LaserPlane, LaserlineMeta, LaserlineView};
+use vision_calibration::session::CalibrationSession;
+use vision_calibration::synthetic::noise::UniformPixelNoise;
+
+// Board extent in target coordinates: a 9×7 grid of 30 mm cells spans
+// [0, 0.24] × [0, 0.18] m; its centre sits at (0.12, 0.09).
+const BOARD_NX: usize = 9;
+const BOARD_NY: usize = 7;
+const BOARD_SPACING: f64 = 0.03;
+const BOARD_MAX_X: f64 = (BOARD_NX - 1) as f64 * BOARD_SPACING;
+const BOARD_MAX_Y: f64 = (BOARD_NY - 1) as f64 * BOARD_SPACING;
+const BOARD_CX: f64 = BOARD_MAX_X / 2.0;
+const BOARD_CY: f64 = BOARD_MAX_Y / 2.0;
+
+fn board() -> Vec<Pt3> {
+    vision_calibration::synthetic::planar::grid_points(BOARD_NX, BOARD_NY, BOARD_SPACING)
+}
+
+/// Six diverse board poses for a plane anchored at optical-axis depth `z0`.
+/// Each board is centred on the optical axis at `z0 ± jitter` (jitter ≤
+/// 25 mm) with mixed pitch/yaw/**roll**. Roll rotates the stripe *within* the
+/// board without pushing it off-board, so the per-view stripes span the
+/// plane's 2D extent instead of lying on a single line — the pose diversity
+/// that makes the laser plane observable (see the math note,
+/// §Identifiability). The stripe stays on-board because the depth spread is
+/// kept small relative to `board_half_extent · sin(tilt)`.
+fn poses(z0: f64) -> Vec<Iso3> {
+    // pitch, yaw, roll (rad), depth jitter (m)
+    let specs: [(f64, f64, f64, f64); 6] = [
+        (0.00, 0.00, 0.00, 0.000),
+        (0.12, -0.05, 0.35, -0.012),
+        (-0.10, 0.09, -0.40, 0.010),
+        (0.06, 0.14, 0.60, 0.014),
+        (-0.13, -0.07, -0.25, -0.014),
+        (0.09, -0.15, 0.45, 0.008),
+    ];
+    specs
+        .iter()
+        .map(|&(pitch, yaw, roll, dz)| {
+            let r = Rotation3::from_euler_angles(pitch, yaw, roll);
+            // Place the *board centre* (not its origin) on the optical axis at
+            // depth z0 + dz, for every rotation.
+            let center_local = Vector3::new(BOARD_CX, BOARD_CY, 0.0);
+            let t = Vector3::new(0.0, 0.0, z0 + dz) - r * center_local;
+            Iso3::from_parts(Translation3::from(t), r.into())
+        })
+        .collect()
+}
+
+/// Generate the on-board laser stripe for one view: intersect the (fixed,
+/// camera-frame) laser plane with the board plane (`z = 0` in target frame),
+/// sample points along the intersection line that fall inside the board
+/// extent, project them, and add deterministic pixel noise.
+fn laser_pixels_for_view(
+    camera: &PinholeCamera,
+    cam_se3_target: &Iso3,
+    plane: &LaserPlane,
+    view_idx: usize,
+    noise: &UniformPixelNoise,
+) -> Vec<Pt2> {
+    // Laser plane expressed in the target frame (board is z = 0 there).
+    let target_se3_cam = cam_se3_target.inverse();
+    let plane_t = plane.transform_by(&target_se3_cam);
+    let n = plane_t.normal.into_inner();
+    let d = plane_t.distance;
+
+    let n_xy = Vector2::new(n.x, n.y);
+    let horiz = n_xy.norm();
+    if horiz < 1e-9 {
+        // Laser plane parallel to the board: no stripe (a degenerate view).
+        return Vec::new();
+    }
+    let dir = Vector2::new(-n.y, n.x) / horiz;
+    // Foot of the perpendicular from the board centre onto the stripe line;
+    // any point on the line will do as the clip anchor.
+    let center = Vector2::new(BOARD_CX, BOARD_CY);
+    let signed = (n_xy.dot(&center) + d) / (horiz * horiz);
+    let p0 = center - signed * n_xy;
+
+    // Clip the infinite stripe line q(t) = p0 + t·dir to the board rectangle
+    // [0, BOARD_MAX_X] × [0, BOARD_MAX_Y] (parametric slab clipping), so the
+    // sampled pixels always land on the physical board.
+    let mut t_lo = f64::NEG_INFINITY;
+    let mut t_hi = f64::INFINITY;
+    for &(origin, delta, hi) in &[(p0.x, dir.x, BOARD_MAX_X), (p0.y, dir.y, BOARD_MAX_Y)] {
+        if delta.abs() < 1e-12 {
+            if origin < 0.0 || origin > hi {
+                return Vec::new(); // line runs outside this slab entirely
+            }
+        } else {
+            let mut ta = (0.0 - origin) / delta;
+            let mut tb = (hi - origin) / delta;
+            if ta > tb {
+                std::mem::swap(&mut ta, &mut tb);
+            }
+            t_lo = t_lo.max(ta);
+            t_hi = t_hi.min(tb);
+        }
+    }
+    if t_hi - t_lo < 0.05 {
+        return Vec::new(); // stripe misses the board or is too short
+    }
+    // Sample inside the on-board span, with a small margin off the edges.
+    let margin = 0.02 * (t_hi - t_lo);
+    let (a, b) = (t_lo + margin, t_hi - margin);
+
+    let mut pixels = Vec::new();
+    for i in 0..41 {
+        let t = a + (b - a) * (i as f64) / 40.0;
+        let x = p0.x + t * dir.x;
+        let y = p0.y + t * dir.y;
+        let p_cam = cam_se3_target.transform_point(&Pt3::new(x, y, 0.0));
+        if let Some(px) = camera.project_point(&p_cam) {
+            // Distinct key space from the corner noise (offset the point index).
+            let noisy = noise.apply(view_idx, 10_000 + i, Vec2::new(px.x, px.y));
+            pixels.push(Pt2::new(noisy.x, noisy.y));
+        }
+    }
+    pixels
+}
+
+/// Build a full synthetic laserline dataset (target corners + laser pixels)
+/// for a given GT plane, intrinsics, and noise level.
+fn build_dataset(
+    plane: &LaserPlane,
+    gt_intr: &FxFyCxCySkew<f64>,
+    board: &[Pt3],
+    poses: &[Iso3],
+    noise: &UniformPixelNoise,
+) -> Vec<LaserlineView> {
+    let distortion = BrownConrady5 {
+        k1: 0.0,
+        k2: 0.0,
+        k3: 0.0,
+        p1: 0.0,
+        p2: 0.0,
+        iters: 8,
+    };
+    let camera = make_pinhole_camera(*gt_intr, distortion);
+
+    let mut views = Vec::new();
+    for (view_idx, pose) in poses.iter().enumerate() {
+        let mut pts_3d = Vec::with_capacity(board.len());
+        let mut pts_2d = Vec::with_capacity(board.len());
+        for (pt_idx, pw) in board.iter().enumerate() {
+            let p_cam = pose.transform_point(pw);
+            if let Some(px) = camera.project_point(&p_cam) {
+                let noisy = noise.apply(view_idx, pt_idx, Vec2::new(px.x, px.y));
+                pts_3d.push(*pw);
+                pts_2d.push(Pt2::new(noisy.x, noisy.y));
+            }
+        }
+        let laser_pixels = laser_pixels_for_view(&camera, pose, plane, view_idx, noise);
+        let obs = CorrespondenceView::new(pts_3d, pts_2d).expect("corner correspondences");
+        views.push(View::new(
+            obs,
+            LaserlineMeta {
+                laser_pixels,
+                laser_weights: Vec::new(),
+            },
+        ));
+    }
+    views
+}
+
+#[test]
+fn laserline_device_recovers_plane_across_grid_and_noise() {
+    let gt_intr = FxFyCxCySkew {
+        fx: 900.0,
+        fy: 900.0,
+        cx: 640.0,
+        cy: 360.0,
+        skew: 0.0,
+    };
+    let board = board();
+
+    // GT plane grid: 2 orientations × 2 working distances (the anchor depth
+    // z0 where the plane crosses the optical axis; the signed distance is
+    // d = -n_z · z0).
+    let orientations = [
+        Vector3::new(0.30, 0.0, 1.0), // ~16.7° tilt about the y-axis
+        Vector3::new(0.0, 0.45, 1.0), // ~24.2° tilt about the x-axis
+    ];
+    let depths = [0.50_f64, 0.62_f64];
+    let noise_levels = [0.0_f64, 0.15, 0.30];
+
+    for (oi, n_raw) in orientations.iter().enumerate() {
+        let n_gt = n_raw.normalize();
+        for &z0 in &depths {
+            let d_gt = -n_gt.z * z0;
+            let plane_gt = LaserPlane::new(n_gt, d_gt);
+            let poses = poses(z0);
+
+            for &noise_px in &noise_levels {
+                let noise = UniformPixelNoise {
+                    seed: 7,
+                    max_abs_px: noise_px,
+                };
+                let dataset = build_dataset(&plane_gt, &gt_intr, &board, &poses, &noise);
+                for (i, v) in dataset.iter().enumerate() {
+                    assert!(
+                        v.meta.laser_pixels.len() >= 8,
+                        "orient={oi} z0={z0}: view {i} has only {} laser pixels",
+                        v.meta.laser_pixels.len()
+                    );
+                }
+
+                let mut session = CalibrationSession::<LaserlineDeviceProblem>::new();
+                session.set_input(dataset).expect("input");
+                run_calibration(&mut session, Some(LaserlineDeviceConfig::default()))
+                    .expect("calibration");
+                let export = session.export().expect("export");
+                let plane = &export.estimate.params.plane;
+
+                // Align to the GT sign (the S2 double cover: (n, d) ≡ (−n, −d)).
+                let mut n_est = plane.normal.into_inner();
+                let mut d_est = plane.distance;
+                if n_est.dot(&n_gt) < 0.0 {
+                    n_est = -n_est;
+                    d_est = -d_est;
+                }
+                let angle_deg = n_est.dot(&n_gt).clamp(-1.0, 1.0).acos().to_degrees();
+                let dist_err_mm = (d_est - d_gt).abs() * 1000.0;
+                let mean_laser = export.stats.mean_laser_error; // px (LineDistNormalized)
+                let mean_reproj = export.stats.mean_reproj_error; // px
+
+                let label = format!("orient={oi} z0={z0} noise={noise_px}px");
+                eprintln!(
+                    "{label}: angle={angle_deg:.4}° dist_err={dist_err_mm:.4}mm \
+                     laser={mean_laser:.4}px reproj={mean_reproj:.4}px"
+                );
+
+                // Recovery tolerances: exact-data cells must be tight; noisy
+                // cells scale with the injected amplitude.
+                // Exact-data cells recover to solver tolerance; noisy cells
+                // scale with the injected amplitude (empirical bounds with
+                // ~2× headroom over the observed recovery — see the math
+                // note's Evidence table).
+                let (angle_tol, dist_tol_mm, laser_bound, reproj_bound) = if noise_px == 0.0 {
+                    (0.05, 0.10, 5.0e-3, 1.0e-3)
+                } else {
+                    (
+                        0.6 * noise_px + 0.03,  // deg
+                        6.0 * noise_px + 0.30,  // mm
+                        noise_px + 0.04,        // px (line-distance residual)
+                        0.95 * noise_px + 0.05, // px (reprojection floor ≈ 0.765·a)
+                    )
+                };
+
+                assert!(
+                    angle_deg < angle_tol,
+                    "{label}: normal angle {angle_deg:.4}° > {angle_tol}°"
+                );
+                assert!(
+                    dist_err_mm < dist_tol_mm,
+                    "{label}: distance error {dist_err_mm:.4} mm > {dist_tol_mm} mm"
+                );
+                assert!(
+                    mean_laser < laser_bound,
+                    "{label}: mean laser residual {mean_laser:.4} px > {laser_bound:.4} px"
+                );
+                assert!(
+                    mean_reproj < reproj_bound,
+                    "{label}: mean reproj {mean_reproj:.4} px > {reproj_bound:.4} px"
+                );
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Property tests — real invariants of the (n̂, d) plane parameterization.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Deterministic LCG in `[0, 1)` (no external RNG crate; keeps the property
+/// sweep reproducible across platforms).
+fn lcg_unit(state: &mut u64) -> f64 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    ((*state >> 11) as f64) / ((1u64 << 53) as f64)
+}
+
+fn uniform(state: &mut u64, lo: f64, hi: f64) -> f64 {
+    lo + (hi - lo) * lcg_unit(state)
+}
+
+/// The point-to-plane signed distance is invariant to the frame in which the
+/// point and plane are expressed: for any SE(3) `T`, `n·p + d` equals
+/// `n_B·(T·p) + d_B` where `(n_B, d_B) = T·plane`. This is the geometric fact
+/// the laser point-to-plane residual (`optim::factors::laserline`) relies on —
+/// the residual is unchanged by any in-plane rotation / rigid re-framing of the
+/// plane. `R` preserves the dot product, so equality is exact.
+#[test]
+fn point_to_plane_residual_is_se3_invariant() {
+    let mut s = 0x00C0_FFEE_u64;
+    for _ in 0..5000 {
+        let n = Vector3::new(
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+        );
+        if n.norm() < 1e-3 {
+            continue;
+        }
+        let d = uniform(&mut s, -2.0, 2.0);
+        let plane = LaserPlane::new(n, d);
+        let p = Pt3::new(
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+        );
+        let t = Iso3::from_parts(
+            Translation3::new(
+                uniform(&mut s, -1.0, 1.0),
+                uniform(&mut s, -1.0, 1.0),
+                uniform(&mut s, -1.0, 1.0),
+            ),
+            Rotation3::from_euler_angles(
+                uniform(&mut s, -PI, PI),
+                uniform(&mut s, -PI, PI),
+                uniform(&mut s, -PI, PI),
+            )
+            .into(),
+        );
+
+        let before = plane.point_distance(&p);
+        let after = plane
+            .transform_by(&t)
+            .point_distance(&t.transform_point(&p));
+        assert!(
+            (before - after).abs() < 1e-10,
+            "SE(3) invariance broken: {before} vs {after}"
+        );
+    }
+}
+
+/// The global sign flip `(n, d) → (−n, −d)` is a gauge of the `(n̂, d)`
+/// parameterization: it names the *same* plane (the S² double cover). The
+/// signed point-to-plane distance therefore only flips sign; its magnitude —
+/// which is what the residual squares — is invariant. The matrix test relies
+/// on this to sign-align the recovered normal to the ground truth.
+#[test]
+fn plane_sign_flip_is_a_gauge() {
+    let mut s = 0x0000_1234_u64;
+    for _ in 0..5000 {
+        let n = Vector3::new(
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+        );
+        if n.norm() < 1e-3 {
+            continue;
+        }
+        let d = uniform(&mut s, -2.0, 2.0);
+        let p = Pt3::new(
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+            uniform(&mut s, -1.0, 1.0),
+        );
+        let plane = LaserPlane::new(n, d);
+        let flipped = LaserPlane::new(-n, -d);
+        let a = plane.point_distance(&p);
+        let b = flipped.point_distance(&p);
+        assert!(
+            (a + b).abs() < 1e-10,
+            "sign flip is not a gauge: {a} vs {b} (should be negatives)"
+        );
+    }
+}

--- a/crates/vision-calibration/tests/rig_extrinsics_matrix.rs
+++ b/crates/vision-calibration/tests/rig_extrinsics_matrix.rs
@@ -1,0 +1,429 @@
+//! Synthetic-GT matrix test for the multi-camera rig extrinsics family (Q8,
+//! `docs/notes/README.md`; math note: `docs/notes/rig-extrinsics.md`).
+//!
+//! Ground-truth grid × noise levels: every cell builds an exact synthetic
+//! two-camera rig via `vision_calibration::synthetic`, runs the *standard*
+//! `step_intrinsics_init_all → step_intrinsics_optimize_all → step_rig_init →
+//! step_rig_optimize` pipeline, and asserts inter-camera rotation/translation
+//! (baseline) recovery plus a reprojection error consistent with the injected
+//! noise floor. It also covers:
+//!
+//! - the reference-camera gauge: shifting which camera pins the rig frame
+//!   re-expresses every extrinsic but leaves the relative inter-camera pose
+//!   and the reprojection error invariant (§gauge of the math note);
+//! - the minimum-overlap requirement: a disconnected co-visibility graph
+//!   (no view where a camera and the reference co-observe the target) is
+//!   rejected by rig init (§identifiability of the math note).
+
+#![allow(missing_docs)]
+
+use nalgebra::{Rotation3, Translation3, UnitQuaternion};
+use vision_calibration::core::{
+    BrownConrady5, CorrespondenceView, FxFyCxCySkew, Iso3, NoMeta, PinholeCamera, Pt3, RigDataset,
+    RigView, RigViewObs, make_pinhole_camera,
+};
+use vision_calibration::rig_extrinsics::{
+    RigExtrinsicsConfig, RigExtrinsicsExport, RigExtrinsicsInput, RigExtrinsicsProblem,
+    RigIntrinsicsManualInit, run_calibration, step_intrinsics_init_all_with_seed, step_rig_init,
+};
+use vision_calibration::session::CalibrationSession;
+use vision_calibration::synthetic::{noise::UniformPixelNoise, planar};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ground-truth fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One cell of the ground-truth grid: an inter-camera extrinsic (`cam1_se3_rig`,
+/// i.e. the relative pose T_C1_C0 because camera 0 pins the rig frame).
+struct GtCell {
+    /// `cam1_se3_rig` = T_C1_R (rig = camera 0): the observable relative pose.
+    cam1_se3_rig: Iso3,
+    label: &'static str,
+}
+
+fn make_iso(angles: (f64, f64, f64), t: (f64, f64, f64)) -> Iso3 {
+    let rot = Rotation3::from_euler_angles(angles.0, angles.1, angles.2);
+    Iso3::from_parts(
+        Translation3::new(t.0, t.1, t.2),
+        UnitQuaternion::from_rotation_matrix(&rot),
+    )
+}
+
+/// Two rig cameras with distinct intrinsics (exercises per-camera intrinsics
+/// handling). Zero distortion isolates the extrinsics geometry — the distortion
+/// sub-model is covered by the planar pack.
+fn rig_cameras() -> [PinholeCamera; 2] {
+    [
+        make_pinhole_camera(
+            FxFyCxCySkew {
+                fx: 850.0,
+                fy: 845.0,
+                cx: 640.0,
+                cy: 480.0,
+                skew: 0.0,
+            },
+            BrownConrady5::default(),
+        ),
+        make_pinhole_camera(
+            FxFyCxCySkew {
+                fx: 820.0,
+                fy: 815.0,
+                cx: 650.0,
+                cy: 470.0,
+                skew: 0.0,
+            },
+            BrownConrady5::default(),
+        ),
+    ]
+}
+
+/// Board shared by every cell: an 8×6 grid of 30 mm cells (48 points).
+fn board() -> Vec<Pt3> {
+    planar::grid_points(8, 6, 0.03)
+}
+
+/// Rig poses (`rig_se3_target`, T_R_T) with strongly diverse pitch/yaw and a
+/// distance ramp. Orientation diversity is required for the per-camera Zhang
+/// init to be well posed *and* for the inter-camera extrinsics to be observable
+/// from the shared views (see the math note, §identifiability). The board is
+/// re-centred on the optical axis so the rotations stay near fronto-parallel.
+fn rig_poses() -> Vec<Iso3> {
+    let angles: [(f64, f64); 8] = [
+        (0.00, 0.00),
+        (0.16, -0.06),
+        (-0.14, 0.10),
+        (0.08, 0.18),
+        (-0.06, -0.16),
+        (0.20, 0.12),
+        (-0.18, -0.10),
+        (0.11, -0.20),
+    ];
+    angles
+        .iter()
+        .enumerate()
+        .map(|(i, (pitch, yaw))| {
+            Iso3::from_parts(
+                // Board spans [0, 0.21] × [0, 0.15] m; recentre and ramp 0.60→0.81 m.
+                Translation3::new(-0.105, -0.075, 0.60 + 0.03 * i as f64),
+                Rotation3::from_euler_angles(*pitch, *yaw, 0.0).into(),
+            )
+        })
+        .collect()
+}
+
+/// (Δtranslation in metres, Δrotation angle in radians) between two poses.
+fn pose_error(a: &Iso3, b: &Iso3) -> (f64, f64) {
+    let dt = (a.translation.vector - b.translation.vector).norm();
+    let r_diff = a.rotation.inverse() * b.rotation;
+    (dt, r_diff.angle())
+}
+
+/// Relative pose T_C1_C0 = `cam_se3_rig[1] · cam_se3_rig[0]⁻¹` — the
+/// gauge-invariant observable (independent of which camera pins the rig frame).
+fn relative_pose(cam_se3_rig: &[Iso3]) -> Iso3 {
+    cam_se3_rig[1] * cam_se3_rig[0].inverse()
+}
+
+/// Build a synthetic two-camera rig dataset. `cam_se3_rig[c]` is the ground-truth
+/// camera-from-rig transform (camera 0 is the rig frame ⇒ identity). Each camera
+/// gets an independent deterministic noise stream (`seed + cam_idx`) so the two
+/// views of a pose are not correlated. Every camera observes every view (full
+/// co-visibility).
+fn build_rig_dataset(
+    cameras: &[PinholeCamera],
+    cam_se3_rig: &[Iso3],
+    board: &[Pt3],
+    rig_poses: &[Iso3],
+    seed: u64,
+    noise_px: f64,
+) -> RigExtrinsicsInput {
+    let num_cameras = cameras.len();
+    // Per-camera projected views: `[cam][view]`.
+    let per_cam_views: Vec<Vec<CorrespondenceView>> = cameras
+        .iter()
+        .enumerate()
+        .map(|(cam_idx, cam)| {
+            let cam_poses: Vec<Iso3> = rig_poses
+                .iter()
+                .map(|rig_se3_target| cam_se3_rig[cam_idx] * rig_se3_target)
+                .collect();
+            let noise = UniformPixelNoise {
+                seed: seed + cam_idx as u64,
+                max_abs_px: noise_px,
+            };
+            planar::project_views_noisy(cam, board, &cam_poses, &noise)
+                .expect("all board points projectable in every camera/view")
+        })
+        .collect();
+
+    let views: Vec<RigView<NoMeta>> = (0..rig_poses.len())
+        .map(|view_idx| RigView {
+            meta: NoMeta,
+            obs: RigViewObs {
+                cameras: (0..num_cameras)
+                    .map(|cam_idx| Some(per_cam_views[cam_idx][view_idx].clone()))
+                    .collect(),
+            },
+        })
+        .collect();
+
+    RigDataset::new(views, num_cameras).expect("valid rig dataset")
+}
+
+/// Run the standard four-step rig pipeline with the given reference camera and
+/// return the export.
+fn solve(input: RigExtrinsicsInput, reference_camera_idx: usize) -> RigExtrinsicsExport {
+    let mut session = CalibrationSession::<RigExtrinsicsProblem>::new();
+    let mut config = RigExtrinsicsConfig::default();
+    config.reference_camera_idx = reference_camera_idx;
+    session.set_config(config).expect("config");
+    session.set_input(input).expect("input");
+    run_calibration(&mut session).expect("calibration");
+    session.export().expect("export")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Matrix test
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rig_extrinsics_recovers_gt_across_grid_and_noise() {
+    // Two rig geometries: a narrow-baseline near-parallel stereo pair and a
+    // wide-baseline strongly converged pair.
+    let grid = [
+        GtCell {
+            cam1_se3_rig: make_iso((0.0, 0.05, 0.0), (-0.06, 0.0, 0.0)),
+            label: "narrow_baseline",
+        },
+        GtCell {
+            cam1_se3_rig: make_iso((0.02, 0.14, 0.01), (-0.25, 0.0, 0.02)),
+            label: "wide_baseline",
+        },
+    ];
+    let noise_levels = [0.0, 0.15, 0.30];
+
+    let cameras = rig_cameras();
+    let board = board();
+    let rig_poses = rig_poses();
+
+    for cell in &grid {
+        // Camera 0 pins the rig frame (identity); camera 1 carries the GT pose.
+        let cam_se3_rig_gt = [Iso3::identity(), cell.cam1_se3_rig];
+        let gt_baseline = cell.cam1_se3_rig.translation.vector.norm();
+
+        for &noise_px in &noise_levels {
+            let input = build_rig_dataset(
+                &cameras,
+                &cam_se3_rig_gt,
+                &board,
+                &rig_poses,
+                /*seed=*/ 20,
+                noise_px,
+            );
+            let export = solve(input, /*reference_camera_idx=*/ 0);
+            let label = format!("{} noise={noise_px}px", cell.label);
+
+            assert_eq!(export.cam_se3_rig.len(), 2, "{label}: camera count");
+            assert!(
+                export.sensors.is_none(),
+                "{label}: pinhole rig has no sensors"
+            );
+
+            // Reference camera pins the rig frame ⇒ its extrinsic is identity.
+            let (dt_ref, dang_ref) = pose_error(&export.cam_se3_rig[0], &Iso3::identity());
+            assert!(
+                dt_ref < 1e-9 && dang_ref < 1e-9,
+                "{label}: reference camera extrinsic not identity (dt={dt_ref}, dang={dang_ref})"
+            );
+
+            // Inter-camera pose recovery. With camera 0 as reference, the
+            // observable relative pose T_C1_C0 equals cam_se3_rig[1].
+            let rel_est = relative_pose(&export.cam_se3_rig);
+            let (dt, dang) = pose_error(&rel_est, &cell.cam1_se3_rig);
+
+            // Rotation recovery (radians). Exact data hits solver tolerance;
+            // noisy cells scale linearly in the injected amplitude
+            // (≈ 2e-2 rad/px — see the math note, §noise sensitivity).
+            let ang_tol = if noise_px == 0.0 {
+                5.0e-4
+            } else {
+                noise_px * 0.03 + 5.0e-4
+            };
+            assert!(
+                dang < ang_tol,
+                "{label}: inter-camera rotation err {dang} rad > {ang_tol}"
+            );
+
+            // Baseline / translation recovery (metres). The inter-camera
+            // translation is the most noise-sensitive DOF: the strongly
+            // converged wide pair couples ≈ 6e-3 rad of rotation error into
+            // ≈ 2 cm of translation error at 0.3 px, roughly 3× the near-parallel
+            // narrow pair. Both scale linearly in the injected amplitude.
+            let trans_tol = if noise_px == 0.0 {
+                5.0e-4
+            } else {
+                noise_px * 0.085 + 1.0e-3
+            };
+            assert!(
+                dt < trans_tol,
+                "{label}: inter-camera translation err {dt} m > {trans_tol} (gt baseline {gt_baseline} m)"
+            );
+
+            // Residual floor: uniform noise in [−a, a] per axis has expected
+            // error-norm mean ≈ 0.765·a; near-zero on exact data. The rig cost
+            // couples both cameras, so allow generous headroom on noisy cells.
+            let reproj_bound = if noise_px == 0.0 {
+                1e-3
+            } else {
+                noise_px * 0.9 + 0.05
+            };
+            assert!(
+                export.mean_reproj_error <= reproj_bound,
+                "{label}: mean reproj {} > bound {reproj_bound}",
+                export.mean_reproj_error
+            );
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Property test — reference-camera gauge invariance
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rig_extrinsics_reference_camera_gauge_invariance() {
+    // The rig frame is a gauge: which camera pins it (identity extrinsic) only
+    // re-expresses every `cam_se3_rig`, it does not change the observable
+    // relative inter-camera pose or the reprojection error. Solving the *same*
+    // pixels with reference camera 0 vs. camera 1 must therefore agree on the
+    // relative pose T_C1_C0 and on the mean reprojection error, while each
+    // solve's reference camera lands at identity (see the math note, §gauge).
+    let cameras = rig_cameras();
+    let board = board();
+    let rig_poses = rig_poses();
+    let cam_se3_rig_gt = [
+        Iso3::identity(),
+        make_iso((0.02, 0.12, 0.01), (-0.20, 0.01, 0.02)),
+    ];
+
+    // A single noisy dataset drives both solves.
+    let input = build_rig_dataset(
+        &cameras,
+        &cam_se3_rig_gt,
+        &board,
+        &rig_poses,
+        /*seed=*/ 31,
+        /*noise_px=*/ 0.15,
+    );
+
+    let export_ref0 = solve(input.clone(), 0);
+    let export_ref1 = solve(input, 1);
+
+    // Each solve pins its own reference camera to identity.
+    let (dt0, dang0) = pose_error(&export_ref0.cam_se3_rig[0], &Iso3::identity());
+    let (dt1, dang1) = pose_error(&export_ref1.cam_se3_rig[1], &Iso3::identity());
+    assert!(
+        dt0 < 1e-9 && dang0 < 1e-9,
+        "ref0 solve: camera 0 not identity (dt={dt0}, dang={dang0})"
+    );
+    assert!(
+        dt1 < 1e-9 && dang1 < 1e-9,
+        "ref1 solve: camera 1 not identity (dt={dt1}, dang={dang1})"
+    );
+
+    // The absolute extrinsics differ between the two gauges …
+    let rel0 = relative_pose(&export_ref0.cam_se3_rig);
+    let rel1 = relative_pose(&export_ref1.cam_se3_rig);
+    let expressed_differently = (export_ref0.cam_se3_rig[1].translation.vector
+        - Iso3::identity().translation.vector)
+        .norm()
+        > 1e-3;
+    assert!(
+        expressed_differently,
+        "sanity: camera-1 extrinsic under ref0 should be non-identity"
+    );
+
+    // … but the observable relative pose is gauge-invariant.
+    let (dt, dang) = pose_error(&rel0, &rel1);
+    assert!(
+        dt < 5e-4 && dang < 5e-4,
+        "relative inter-camera pose not gauge-invariant under reference shift: dt={dt} m, dang={dang} rad"
+    );
+
+    // The reprojection error is a property of the reconstructed geometry, not
+    // of the frame choice — it is invariant to the reference camera. The two
+    // solves converge to the same minimum from different gauge fixings, so the
+    // residual gap is bounded by solver tolerance, not by the gauge.
+    assert!(
+        (export_ref0.mean_reproj_error - export_ref1.mean_reproj_error).abs() < 5e-3,
+        "reprojection error not gauge-invariant: {} vs {}",
+        export_ref0.mean_reproj_error,
+        export_ref1.mean_reproj_error
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Degeneracy test — disconnected co-visibility graph
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn rig_extrinsics_rejects_disconnected_covisibility_graph() {
+    // Linear rig init recovers camera 1's extrinsic from views where BOTH
+    // camera 1 and the reference co-observe the target. If the co-visibility
+    // graph is disconnected — camera 0 sees views {0..3}, camera 1 sees views
+    // {4..7}, no shared view — the relative pose is unobservable and rig init
+    // must fail with an overlap error (see the math note, §identifiability).
+    let cameras = rig_cameras();
+    let board = board();
+    let rig_poses = rig_poses();
+    let cam_se3_rig_gt = [
+        Iso3::identity(),
+        make_iso((0.0, 0.1, 0.0), (-0.15, 0.0, 0.0)),
+    ];
+
+    // Project every camera in every view (exact), then blank out the overlap.
+    let per_cam_views: Vec<Vec<CorrespondenceView>> = cameras
+        .iter()
+        .enumerate()
+        .map(|(cam_idx, cam)| {
+            let cam_poses: Vec<Iso3> = rig_poses
+                .iter()
+                .map(|rig_se3_target| cam_se3_rig_gt[cam_idx] * rig_se3_target)
+                .collect();
+            planar::project_views_all(cam, &board, &cam_poses).expect("projectable")
+        })
+        .collect();
+
+    let views: Vec<RigView<NoMeta>> = (0..rig_poses.len())
+        .map(|view_idx| {
+            // Camera 0 owns the first half of the views, camera 1 the second —
+            // each keeps ≥ 3 views (enough for per-camera Zhang) but they never
+            // share a view.
+            let cam0 = (view_idx < 4).then(|| per_cam_views[0][view_idx].clone());
+            let cam1 = (view_idx >= 4).then(|| per_cam_views[1][view_idx].clone());
+            RigView {
+                meta: NoMeta,
+                obs: RigViewObs {
+                    cameras: vec![cam0, cam1],
+                },
+            }
+        })
+        .collect();
+    let input = RigDataset::new(views, 2).expect("valid rig dataset");
+
+    let mut session = CalibrationSession::<RigExtrinsicsProblem>::new();
+    session.set_input(input).expect("input");
+
+    // Seed both cameras with their GT intrinsics so the per-camera stage is
+    // trivially well posed and the test isolates the connectivity failure.
+    let mut seed = RigIntrinsicsManualInit::default();
+    seed.per_cam_intrinsics = Some(cameras.iter().map(|c| c.k).collect());
+    step_intrinsics_init_all_with_seed(&mut session, seed, None).expect("intrinsics init");
+
+    let err = step_rig_init(&mut session).expect_err("disconnected graph must fail rig init");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("overlap"),
+        "error should report the missing co-visibility overlap, got: {msg}"
+    );
+}

--- a/crates/vision-calibration/tests/single_cam_handeye_matrix.rs
+++ b/crates/vision-calibration/tests/single_cam_handeye_matrix.rs
@@ -1,0 +1,376 @@
+//! Synthetic-GT matrix test for the single-camera hand-eye family (Q8,
+//! `docs/notes/README.md`; math note: `docs/notes/hand-eye.md`).
+//!
+//! Ground-truth grid × noise levels: every cell builds an exact synthetic
+//! dataset via `vision_calibration::synthetic`, runs the *standard*
+//! `step_intrinsics_init → step_intrinsics_optimize → step_handeye_init →
+//! step_handeye_optimize` pipeline, and asserts hand-eye rotation/translation
+//! recovery plus a reprojection error consistent with the injected noise
+//! floor. It also covers the EyeToHand convention and the base-frame gauge
+//! invariance of the recovered hand-eye transform.
+
+#![allow(missing_docs)]
+
+use nalgebra::{Rotation3, Translation3, UnitQuaternion};
+use vision_calibration::core::{
+    BrownConrady5, FxFyCxCySkew, Iso3, PinholeCamera, Pt3, make_pinhole_camera,
+};
+use vision_calibration::optim::HandEyeMode;
+use vision_calibration::session::CalibrationSession;
+use vision_calibration::single_cam_handeye::{
+    HandeyeMeta, SingleCamHandeyeConfig, SingleCamHandeyeExport, SingleCamHandeyeInput,
+    SingleCamHandeyeProblem, SingleCamHandeyeView, step_handeye_init, step_handeye_optimize,
+    step_intrinsics_init, step_intrinsics_optimize,
+};
+use vision_calibration::synthetic::{noise::UniformPixelNoise, planar};
+
+/// One cell of the ground-truth grid: a focal regime and a hand-eye transform.
+struct GtCell {
+    fx: f64,
+    fy: f64,
+    /// Hand-eye ground truth (`gripper_se3_camera`, `T_G_C`) for EyeInHand.
+    handeye: Iso3,
+    label: &'static str,
+}
+
+/// Board shared by every cell: a 9×7 grid of 30 mm cells (63 points).
+fn board() -> Vec<Pt3> {
+    planar::grid_points(9, 7, 0.03)
+}
+
+/// Robot stations (`base_se3_gripper`, `T_B_G`) with strongly diverse rotation
+/// axes. Hand-eye identifiability *requires* ≥ 2 relative motions with
+/// non-parallel rotation axes (see the math note, §identifiability): the
+/// roll/pitch/yaw mix below supplies that, and the translation ramp spreads
+/// the target distance so Zhang's intrinsics init is well posed too.
+fn robot_poses() -> Vec<Iso3> {
+    // (euler angles rad, translation m) per station.
+    type Station = ((f64, f64, f64), (f64, f64, f64));
+    let specs: [Station; 9] = [
+        ((0.00, 0.00, 0.00), (0.00, 0.00, 0.00)),
+        ((0.30, 0.00, 0.00), (0.10, 0.00, 0.00)), // roll
+        ((0.00, 0.30, 0.00), (0.00, 0.10, 0.00)), // pitch
+        ((0.00, 0.00, 0.30), (0.00, 0.00, 0.08)), // yaw
+        ((0.22, 0.20, 0.00), (0.05, -0.05, 0.02)),
+        ((-0.24, 0.00, 0.20), (-0.05, 0.05, 0.03)),
+        ((0.16, -0.18, 0.12), (0.02, -0.04, 0.05)),
+        ((-0.15, 0.22, -0.10), (-0.03, 0.03, 0.04)),
+        ((0.20, -0.10, 0.24), (0.04, 0.02, 0.01)),
+    ];
+    specs
+        .iter()
+        .map(|&(angles, t)| make_iso(angles, t))
+        .collect()
+}
+
+fn make_iso(angles: (f64, f64, f64), t: (f64, f64, f64)) -> Iso3 {
+    let rot = Rotation3::from_euler_angles(angles.0, angles.1, angles.2);
+    Iso3::from_parts(
+        Translation3::new(t.0, t.1, t.2),
+        UnitQuaternion::from_rotation_matrix(&rot),
+    )
+}
+
+fn camera(fx: f64, fy: f64) -> PinholeCamera {
+    make_pinhole_camera(
+        FxFyCxCySkew {
+            fx,
+            fy,
+            cx: 512.0,
+            cy: 384.0,
+            skew: 0.0,
+        },
+        // Zero distortion: this family's proof pack isolates the hand-eye
+        // geometry; the distortion sub-model is covered by the planar pack.
+        BrownConrady5::default(),
+    )
+}
+
+/// (Δtranslation in metres, Δrotation angle in radians) between two poses.
+fn pose_error(a: &Iso3, b: &Iso3) -> (f64, f64) {
+    let dt = (a.translation.vector - b.translation.vector).norm();
+    let r_diff = a.rotation.inverse() * b.rotation;
+    (dt, r_diff.angle())
+}
+
+/// Build the per-view EyeInHand observations for a ground-truth
+/// `(camera, handeye X = T_G_C, target Y = T_B_T)`, with deterministic pixel
+/// noise. The camera pose per view is `T_C_T_i = (T_B_G_i · X)^-1 · Y`.
+fn eye_in_hand_views(
+    camera: &PinholeCamera,
+    board: &[Pt3],
+    robot_poses: &[Iso3],
+    handeye: &Iso3,
+    target_in_base: &Iso3,
+    noise: &UniformPixelNoise,
+) -> Vec<SingleCamHandeyeView> {
+    let cam_poses: Vec<Iso3> = robot_poses
+        .iter()
+        .map(|tbg| (tbg * handeye).inverse() * target_in_base)
+        .collect();
+    let obs = planar::project_views_noisy(camera, board, &cam_poses, noise)
+        .expect("all board points projectable in every view");
+    obs.into_iter()
+        .zip(robot_poses.iter())
+        .map(|(obs, tbg)| SingleCamHandeyeView {
+            obs,
+            meta: HandeyeMeta {
+                base_se3_gripper: *tbg,
+            },
+        })
+        .collect()
+}
+
+/// Run the standard four-step single-cam hand-eye pipeline and export.
+fn solve(input: SingleCamHandeyeInput, mode: HandEyeMode) -> SingleCamHandeyeExport {
+    solve_with(input, mode, true)
+}
+
+/// Same, with control over robot-pose refinement (the default is `true`).
+fn solve_with(
+    input: SingleCamHandeyeInput,
+    mode: HandEyeMode,
+    refine_robot_poses: bool,
+) -> SingleCamHandeyeExport {
+    let mut session = CalibrationSession::<SingleCamHandeyeProblem>::new();
+    let mut config = SingleCamHandeyeConfig::default();
+    config.handeye_mode = mode;
+    config.refine_robot_poses = refine_robot_poses;
+    session.set_config(config).expect("config");
+    session.set_input(input).expect("input");
+    step_intrinsics_init(&mut session, None).expect("intrinsics init");
+    step_intrinsics_optimize(&mut session, None).expect("intrinsics optimize");
+    step_handeye_init(&mut session, None).expect("handeye init");
+    step_handeye_optimize(&mut session, None).expect("handeye optimize");
+    session.export().expect("export")
+}
+
+#[test]
+fn single_cam_handeye_recovers_gt_across_grid_and_noise() {
+    // Two hand-eye regimes: a modest offset and a larger rotated/translated one.
+    let x_small = make_iso((0.10, -0.05, 0.02), (0.05, -0.03, 0.08));
+    let x_large = make_iso((0.25, 0.18, -0.12), (-0.09, 0.06, 0.12));
+
+    let grid = [
+        GtCell {
+            fx: 800.0,
+            fy: 780.0,
+            handeye: x_small,
+            label: "f800/X_small",
+        },
+        GtCell {
+            fx: 800.0,
+            fy: 780.0,
+            handeye: x_large,
+            label: "f800/X_large",
+        },
+        GtCell {
+            fx: 1200.0,
+            fy: 1200.0,
+            handeye: x_small,
+            label: "f1200/X_small",
+        },
+    ];
+    let noise_levels = [0.0, 0.15, 0.30];
+
+    // Target fixed in the base frame, ~1 m in front, mildly tilted so the
+    // near-identity robot station is not degenerately fronto-parallel.
+    let target_in_base = make_iso((0.05, -0.08, 0.0), (-0.10, -0.08, 1.0));
+
+    let board = board();
+    let robot_poses = robot_poses();
+
+    for cell in &grid {
+        let cam_gt = camera(cell.fx, cell.fy);
+        for &noise_px in &noise_levels {
+            let noise = UniformPixelNoise {
+                seed: 7,
+                max_abs_px: noise_px,
+            };
+            let views = eye_in_hand_views(
+                &cam_gt,
+                &board,
+                &robot_poses,
+                &cell.handeye,
+                &target_in_base,
+                &noise,
+            );
+            let input = SingleCamHandeyeInput::new(views).expect("input");
+            let export = solve(input, HandEyeMode::EyeInHand);
+
+            let x_est = export
+                .gripper_se3_camera
+                .expect("EyeInHand populates gripper_se3_camera");
+            let (dt, dang) = pose_error(&x_est, &cell.handeye);
+            let label = format!("{} noise={noise_px}px", cell.label);
+
+            // Focal recovery (relative). Exact data must be tight; noisy cells
+            // scale with the injected amplitude.
+            let focal_tol = if noise_px == 0.0 { 0.003 } else { 0.03 };
+            assert!(
+                (export.camera.k.fx - cell.fx).abs() / cell.fx < focal_tol
+                    && (export.camera.k.fy - cell.fy).abs() / cell.fy < focal_tol,
+                "{label}: focal ({}, {}) vs gt ({}, {})",
+                export.camera.k.fx,
+                export.camera.k.fy,
+                cell.fx,
+                cell.fy
+            );
+
+            // Hand-eye rotation recovery (radians). 1e-3 rad ≈ 0.057°.
+            let ang_tol = if noise_px == 0.0 { 2.0e-3 } else { 0.02 };
+            assert!(
+                dang < ang_tol,
+                "{label}: hand-eye rotation err {dang} rad > {ang_tol}"
+            );
+
+            // Hand-eye translation recovery (metres). The translation DOF is
+            // the most noise-sensitive part of the chain (see the math note,
+            // §noise sensitivity): it is the ratio of pose residuals to the
+            // rank-deficient (R_A − I) blocks.
+            let trans_tol = if noise_px == 0.0 { 2.0e-3 } else { 8.0e-3 };
+            assert!(
+                dt < trans_tol,
+                "{label}: hand-eye translation err {dt} m > {trans_tol}"
+            );
+
+            // Residual floor: uniform noise in [−a, a] per axis has expected
+            // error-norm mean ≈ 0.765·a; near-zero on exact data.
+            let reproj_bound = if noise_px == 0.0 {
+                1e-3
+            } else {
+                noise_px * 0.9 + 0.05
+            };
+            assert!(
+                export.mean_reproj_error <= reproj_bound,
+                "{label}: mean reproj {} > bound {reproj_bound}",
+                export.mean_reproj_error
+            );
+        }
+    }
+}
+
+#[test]
+fn single_cam_handeye_eye_to_hand_recovers_gt() {
+    // EyeToHand: a scene-fixed camera observes a gripper-mounted target.
+    //   handeye = camera_se3_base (T_C_B), target = gripper_se3_target (T_G_T)
+    //   T_C_T_i = T_C_B · T_B_G_i · T_G_T
+    let cam_gt = camera(950.0, 940.0);
+    let camera_se3_base = make_iso((0.08, -0.06, 0.03), (0.02, 0.04, 1.2));
+    let gripper_se3_target = make_iso((0.03, 0.05, -0.02), (0.03, -0.02, 0.02));
+
+    let board = board();
+    let robot_poses = robot_poses();
+
+    for &noise_px in &[0.0, 0.2] {
+        let noise = UniformPixelNoise {
+            seed: 11,
+            max_abs_px: noise_px,
+        };
+        let cam_poses: Vec<Iso3> = robot_poses
+            .iter()
+            .map(|tbg| camera_se3_base * tbg * gripper_se3_target)
+            .collect();
+        let obs =
+            planar::project_views_noisy(&cam_gt, &board, &cam_poses, &noise).expect("projectable");
+        let views: Vec<SingleCamHandeyeView> = obs
+            .into_iter()
+            .zip(robot_poses.iter())
+            .map(|(obs, tbg)| SingleCamHandeyeView {
+                obs,
+                meta: HandeyeMeta {
+                    base_se3_gripper: *tbg,
+                },
+            })
+            .collect();
+        let input = SingleCamHandeyeInput::new(views).expect("input");
+        let export = solve(input, HandEyeMode::EyeToHand);
+
+        let x_est = export
+            .camera_se3_base
+            .expect("EyeToHand populates camera_se3_base");
+        let g_est = export
+            .gripper_se3_target
+            .expect("EyeToHand populates gripper_se3_target");
+        let (dt_x, dang_x) = pose_error(&x_est, &camera_se3_base);
+        let (dt_g, dang_g) = pose_error(&g_est, &gripper_se3_target);
+
+        // `camera_se3_base` is a *derived*, distant pose (target ~1.2 m away),
+        // so its translation is the least-constrained DOF; allow it a little
+        // more headroom than the direct DLT output `gripper_se3_target`.
+        let (ang_tol, trans_tol, reproj_bound) = if noise_px == 0.0 {
+            (3.0e-3, 3.0e-3, 1e-3)
+        } else {
+            (0.02, 1.2e-2, noise_px * 0.9 + 0.05)
+        };
+        assert!(
+            dang_x < ang_tol && dang_g < ang_tol,
+            "noise={noise_px}px: rotation err camera_se3_base={dang_x} gripper_se3_target={dang_g} > {ang_tol}"
+        );
+        assert!(
+            dt_x < trans_tol && dt_g < trans_tol,
+            "noise={noise_px}px: translation err camera_se3_base={dt_x} gripper_se3_target={dt_g} > {trans_tol}"
+        );
+        assert!(
+            export.mean_reproj_error <= reproj_bound,
+            "noise={noise_px}px: mean reproj {} > {reproj_bound}",
+            export.mean_reproj_error
+        );
+    }
+}
+
+#[test]
+fn single_cam_handeye_base_frame_gauge_invariance() {
+    // Rebasing the robot base frame (T_B_G_i → G · T_B_G_i, T_B_T → G · T_B_T)
+    // leaves every camera-frame observation identical:
+    //   (G·T_B_G · X)^-1 · (G·T_B_T) = X^-1 · T_B_G^-1 · T_B_T.
+    // So the recovered hand-eye X and the reprojection error must be invariant
+    // to G, while only the fixed target pose absorbs it. This is a genuine
+    // gauge of the joint reprojection cost (see the math note, §gauge).
+    //
+    // Robot-pose refinement is disabled here: the zero-mean se(3) priors are
+    // written in the base frame via a left-multiplicative correction, so under
+    // rebasing the penalty transforms by Ad_G and is *not* invariant (it mildly
+    // breaks this gauge — a real, documented subtlety). With the priors off the
+    // reprojection cost is exactly gauge-invariant.
+    let cam_gt = camera(880.0, 870.0);
+    let handeye = make_iso((0.12, -0.07, 0.04), (0.06, -0.02, 0.09));
+    let target_in_base = make_iso((0.04, -0.06, 0.0), (-0.08, -0.05, 1.0));
+    let board = board();
+    let robot_poses = robot_poses();
+    let noise = UniformPixelNoise {
+        seed: 5,
+        max_abs_px: 0.1,
+    };
+
+    let solve_for = |poses: &[Iso3], target: &Iso3| -> SingleCamHandeyeExport {
+        let views = eye_in_hand_views(&cam_gt, &board, poses, &handeye, target, &noise);
+        let input = SingleCamHandeyeInput::new(views).expect("input");
+        solve_with(input, HandEyeMode::EyeInHand, false)
+    };
+
+    let base = solve_for(&robot_poses, &target_in_base);
+
+    // Arbitrary rigid rebasing of the base frame.
+    let g = make_iso((0.20, -0.35, 0.15), (0.3, -0.4, 0.2));
+    let rebased_poses: Vec<Iso3> = robot_poses.iter().map(|p| g * p).collect();
+    let rebased_target = g * target_in_base;
+    let rebased = solve_for(&rebased_poses, &rebased_target);
+
+    let x_base = base.gripper_se3_camera.unwrap();
+    let x_rebased = rebased.gripper_se3_camera.unwrap();
+    let (dt, dang) = pose_error(&x_base, &x_rebased);
+
+    // The hand-eye X is gauge-invariant; both solves converge from the same
+    // noisy pixels to the same X up to solver tolerance.
+    assert!(
+        dt < 1e-6 && dang < 1e-6,
+        "hand-eye not gauge-invariant under base rebasing: dt={dt} m, dang={dang} rad"
+    );
+    assert!(
+        (base.mean_reproj_error - rebased.mean_reproj_error).abs() < 1e-9,
+        "reprojection error not gauge-invariant: {} vs {}",
+        base.mean_reproj_error,
+        rebased.mean_reproj_error
+    );
+}

--- a/crates/vision-mvg/tests/two_view_matrix.rs
+++ b/crates/vision-mvg/tests/two_view_matrix.rs
@@ -1,0 +1,261 @@
+//! Synthetic-GT matrix test for the two-view / triangulation family (Q8,
+//! `docs/notes/README.md`; math note: `docs/notes/two-view-triangulation.md`).
+//!
+//! Ground-truth grid (baseline / parallax regimes) × pixel-noise levels. Every
+//! cell builds an exact synthetic stereo pair with a known intrinsic `K` and a
+//! known relative pose `(R, t)`, projects a non-coplanar 3D point cloud to
+//! pixels, adds deterministic per-pixel noise, and pushes the result through:
+//!
+//! 1. **Relative pose recovery** (`recover_relative_pose`, the 5-point +
+//!    cheirality pipeline on normalized coordinates) — asserts rotation error
+//!    (deg) and translation-direction error (deg).
+//! 2. **Metric triangulation** (`triangulate_nview`, DLT + Gauss-Newton) with
+//!    the *known* metric projection matrices — asserts reprojection error (px)
+//!    and 3D Euclidean error against ground truth, scaled to the injected
+//!    noise floor.
+//!
+//! Two-view geometry is observable only up to a similarity scale, so (1) uses
+//! only the scale-invariant quantities (rotation, translation *direction*).
+//! (2) resolves the scale gauge by handing the solver the true metric cameras,
+//! which is exactly the frozen-extrinsics regime the triangulation solver runs
+//! in downstream.
+
+#![allow(missing_docs)]
+
+use nalgebra::Rotation3;
+use vision_calibration_core::synthetic::noise::UniformPixelNoise;
+use vision_calibration_core::{FxFyCxCySkew, Mat3, Pt2, Pt3, Vec3, pixel_to_normalized};
+use vision_geometry::camera_matrix::Mat34;
+use vision_mvg::triangulation::triangulate_nview;
+use vision_mvg::{Correspondence2D, recover_relative_pose};
+
+/// Shared intrinsics for both views (a 1280×720-ish pinhole).
+fn intrinsics() -> Mat3 {
+    FxFyCxCySkew {
+        fx: 800.0,
+        fy: 790.0,
+        cx: 640.0,
+        cy: 360.0,
+        skew: 0.0,
+    }
+    .k_matrix()
+}
+
+/// A non-coplanar 3D point cloud spread across the shared frustum. Depth varies
+/// non-linearly with `(ix, iy)` so the points do not lie near any plane — a
+/// planar cloud would make the essential matrix / metric-DLT rank deficient
+/// (see the math note, §Identifiability and degeneracies).
+fn world_points() -> Vec<Pt3> {
+    let mut world = Vec::new();
+    for iy in 0..6 {
+        for ix in 0..7 {
+            let x = -1.2 + 0.4 * ix as f64;
+            let y = -0.9 + 0.36 * iy as f64;
+            let z = 3.0
+                + 0.6 * ((ix as f64) * 0.7).sin()
+                + 0.5 * ((iy as f64) * 1.1).cos()
+                + 0.12 * (ix + iy) as f64;
+            world.push(Pt3::new(x, y, z));
+        }
+    }
+    world
+}
+
+/// One ground-truth relative pose (a baseline / parallax regime).
+struct GtCell {
+    name: &'static str,
+    /// Euler angles (rad) for the camera-1 → camera-2 rotation.
+    rot: (f64, f64, f64),
+    /// Metric translation camera-1 → camera-2 (`pc2 = R·pc1 + t`).
+    t: Vec3,
+    /// Tolerance scale: rotation-error bound per pixel of noise (deg/px).
+    rot_deg_per_px: f64,
+    /// Tolerance scale: translation-direction-error bound per pixel of noise.
+    tdir_deg_per_px: f64,
+    /// Tolerance scale: median 3D triangulation error bound per pixel of noise.
+    err3d_per_px: f64,
+}
+
+fn cells() -> Vec<GtCell> {
+    vec![
+        // Tolerance scales are ~2× the observed deterministic errors, so the
+        // assertions are meaningful yet stable (the noise is seeded). The
+        // translation-direction scale climbs sharply as the baseline narrows —
+        // the two-view parallax degeneracy made quantitative.
+        GtCell {
+            name: "wide-sideways",
+            rot: (0.04, -0.03, 0.02),
+            t: Vec3::new(0.8, 0.05, 0.10),
+            rot_deg_per_px: 0.5,
+            tdir_deg_per_px: 1.0,
+            err3d_per_px: 0.04,
+        },
+        GtCell {
+            name: "wide-rotated",
+            rot: (0.18, -0.12, 0.06),
+            t: Vec3::new(0.7, 0.15, 0.10),
+            rot_deg_per_px: 0.5,
+            tdir_deg_per_px: 1.5,
+            err3d_per_px: 0.04,
+        },
+        GtCell {
+            name: "medium",
+            rot: (0.06, -0.04, 0.02),
+            t: Vec3::new(0.30, 0.03, 0.04),
+            rot_deg_per_px: 0.4,
+            tdir_deg_per_px: 2.5,
+            err3d_per_px: 0.1,
+        },
+        GtCell {
+            name: "narrow",
+            rot: (0.03, -0.02, 0.00),
+            t: Vec3::new(0.10, 0.01, 0.01),
+            rot_deg_per_px: 0.4,
+            tdir_deg_per_px: 8.0,
+            err3d_per_px: 0.3,
+        },
+    ]
+}
+
+/// Rotation error (deg) between two rotation matrices.
+fn rot_err_deg(r_est: &Mat3, r_gt: &Mat3) -> f64 {
+    let d = r_est.transpose() * r_gt;
+    let cos = ((d.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+    cos.acos().to_degrees()
+}
+
+/// Translation-direction error (deg). Two-view `t` is recovered up to scale;
+/// the sign is fixed by cheirality but the reported metric is the acute angle
+/// between the estimated and GT translation *lines* (`|cos|`).
+fn tdir_err_deg(t_est: &Vec3, t_gt: &Vec3) -> f64 {
+    let cos = t_est
+        .normalize()
+        .dot(&t_gt.normalize())
+        .abs()
+        .clamp(0.0, 1.0);
+    cos.acos().to_degrees()
+}
+
+/// Build the metric pixel-domain projection matrices `P₁ = K[I|0]`,
+/// `P₂ = K[R|t]`.
+fn projection_pair(k: &Mat3, r: &Mat3, t: &Vec3) -> (Mat34, Mat34) {
+    let mut p1 = Mat34::zeros();
+    p1.fixed_view_mut::<3, 3>(0, 0).copy_from(k);
+    let mut p2 = Mat34::zeros();
+    p2.fixed_view_mut::<3, 3>(0, 0).copy_from(&(k * r));
+    p2.set_column(3, &(k * t));
+    (p1, p2)
+}
+
+fn project(p: &Mat34, pw: &Pt3) -> Option<Pt2> {
+    let x = p * nalgebra::Vector4::new(pw.x, pw.y, pw.z, 1.0);
+    if x.z <= 1e-6 {
+        return None;
+    }
+    Some(Pt2::new(x.x / x.z, x.y / x.z))
+}
+
+fn median(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}
+
+#[test]
+fn two_view_recovers_pose_and_triangulation_across_grid_and_noise() {
+    let k = intrinsics();
+    let world = world_points();
+    let noise_levels = [0.0_f64, 0.2, 0.5];
+
+    for cell in cells() {
+        let r_gt = *Rotation3::from_euler_angles(cell.rot.0, cell.rot.1, cell.rot.2).matrix();
+        let (p1, p2) = projection_pair(&k, &r_gt, &cell.t);
+
+        for &noise_px in &noise_levels {
+            let noise = UniformPixelNoise {
+                seed: 0xB1AB,
+                max_abs_px: noise_px,
+            };
+
+            // Project the cloud to noisy pixels in both views.
+            let mut corrs = Vec::new();
+            let mut px1 = Vec::new();
+            let mut px2 = Vec::new();
+            let mut kept_world = Vec::new();
+            for (j, pw) in world.iter().enumerate() {
+                let (Some(u1), Some(u2)) = (project(&p1, pw), project(&p2, pw)) else {
+                    continue;
+                };
+                let n1 = noise.sample(0, j);
+                let n2 = noise.sample(1, j);
+                let q1 = Pt2::new(u1.x + n1.x, u1.y + n1.y);
+                let q2 = Pt2::new(u2.x + n2.x, u2.y + n2.y);
+                corrs.push(Correspondence2D::new(
+                    pixel_to_normalized(q1, &k),
+                    pixel_to_normalized(q2, &k),
+                ));
+                px1.push(q1);
+                px2.push(q2);
+                kept_world.push(*pw);
+            }
+            assert!(corrs.len() >= 30, "too few visible correspondences");
+
+            let label = format!("{} noise={noise_px}px", cell.name);
+
+            // --- (1) Relative pose recovery ---
+            let pose = recover_relative_pose(&corrs)
+                .unwrap_or_else(|e| panic!("{label}: pose recovery failed: {e:?}"));
+            let rerr = rot_err_deg(&pose.r, &r_gt);
+            let terr = tdir_err_deg(&pose.t, &cell.t);
+
+            // --- (2) Metric triangulation with the true cameras ---
+            let mut reproj_px = Vec::new();
+            let mut err3d = Vec::new();
+            for ((u1, u2), pw) in px1.iter().zip(px2.iter()).zip(kept_world.iter()) {
+                let tp = triangulate_nview(&[p1, p2], &[*u1, *u2])
+                    .unwrap_or_else(|e| panic!("{label}: triangulation failed: {e:?}"));
+                assert!(tp.in_front, "{label}: triangulated point behind a camera");
+                reproj_px.push(tp.reprojection_error);
+                err3d.push((tp.point - pw).norm());
+            }
+            let med_reproj = median(reproj_px);
+            let med_err3d = median(err3d);
+
+            eprintln!(
+                "{label:24} | rot {rerr:7.4} deg | tdir {terr:8.4} deg | \
+                 reproj {med_reproj:.3e} px | 3Derr {med_err3d:.3e}"
+            );
+
+            // Tolerances: exact data must be tight; noisy cells scale with the
+            // injected amplitude (empirical bounds with margin).
+            if noise_px == 0.0 {
+                assert!(rerr < 0.02, "{label}: rotation {rerr} deg (exact)");
+                assert!(terr < 0.05, "{label}: t-dir {terr} deg (exact)");
+                assert!(med_reproj < 1e-6, "{label}: reproj {med_reproj} px (exact)");
+                assert!(med_err3d < 1e-5, "{label}: 3D err {med_err3d} (exact)");
+            } else {
+                let rot_bound = cell.rot_deg_per_px * noise_px;
+                let tdir_bound = cell.tdir_deg_per_px * noise_px;
+                // Reprojection floor: post-fit reprojection tracks the pixel
+                // noise (uniform [-a, a] per axis ⇒ error-norm mean ≈ 0.765·a).
+                let reproj_bound = noise_px * 1.0 + 0.02;
+                let err3d_bound = cell.err3d_per_px * noise_px;
+                assert!(
+                    rerr < rot_bound,
+                    "{label}: rotation {rerr} deg > bound {rot_bound}"
+                );
+                assert!(
+                    terr < tdir_bound,
+                    "{label}: t-dir {terr} deg > bound {tdir_bound}"
+                );
+                assert!(
+                    med_reproj < reproj_bound,
+                    "{label}: reproj {med_reproj} px > bound {reproj_bound}"
+                );
+                assert!(
+                    med_err3d < err3d_bound,
+                    "{label}: 3D err {med_err3d} > bound {err3d_bound}"
+                );
+            }
+        }
+    }
+}

--- a/crates/vision-mvg/tests/two_view_properties.rs
+++ b/crates/vision-mvg/tests/two_view_properties.rs
@@ -1,0 +1,214 @@
+//! Property tests for two-view / triangulation invariants (Q8,
+//! `docs/notes/two-view-triangulation.md`).
+//!
+//! These are deterministic parameter sweeps (no external proptest dependency —
+//! the workspace has none) that check *structural* invariants which must hold
+//! for **any** valid configuration, over a grid of rotations, translation
+//! directions, and scene points. They extend the single-configuration unit
+//! tests in `vision-geometry` / `vision-mvg` `#[cfg(test)]` modules to a broad
+//! sweep. Each checks a real invariant, not a restatement of the implementation:
+//!
+//! 1. `E = [t]× R` consistency: the GT essential matrix annihilates GT
+//!    calibrated correspondences (`x₂ᵀ E x₁ = 0`), and `decompose_essential`
+//!    recovers `(R, t̂)` up to the known sign fourfold.
+//! 2. Estimated-`F` epipolar residual: `fundamental_8point` on noiseless pixel
+//!    correspondences yields `|x₂ᵀ F x₁| / ‖F‖ ≈ 0`.
+//! 3. Triangulate → reproject round trip: `triangulate_nview` on noiseless
+//!    metric cameras reprojects back onto the observations.
+
+#![allow(missing_docs)]
+
+use nalgebra::Rotation3;
+use vision_calibration_core::{FxFyCxCySkew, Mat3, Pt2, Pt3, Vec3};
+use vision_geometry::camera_matrix::Mat34;
+use vision_geometry::epipolar::{decompose_essential, fundamental_8point};
+use vision_mvg::triangulation::triangulate_nview;
+
+fn skew(v: &Vec3) -> Mat3 {
+    Mat3::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0)
+}
+
+/// A small, deterministic sweep of relative poses (Euler angles rad, metric t).
+fn pose_grid() -> Vec<(Rotation3<f64>, Vec3)> {
+    let rots = [
+        (0.00, 0.00, 0.00),
+        (0.10, -0.05, 0.02),
+        (-0.15, 0.08, -0.04),
+        (0.22, 0.14, 0.06),
+        (-0.05, -0.18, 0.10),
+    ];
+    let ts = [
+        Vec3::new(0.6, 0.02, 0.05),
+        Vec3::new(-0.4, 0.30, -0.10),
+        Vec3::new(0.10, -0.50, 0.20),
+        Vec3::new(0.25, 0.10, 0.40),
+    ];
+    let mut out = Vec::new();
+    for r in &rots {
+        for t in &ts {
+            out.push((Rotation3::from_euler_angles(r.0, r.1, r.2), *t));
+        }
+    }
+    out
+}
+
+/// A non-coplanar calibrated point cloud in front of camera 1.
+fn scene() -> Vec<Pt3> {
+    let mut pts = Vec::new();
+    for iy in 0..5 {
+        for ix in 0..5 {
+            let x = -0.5 + 0.25 * ix as f64;
+            let y = -0.4 + 0.2 * iy as f64;
+            let z = 2.0 + 0.5 * ((ix as f64) * 0.9).sin() + 0.3 * (ix + iy) as f64;
+            pts.push(Pt3::new(x, y, z));
+        }
+    }
+    pts
+}
+
+/// Invariant 1: `E = [t]× R` annihilates GT calibrated correspondences, and
+/// `decompose_essential(E)` contains the GT `(R, t̂)`.
+#[test]
+fn essential_skew_t_r_is_consistent_and_decomposes() {
+    let world = scene();
+
+    for (rot, t) in pose_grid() {
+        // Pure rotation (t = 0) yields E = 0, which is correctly rejected by
+        // decompose_essential; skip it here (covered by the degeneracy tests).
+        if t.norm() < 1e-9 {
+            continue;
+        }
+        let r = *rot.matrix();
+        let e = skew(&t) * r;
+
+        // Epipolar constraint for every GT correspondence: x₂ᵀ E x₁ = 0.
+        let e_norm = e.norm();
+        assert!(e_norm > 0.0);
+        for pw in &world {
+            let pc1 = pw.coords;
+            let pc2 = r * pw.coords + t;
+            if pc1.z <= 1e-6 || pc2.z <= 1e-6 {
+                continue;
+            }
+            let x1 = nalgebra::Vector3::new(pc1.x / pc1.z, pc1.y / pc1.z, 1.0);
+            let x2 = nalgebra::Vector3::new(pc2.x / pc2.z, pc2.y / pc2.z, 1.0);
+            let res = (x2.transpose() * e * x1)[0].abs() / e_norm;
+            assert!(res < 1e-12, "epipolar residual {res:.3e} for GT E");
+        }
+
+        // The GT (R, t̂) must appear among the four decomposition candidates.
+        let candidates = decompose_essential(&e).unwrap();
+        let mut found = false;
+        for (r_est, t_est) in &candidates {
+            let d = r_est.transpose() * r;
+            let cos = ((d.trace() - 1.0) * 0.5).clamp(-1.0, 1.0);
+            let ang = cos.acos().to_degrees();
+            let cos_t = t_est.normalize().dot(&t.normalize()).abs();
+            if ang < 1e-6 && (1.0 - cos_t) < 1e-9 {
+                found = true;
+            }
+        }
+        assert!(found, "decompose_essential did not recover the GT pose");
+    }
+}
+
+/// Invariant 2: `fundamental_8point` on noiseless pixel correspondences yields a
+/// matrix that satisfies the epipolar constraint on the GT correspondences.
+#[test]
+fn fundamental_8point_epipolar_residual_is_tight() {
+    let k = FxFyCxCySkew {
+        fx: 820.0,
+        fy: 800.0,
+        cx: 640.0,
+        cy: 360.0,
+        skew: 0.0,
+    }
+    .k_matrix();
+    let world = scene();
+
+    for (rot, t) in pose_grid() {
+        if t.norm() < 1e-9 {
+            continue; // pure rotation ⇒ F is not defined by a baseline
+        }
+        let r = *rot.matrix();
+
+        let mut pts1 = Vec::new();
+        let mut pts2 = Vec::new();
+        for pw in &world {
+            let pc1 = pw.coords;
+            let pc2 = r * pw.coords + t;
+            if pc1.z <= 1e-6 || pc2.z <= 1e-6 {
+                continue;
+            }
+            let u1 = k * pc1;
+            let u2 = k * pc2;
+            pts1.push(Pt2::new(u1.x / u1.z, u1.y / u1.z));
+            pts2.push(Pt2::new(u2.x / u2.z, u2.y / u2.z));
+        }
+        assert!(pts1.len() >= 8);
+
+        let f = fundamental_8point(&pts1, &pts2).unwrap();
+        let f_norm = f.norm();
+        assert!(f_norm > 0.0);
+        let mut max_res = 0.0_f64;
+        for (a, b) in pts1.iter().zip(pts2.iter()) {
+            let x1 = nalgebra::Vector3::new(a.x, a.y, 1.0);
+            let x2 = nalgebra::Vector3::new(b.x, b.y, 1.0);
+            let res = (x2.transpose() * f * x1)[0].abs() / f_norm;
+            max_res = max_res.max(res);
+        }
+        assert!(
+            max_res < 1e-6,
+            "estimated-F epipolar residual {max_res:.3e}"
+        );
+    }
+}
+
+/// Invariant 3: triangulate → reproject round trip. For noiseless metric
+/// cameras the recovered 3D point reprojects onto the observations and matches
+/// the GT point.
+#[test]
+fn triangulate_reproject_roundtrip() {
+    let k = FxFyCxCySkew {
+        fx: 820.0,
+        fy: 800.0,
+        cx: 640.0,
+        cy: 360.0,
+        skew: 0.0,
+    }
+    .k_matrix();
+    let world = scene();
+
+    for (rot, t) in pose_grid() {
+        let r = *rot.matrix();
+        let mut p1 = Mat34::zeros();
+        p1.fixed_view_mut::<3, 3>(0, 0).copy_from(&k);
+        let mut p2 = Mat34::zeros();
+        p2.fixed_view_mut::<3, 3>(0, 0).copy_from(&(k * r));
+        p2.set_column(3, &(k * t));
+
+        for pw in &world {
+            let x1 = p1 * nalgebra::Vector4::new(pw.x, pw.y, pw.z, 1.0);
+            let x2 = p2 * nalgebra::Vector4::new(pw.x, pw.y, pw.z, 1.0);
+            if x1.z <= 1e-6 || x2.z <= 1e-6 {
+                continue;
+            }
+            let u1 = Pt2::new(x1.x / x1.z, x1.y / x1.z);
+            let u2 = Pt2::new(x2.x / x2.z, x2.y / x2.z);
+
+            let tp = triangulate_nview(&[p1, p2], &[u1, u2]).unwrap();
+            // Round-trip: reprojection error is ~0 and the 3D point matches GT.
+            assert!(
+                tp.reprojection_error < 1e-6,
+                "reprojection error {:.3e}",
+                tp.reprojection_error
+            );
+            assert!(tp.in_front);
+            assert!(
+                (tp.point - pw).norm() < 1e-6,
+                "3D round-trip error {:.3e}",
+                (tp.point - pw).norm()
+            );
+        }
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -77,9 +77,11 @@ facade module; both intrinsics examples and `rtv3d_rig` spec-seeded (bootstrap
 behind `RTV3D_SEED=generic|oracle`); `calib-bench accept` runs all registered
 datasets through the seeded route with per-entry hard gates (19 passed / 2
 UNAVAILABLE / exit 0), the cheap stereo subset gates CI, and the 0.4 px
-from-scratch diagnose check is demoted to informational. Ringgrid acceptance
-runs at the provisional ≤ 1.0 px pre-Q3 bar (cam1 knife edge 0.5008 px owned
-by Q3).
+from-scratch diagnose check is demoted to informational. **Update 2026-07-08
+(Q3):** ringgrid gates tightened to ≤ 0.7 px (per-cam means 0.42–0.50 px);
+the projective ellipse-center bias is already corrected inside the
+`ringgrid` 0.7 detector, and the remaining floor is small-marker
+localization noise (`docs/notes/ringgrid-bias.md`).
 
 ### Track Q — Algorithmic soundness: proofs + regression
 
@@ -119,7 +121,7 @@ B-EXPLORE) → B-DIST (signed installers).
 
 1. One acceptance command runs every on-disk registered dataset through the
    seeded official route with hard gates (rtv3d_ref ≤ 0.5 px all six cameras;
-   rtv3d full rig beats the oracle; ringgrid median ≤ 1.0 px post Q3).
+   rtv3d full rig beats the oracle; ringgrid ≤ 0.7 px per camera — met, Q3).
 2. Proof pack per shipped algorithm family; basin study for seeded init.
 3. API frozen: facade-only consumers, normalized configs, typed errors
    everywhere, no duplicate public type names, no deprecated shims.
@@ -287,7 +289,7 @@ puzzleboard / ringgrid) are supported.
   opt-in, behind API key configuration); init-failure diagnosis sweeps
   (perturbed re-runs).
 
-### Track V — Real-data validation: rtv3d (V1–V5, V8 DONE; V6 → Q5; V7 parked)
+### Track V — Real-data validation: rtv3d (V1–V5, V8 DONE; V6 → Q5 DONE; V7 parked)
 
 Prove the library functional on the rtv3d sensor — a private dataset from a
 6-device laser-plane-triangulation head (Scheimpflug camera + laser projector
@@ -307,9 +309,12 @@ per device), with a legacy-system oracle calibration to beat.
   bench. Local floor: 1.19 px mean reprojection, laser point-to-plane RMS
   0.018–0.035 mm over 10,797 points. Laser criterion passes; reprojection
   stays above the (now-parked) 0.4 px from-scratch target.
-- **V6 → Q5.** Settle the dataset's absolute scale (our hexagon: 90.1 mm at
-  5.2 mm cells; the oracle implies ~98.5 mm). Absorbed into the production-grade
-  program as Q5 — the metric anchor belongs in the S1 device spec.
+- **V6 → Q5 (DONE 2026-07-08).** Settled: no metric ambiguity. The apparent
+  90.1 mm (ours) vs ~98.5 mm (oracle) hexagon gap was `rtv3d_rig.rs` comparing
+  against the pre-laser hand-eye-stage extrinsics; the joint (laser-informed)
+  BA extrinsics measure 98.21 ± 0.41 mm, matching the oracle's own
+  healthy-camera hexagon (98.13 ± 1.10 mm) to 0.08 %. 5.2 mm cells confirmed
+  correct. See `docs/notes/rtv3d-scale.md`.
 - **V7 (PARKED, user call 2026-06-14).** Drive the rtv3d from-scratch
   reprojection floor below 0.4 px. Isolated to a detector/target/model floor,
   not rig-chain error (best centered means 0.747–1.199 px). Superseded as an

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -122,12 +122,27 @@ two-view/triangulation.
   saved locally for `linear_init` + `ba_iter` (`--save-baseline main`;
   machine-specific, not committed — workflow documented in
   `docs/notes/README.md`).
-- [ ] Q3-RINGGRID-BIAS - Drive the ringgrid floor (median ≈ 4.7 px) down:
-  closed-form perspective ellipse-center-vs-ring-center bias correction in the
-  detector or at residual level; diagnose the cam5 ~38 px geometric outlier
-  (S3 spec seeds may expose the cause); ringgrid math note (the bias mechanism
-  is its proof). Target: median ≤ 1.0 px; cam5 fixed or excluded with a
-  documented physical cause; regression record updated.
+- [x] Q3-RINGGRID-BIAS - Ringgrid ellipse-center bias.
+  **Done 2026-07-08 — resolved as already-corrected-at-detector-level; no
+  pipeline correction wired (it would double-correct).** The entry's framing
+  numbers were stale: post-V8 (180° pose fix + ringgrid 0.7) the per-camera
+  means are 0.42–0.50 px, not "median ≈ 4.7 px", and the "cam5 ~38 px
+  outlier" no longer exists (cam5 = 0.4867 px). Diagnosis with the current
+  calibrated model (closed-form conic-center math: `C' = H⁻ᵀCH⁻¹`, bias =
+  `center(C') − H(c)`): predicted outer-edge projective bias is ~0.09 px
+  mean / ≤ 0.45 px max — and the residual-field regression coefficient
+  against it is ≈ 0 (|coef| ≤ 0.10, mean cos ≈ 0), i.e. the bias is absent
+  from the residuals because `ringgrid` 0.7 defaults to
+  `CircleRefinementMethod::ProjectiveCenter` (two-conic pencil, Wang 2019)
+  and removes it before calibration ever sees the centers. The remaining
+  ~0.47 px floor is small-marker localization noise (bias scales with
+  marker-pixel-radius², and these markers are a few px across) — closing it
+  further is detector-side work, out of calibration scope. Landed:
+  `vision-calibration-bench::ringgrid_bias` diagnostic module (conic math +
+  3 unit tests + `#[ignore]`d E2E table generator), proof-pack note
+  `docs/notes/ringgrid-bias.md`, ringgrid accept gates tightened 1.0 →
+  0.7 px in the (gitignored, local) `registry/private.json` — 6/6 PASS at
+  the new bar, control datasets bit-identical, baselines untouched.
 - [x] Q4-MWIRE-SCHEIMPFLUG - **Done 2026-07-04.** `distortion_model:
   DistortionKind` added to `ScheimpflugIntrinsicsConfig` (serde-default
   BrownConrady5) and to rig `SensorMode::Scheimpflug` (BC5-typed for schema
@@ -161,12 +176,26 @@ two-view/triangulation.
   cams 3/4 — a *controlled* all-free sweep with a proper warm start is the
   V7-floor follow-up if wanted. Committed bench defaults stay BC5, zero
   baseline drift. App selector → B-QUAL2, Python field → R5.
-- [ ] Q5-RTV3D-SCALE - (absorbs V6-SCALE) Settle the rtv3d absolute scale
-  (hexagon 90.1 mm at 5.2 mm cells vs oracle-implied ~98.5 mm; if 98.5 mm is
-  right the true cell is ≈ 5.69 mm and both shipped board specs are wrong).
-  With S1, the natural fix is a metric anchor in the device spec (known target
-  dimension or baseline prior in the rig bundle). Math note states exactly
-  which measurement pins scale and its sensitivity. Gate in `rtv3d_rig.rs`.
+- [x] Q5-RTV3D-SCALE - **Done 2026-07-08** (absorbs V6-SCALE). Settled: no
+  real scale ambiguity, no cell-size correction needed — 5.2 mm is confirmed
+  correct. The "90.1 mm ours vs ~98.5 mm oracle" gap was a pipeline-stage
+  bookkeeping bug in `rtv3d_rig.rs`'s oracle comparison: it read the
+  hand-eye-stage extrinsics (before laser data is incorporated), which
+  under-determine absolute rig scale by a uniform ~10 % (a Scheimpflug
+  tilt↔pose valley effect, not noise — hexagon shape stays regular, ~0.4 %
+  edge spread, at both stages). Rerunning the comparison against the *joint*
+  (laser-informed) BA extrinsics — the actual calibration this project already
+  ships — gives a hexagon of 98.21 ± 0.41 mm, matching the oracle's own
+  4-good-camera hexagon (98.13 ± 1.10 mm, cam 5 excluded as the already-known
+  fx=51 degenerate) to **0.08 %**. No 4.75/5.69 mm cell size appears in any
+  dataset file; the ratio also isn't a fixed constant across pipeline
+  versions (8.6 %→10.4 %→0.08 %), ruling out a genuine cell-size mix-up.
+  Fixed `compare_to_oracle()` to source the scale table from the joint-BA
+  extrinsics (falling back to hand-eye-stage when no laser data) and added a
+  permanent hexagon neighbor-edge diagnostic table. Full derivation and
+  numbers: `docs/notes/rtv3d-scale.md`. `privatedata/rtv3d/spec.json`
+  (gitignored, local-only) got a description-field annotation pointing to
+  this note; no numeric seed field changed.
 - [x] Q6-BASIN-STUDY - Convergence-basin study for seeded Scheimpflug init:
   bench example perturbing spec seeds (focal ×[0.5..2], tilt ±, pp ±) over a
   grid; gate-pass rate per perturbation radius on rtv3d_ref + ringgrid; table
@@ -212,9 +241,27 @@ two-view/triangulation.
   `vision_geometry::{camera_matrix, epipolar, homography, triangulation}`
   against ground truth) plus the Q2 committed bench baselines already gate
   numeric drift end-to-end (YAGNI).
-- [ ] Q8-PROOF-PACKS - Remaining proof packs (batched): hand-eye, laserline
-  bundle, rig extrinsics, two-view/triangulation; rectification gets the short
-  note only (C4 gate already exists).
+- [x] Q8-PROOF-PACKS - Remaining proof packs (batched): hand-eye, laserline
+  bundle, rig extrinsics, two-view/triangulation; rectification short note.
+  **Done 2026-07-08.** Five notes landed in `docs/notes/` (hand-eye,
+  rig-extrinsics, laserline-bundle, two-view-triangulation, rectification)
+  plus four new matrix/property test files: `single_cam_handeye_matrix.rs`,
+  `rig_extrinsics_matrix.rs`, `laserline_device_matrix.rs` (facade tests) and
+  `two_view_matrix.rs`/`two_view_properties.rs` (vision-mvg) — every family
+  now has a GT-grid × noise sweep through the standard pipeline with
+  noise-floor assertions, plus gauge/degeneracy property tests
+  (base-frame gauge, reference-camera swap, disconnected co-visibility
+  rejection, S² plane sign gauge, SE(3) point-to-plane invariance).
+  Findings worth knowing: robot-pose refinement mildly breaks the hand-eye
+  base-frame gauge (left-multiplicative base-frame priors are not
+  Ad-invariant; ~5e-4 rad/m under rebasing vs 1e-14 with refinement off);
+  `fix_first_rig_pose` is redundant with the reference-camera gauge fix and
+  mildly pessimizing (0.134 vs 0.124 px on the wide matrix cell) — R2/ADR
+  0024 config candidate; the linear rig init needs a *direct*
+  reference↔camera co-visibility edge (no chaining); no laserline feature
+  gate exists in facade/pipeline (only bench's `laser` pulls the extractor);
+  wide rig baselines recover *noisier* extrinsic translation than narrow
+  ones (rotation error × longer moment arm) though they triangulate stiffer.
 
 ## R — API/config/design revision (Phase II)
 
@@ -353,11 +400,9 @@ two-view/triangulation.
   the rtv3d floor, but all six cameras still fail the raw `<0.4 px` gate
   (best centered means: 0.747–1.199 px), pointing to detector/target/model
   floor rather than rig-chain error.
-- [~] V6-SCALE - **Absorbed into Q5-RTV3D-SCALE 2026-07-02** (production-grade
-  program): settle rtv3d absolute scale (our hexagon: 90.1 mm at 5.2 mm cells;
-  oracle implies ~98.5 mm; if 98.5 mm is right the true cell is ≈5.69 mm and
-  both shipped board specs are wrong). The metric anchor belongs in the S1
-  device spec.
+- [x] V6-SCALE - Absorbed into Q5-RTV3D-SCALE 2026-07-02, **settled (no metric
+  anchor needed) 2026-07-08** — see Q5-RTV3D-SCALE's completion note and
+  `docs/notes/rtv3d-scale.md`.
 - [~] V7-RTV3D-INTRINSICS-FLOOR - **PARKED (user call 2026-06-14; disposition
   confirmed 2026-07-02).** Drive the rtv3d from-scratch reprojection floor
   below 0.4 px or prove the blocking model/data term. Isolated to a

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -50,7 +50,28 @@ gate exists), two-view/triangulation.
 
 - [Planar intrinsics](planar-intrinsics.md) — Zhang init + Brown–Conrady
   refinement (the template pack).
-- [Scheimpflug intrinsics](scheimpflug-intrinsics.md) — stub pack (full
-  pack is Q8): model summary, the ADR 0022/0023 seeded route, and the Q6
-  convergence-basin study (`calib-bench basin`) with measured basins for
-  `rtv3d_ref` / `rtv3d_ringgrid`.
+- [Scheimpflug intrinsics](scheimpflug-intrinsics.md) — stub pack: model
+  summary, the ADR 0022/0023 seeded route, and the Q6 convergence-basin
+  study (`calib-bench basin`) with measured basins for `rtv3d_ref` /
+  `rtv3d_ringgrid`.
+- [Hand-eye](hand-eye.md) — Tsai–Lenz AX=XB init + joint BA;
+  motion-diversity identifiability, base-frame gauge, the 180°
+  robot-pose-ingestion guard.
+- [Rig extrinsics](rig-extrinsics.md) — per-camera Zhang + linear rig init
+  + joint BA; reference-camera gauge, co-visibility requirements,
+  narrow-vs-wide baseline noise trade.
+- [Laserline bundle](laserline-bundle.md) — S² plane block + 1D stripe
+  residuals; stripe non-collinearity identifiability, the soft distance
+  DOF, rig-axis reuse.
+- [Two-view / triangulation](two-view-triangulation.md) — 8/7/5-point
+  solvers, pose recovery + cheirality, DLT+GN triangulation; parallax
+  degeneracy made quantitative.
+- [Rectification](rectification.md) — short pack: Scheimpflug tilt as a
+  normalized-plane homography; row-alignment evidence (C4 gate).
+- [Ringgrid bias](ringgrid-bias.md) — Q3 close-out: the projective
+  ellipse-center bias is already removed inside the `ringgrid` 0.7
+  detector; predicted bias (~0.09 px) is absent from the residual field,
+  so the ~0.47 px floor is small-marker localization noise.
+- [rtv3d scale](rtv3d-scale.md) — Q5 close-out: the oracle-vs-measured
+  scale gap was a pipeline-stage bookkeeping artifact; 5.2 mm cell
+  confirmed, joint-BA hexagon matches the oracle to 0.08 %.

--- a/docs/notes/hand-eye.md
+++ b/docs/notes/hand-eye.md
@@ -1,0 +1,168 @@
+# Hand-eye — proof pack
+
+Family: robot-mounted-camera calibration (`SingleCamHandeyeProblem`; the
+hand-eye axis of `RigHandeyeProblem`). Linear `AX = XB` initialization in
+`vision-calibration-linear::handeye` (Tsai–Lenz, all pairs); pipeline in
+`vision-calibration-pipeline::single_cam_handeye`; joint bundle adjustment in
+`vision-calibration-optim::problems::handeye` (`optimize_handeye`).
+
+## Model
+
+Each view carries a measured robot pose `T_B_G` (`base_se3_gripper`, ADR 0009)
+and a planar-target observation. The camera stage (pinhole + Brown–Conrady) is
+exactly the planar family's — see `docs/notes/planar-intrinsics.md`. Hand-eye
+adds the rigid unknown `X` and a single fixed target pose `Y`, wired two ways
+(`HandEyeMode`, `handeye_observer_se3_target`):
+
+- **EyeInHand** — camera on the gripper. `X = gripper_se3_camera` (`T_G_C`),
+  `Y = base_se3_target` (`T_B_T`); per view
+  `T_C_T_i = (T_B_G_i · X)^{-1} · Y = X^{-1} · T_G_B_i · Y`.
+- **EyeToHand** — camera fixed in the scene, target on the gripper.
+  `X = camera_se3_base` (`T_C_B`), `Y = gripper_se3_target` (`T_G_T`); per view
+  `T_C_T_i = X · T_B_G_i · Y`.
+
+`T_C_T_i` then projects the board through the shared camera. For a rig the
+observer is the rig frame, not the camera, so `RigHandeyeProblem` composes
+`cam_se3_rig` on top of the same chain (`vision-calibration-pipeline::rig_handeye`;
+its extrinsics axis is the rig-extrinsics pack's job — not re-derived here).
+
+Robot poses reach the pipeline as `Iso3`. The row-major-4×4 loader
+(`vision-calibration-pipeline::dataset_runner::poses`) re-orthonormalizes each
+rotation with an SVD polar decomposition (`nearest_rotation`) instead of
+nalgebra's identity-seeded iterative `Rotation3::from_matrix`, which silently
+mis-converges on **exact 180° rotations** (common in real robot stations) and
+returned the wrong axis. The linear solver's own matrix→quaternion conversions
+use `from_matrix_unchecked` (non-iterative) and are unaffected. Guarded by the
+regression test `matrix4x4_rotation_roundtrips_exact_180_degree`.
+
+## Initialization (Tsai–Lenz, all pairs)
+
+For every view pair `(i, j)` the pipeline forms two relative motions: the
+gripper motion `A = T_B_G_i^{-1} · T_B_G_j` and the observation motion
+`B = S_i^{-1} · S_j`, where the stream `S` is `target_se3_camera` (EyeInHand)
+or `camera_se3_target` (EyeToHand) — both routes call `tsai_lenz_allpairs`
+(`estimate_handeye_dlt` / `estimate_gripper_se3_target_dlt`). Each pair is a
+constraint `A · X = X · B`, split into
+
+```
+R_A R_X = R_X R_B                 (rotation)
+(R_A − I) t_X = R_X t_B − t_A     (translation)
+```
+
+Rotation is solved in quaternions: each pair contributes
+`[L(q_A) − R(q_B)] q_X = 0` (left/right multiplication matrices); stacking all
+pairs gives a `4N×4` system whose smallest right-singular vector is `q_X`,
+extracted via the `AᵀA` symmetric-eigen null space (`math::null_space`) rather
+than nalgebra's dense SVD, which can hang on tall real matrices. Translation
+stacks the `(R_A − I)` blocks against `R_X t_B − t_A` (`3N×3`) and solves ridge
+normal equations (`math::ridge_lstsq`, `λ = 1e-12`). `R_X` is projected back to
+SO(3) (`math::project_to_so3`).
+
+Pair conditioning is guarded before the solve (`build_all_pairs` /
+`is_good_pair`): pairs whose smaller rotation angle is below
+`min_motion_angle_deg` (default **5°**) are dropped, and — when
+`reject_axis_parallel` is on (the pipeline default) — pairs whose rotation axes
+are near-parallel (`|α̂ × β̂| < 1e-3`) are dropped as ill-conditioned.
+
+## Cost
+
+`optimize_handeye` (`build_handeye_ir`) minimizes total robust reprojection
+
+```
+E = Σ_i Σ_j ρ( ‖ π( camera, T_C_T_i(X, Y, T_B_G_i) · X_j ) − u_ij ‖² )
+```
+
+over: per-camera intrinsics + distortion (`k3` fixed by default), the hand-eye
+`X` and the fixed target `Y` (both SE(3)), and `cam_se3_rig` (fixed for
+single-camera via `fix_extrinsics`). Optionally (default **on** for
+single-cam) each robot pose gets a per-view se(3) correction
+`T_B_G_i ↦ exp(δ_i) · T_B_G_i` (left-multiply) with a zero-mean anisotropic
+prior (rotation σ = 0.5°, translation σ = 1 mm) and `δ_0 ≡ 0`. Factors are
+autodiff-generic (ADR 0008); `ρ` defaults to none (Huber for detector tails).
+
+## Identifiability and degeneracies
+
+- **Minimum motion.** `R_A R_X = R_X R_B` from one motion only forces `R_X` to
+  carry `axis(B)` onto `axis(A)` — a one-parameter family (free spin about that
+  axis) remains. Two motions with **non-parallel** rotation axes pin `R_X`
+  fully. The pipeline requires ≥ 3 views (≥ 2 independent motions).
+- **Translation along the rotation axis is unobservable per motion.**
+  `(R_A − I)` is rank-deficient: for a rotation of angle θ about axis `n`, its
+  null space is `span(n)`. So one motion never sees the component of `t_X` along
+  its own rotation axis; only stacking ≥ 2 non-parallel-axis motions makes the
+  `(R_A − I)` stack full-rank-3 and `t_X` observable.
+- **Pure translations.** With no rotation, `q_A = q_B = 1 ⇒ L − R = 0` and
+  `R_A − I = 0`: the pair carries *zero* hand-eye information. Rejected by the
+  min-angle gate.
+- **Parallel axes / common screw axis.** If all motions share a rotation axis
+  `n`, the `(R_A − I)` stack stays rank-2 (`t_X` along `n` unobservable) and
+  `R_X` is fixed only up to a spin about `n`. This is exactly the near-parallel
+  case the `axis_parallel_eps` guard removes — and why the matrix test's robot
+  stations mix roll, pitch, and yaw.
+- **Small rotations.** `(R_A − I) ≈ [θ n]_×` is ill-conditioned as `θ → 0`,
+  amplifying translation-noise into `t_X`; the 5° gate trades usable pairs for
+  conditioning.
+- **Intrinsics coupling.** Hand-eye is estimated *after* intrinsics, so a
+  focal-length bias skews every per-view `T_C_T_i` and hence the hand-eye
+  translation *scale*; the joint BA re-refines intrinsics to absorb this.
+
+## Gauge
+
+With raw robot poses (refinement off) the joint reprojection cost has a
+**base-frame gauge**: rebasing `T_B_G_i ↦ G · T_B_G_i` and `Y ↦ G · Y` leaves
+every `T_C_T_i` unchanged (`(G T_B_G X)^{-1}(G Y) = X^{-1} T_B_G^{-1} Y`), so
+`X` is invariant and only `Y` absorbs `G`. Otherwise there is no free gauge: the
+board fixes the target frame metrically, the robot poses are measurements, and
+`K` fixes the camera frame, so `X` and `Y` are fully determined once the motion
+requirements above are met.
+
+Robot-pose refinement adds the per-view correction field `{δ_i}`. Its
+**common mode is a gauge**: a constant correction is re-absorbable into a fixed
+transform — the target `Y` in EyeInHand (`exp(-δ)` sits adjacent to `Y`), the
+hand-eye `X` in EyeToHand. `build_handeye_ir` fixes `δ_0 ≡ 0` to remove it, and
+the zero-mean priors regularize the remaining near-null directions. Note the
+priors, written in the base frame via a *left*-multiplicative correction, are
+not `Ad_G`-invariant, so enabling refinement mildly breaks the base-frame gauge
+above (measured: rebasing shifts `X` by ~5e-4 rad / 5e-4 m with refinement on,
+vs ~1e-14 with it off — the gauge test runs with refinement off to assert the
+exact invariant).
+
+## Noise sensitivity
+
+For iid pixel noise with per-axis amplitude `a` (uniform `[−a, a]`, expected
+error-norm mean ≈ `0.765·a`) the post-fit mean reprojection approaches that
+floor, and hand-eye errors scale ≈ linearly in `a` through `(JᵀJ)⁻¹`.
+Translation is the most sensitive DOF (it is the ratio of pose residuals to the
+rank-deficient `(R_A − I)` blocks). Empirically (matrix test below):
+
+| noise `a` | mean reproj | hand-eye Δrot | hand-eye Δt |
+|---|---:|---:|---:|
+| 0.00 px | ~0 (< 1e-4) | ~1e-14 rad | ~1e-13 m |
+| 0.15 px | 0.112 px | ≤ 7e-4 rad | ≤ 0.5 mm |
+| 0.30 px | 0.224 px | ≤ 1.4e-3 rad | ≤ 0.9 mm |
+
+(EyeInHand, 9 robot stations, 63-point board, `fx ∈ {800, 1200}`.) The reproj
+column tracks `0.765·a` (0.115, 0.230). EyeToHand shows the translation
+sensitivity of a *distant, derived* pose: at `a = 0.20 px` the direct DLT output
+`gripper_se3_target` recovers to ~0.1 mm, while `camera_se3_base` (target ~1.2 m
+away) drifts to ~8 mm.
+
+## Evidence
+
+- **Matrix test**:
+  `crates/vision-calibration/tests/single_cam_handeye_matrix.rs` —
+  `single_cam_handeye_recovers_gt_across_grid_and_noise` (GT grid: 2 focal
+  regimes × 2 hand-eye transforms, noise `{0, 0.15, 0.30}` px, standard
+  `step_intrinsics_init → step_intrinsics_optimize → step_handeye_init →
+  step_handeye_optimize` pipeline); `single_cam_handeye_eye_to_hand_recovers_gt`
+  (the EyeToHand convention); `single_cam_handeye_base_frame_gauge_invariance`
+  (the base-frame gauge, refinement off).
+- **Robot-pose ingestion**: `nearest_rotation` (SVD polar decomposition) and
+  `matrix4x4_rotation_roundtrips_exact_180_degree` in
+  `vision-calibration-pipeline::dataset_runner::poses`.
+- **Linear init unit test**: `handeye_dlt_recovers_ground_truth`
+  (`vision-calibration-linear::handeye`).
+- **Related**: `docs/notes/planar-intrinsics.md` (shared camera / projection
+  equations and pixel-noise-floor argument); `RigHandeyeProblem` for the rig
+  axis (same Tsai–Lenz DLT with the rig as observer); ADR 0008 (autodiff IR),
+  ADR 0009 (`frame_se3_frame` conventions).

--- a/docs/notes/laserline-bundle.md
+++ b/docs/notes/laserline-bundle.md
@@ -1,0 +1,211 @@
+# Laserline bundle — proof pack
+
+Family: single-camera + laser-plane device from planar-target views plus
+laser-stripe pixels (`LaserlineDeviceProblem`; init in
+`vision-calibration-linear::laserline` + the shared Zhang path, refinement in
+`vision-calibration-optim::problems::laserline_bundle`). The same laser cost
+is reused, with a composed pose, by the rig laser axes
+(`RigLaserlineDeviceProblem`, `RigHandeyeLaserlineProblem`) — cited in
+§Rig axes, not re-derived here (their rig/hand-eye parts have their own packs).
+
+## Model
+
+Same composable camera as the planar/Scheimpflug families (ADR 0005),
+`pixel = K( sensor( distort( project(X_c) ) ) )`, `X_c = T_C_T · X_t`
+(pinhole projection, Brown–Conrady 5 distortion, an optional Scheimpflug
+`HomographySensor`, `FxFyCxCySkew`) — see `docs/notes/planar-intrinsics.md`
+for the projection/distortion equations and
+`docs/notes/scheimpflug-intrinsics.md` for the sensor stage. The sensor is a
+hardware property, fixed by default (`fix_sensor: true`); it is taken from
+`config.init.sensor_init`, never from a manual-init seed (ADR 0011).
+
+The new object is the **laser plane**, stored in the camera frame as
+`LaserPlane { normal: Unit<Vector3>, distance }` with plane equation
+
+```
+n̂ · p + d = 0      (p in camera coordinates)
+```
+
+(`vision-calibration-optim::params::laser_plane`). In optimization it is two
+param blocks: `plane_normal` on the **S²** manifold (dim 3) and
+`plane_distance` a Euclidean scalar (dim 1) — so the unit-norm constraint is
+carried by the manifold rather than penalized.
+
+Laser observations enter as per-view **stripe pixels**: `LaserlineMeta`
+carries `laser_pixels` (optionally per-pixel `laser_weights`) alongside the
+target correspondences. On real data those pixels come from a subpixel line
+extractor injected through the open `LaserPixelExtractor` trait (ADR 0021) —
+the published crates ship no extractor, only the geometry that consumes its
+output.
+
+## Initialization
+
+Two stages, both closed-form:
+
+1. **Intrinsics / distortion / poses** — the shared Zhang path
+   (`estimate_intrinsics_iterative`: Hartley-normalized DLT homographies →
+   image of the absolute conic → `K`, per-view PnP poses, iterative
+   `(k1, k2[, p1, p2])` fit), identical to the planar family.
+2. **Laser plane** — `linear::laserline::LaserlinePlaneSolver::from_views`:
+   each laser pixel is undistorted and back-projected to a camera-frame ray,
+   intersected with the target plane (`z = 0` in the *known* per-view pose) to
+   a 3D point, then a plane is fit to the pooled points by covariance
+   eigendecomposition (smallest eigenvector = `n̂`, `d = −n̂ · centroid`). The
+   fit rejects rank-1 (collinear) point clouds and records an RMSE
+   (`initial_plane_rmse`). It requires **≥ 2** views because one stripe alone
+   is collinear (see §Identifiability).
+
+`step_init_with_seed` (ADR 0011) lets any of intrinsics / distortion / poses /
+plane be supplied instead of estimated.
+
+## Cost
+
+Joint bundle adjustment (`optimize_laserline`, IR per ADR 0008) over
+intrinsics, distortion (`k3` fixed by default), the sensor (if freed), all
+per-view poses (SE(3), `fix_poses: [0]` by default), and the laser plane
+(S² normal + scalar distance). Two residual families sum into one problem:
+
+```
+E = Σ_i Σ_j ρ_c‖ π(K,d,sensor,T_i·X_j) − u_ij ‖²   (target corners, 2D)
+  + Σ_i Σ_k ρ_l · r(K,d,sensor,T_i, n̂,d ; q_ik)²    (laser stripe, 1D)
+```
+
+`ρ_c` / `ρ_l` are the configured robust losses (defaults Huber 1.0 px and
+Huber 0.01, per-family weights). The laser residual `r` has two forms
+(`LaserlineResidualType`, `factors::laserline`):
+
+- **`LineDistNormalized`** (default): intersect the laser and target planes
+  into a 3D line, project it to the `z = 1` normalized plane, undistort the
+  pixel, take the perpendicular 2D point-to-line distance, and scale by
+  `√(fx·fy)`. Units: **pixels** — directly comparable to the reprojection
+  floor, which is why it is the default.
+- **`PointToPlane`**: undistort → ray → intersect target plane → 3D point →
+  signed distance `n̂·p + d` to the laser plane. Units: **metres**.
+
+The plane appears **only** in the laser residuals; corners never touch it. So
+the plane is fit from the stripes *conditioned on the poses*, and the poses
+are pinned overwhelmingly by the corners — the two halves are nearly
+block-separable. Factors are autodiff-generic (ADR 0008); the S² retraction
+supplies the normal Jacobian.
+
+### Rig axes
+
+`RigLaserlineDeviceProblem` and `RigHandeyeLaserlineProblem` reuse the *same*
+laser cores through `LaserChain::RigHandEye{,RobotDelta}`
+(`optim::ir::types::LaserChain`), which composes `cam_se3_target` from
+`(cam_se3_rig, hand-eye, target_ref, robot pose[, robot Δ])` instead of taking
+a single free pose. A unit test pins the rig residual equal to the single-pose
+residual evaluated at the explicitly composed pose, in both hand-eye modes and
+both residual types (`factors::laserline` tests). Refinement/residual entry
+points: `optim::problems::{laserline_rig_bundle, rig_handeye_laserline_bundle}`,
+pipeline `rig_laserline_device` / `rig_handeye_laserline`. The rig extrinsics
+and hand-eye gauges are covered by their own packs; the laser plane adds none
+beyond the S² sign gauge below.
+
+## Identifiability and degeneracies
+
+The plane is seen only through its stripes, each of which is the plane ∩ board
+line — **collinear** points. One board pose therefore constrains only one
+in-plane direction; the plane is rank-deficient along the stripe. Recovery
+needs the per-view stripes to **span the plane's 2D**:
+
+- **Stripe non-collinearity (the core requirement).** ≥ 2 board poses whose
+  stripes differ in direction and/or offset. Board **orientation** diversity
+  (roll about the optical axis rotates the stripe *within* the board; pitch/yaw
+  reposition it) is the cheap, robust source — it perturbs the stripe without
+  driving it off the board. The linear solver rejects a rank-1 pooled cloud
+  outright.
+- **Distance is the soft DOF.** `n̂` is well pinned by stripe geometry, but the
+  stand-off `d` is constrained by how much the metric stripe positions move
+  across **depth-diverse** poses. Shallow plane tilt or board depths clustered
+  at one distance leaves `d` weakly observable (high variance, not a wrong
+  minimum) — the matrix test mixes tilt with a small depth ramp for this
+  reason.
+- **Degenerate geometries.**
+  - *Stripes all parallel* (e.g. board rotated only about an axis parallel to
+    the intersection line, or pure depth translation with no tilt diversity):
+    stripes stay collinear/parallel → the in-plane direction orthogonal to
+    them is unobservable.
+  - *Laser plane through the camera centre* (`d → 0`): the plane projects to a
+    single fixed image line for every pose, so the stripe carries **no** depth
+    information of its own; calibration can still succeed off the known poses,
+    but the *deployed* triangulation is ill-posed and `d` is maximally
+    ill-conditioned. Small `|d|` is the same pathology, softened.
+  - *Laser plane parallel to a board pose*: the intersection line goes to
+    infinity — no stripe in that view (guarded: the line-direction cross
+    product vanishes → large residual / empty stripe).
+  - *Ray parallel to / behind the target plane*: guarded with a large residual
+    so a stray pixel cannot pull the solve.
+- **View count.** The pipeline requires ≥ 3 views, each with ≥ 4 corner points
+  (homography) and ≥ 1 laser pixel; the plane needs ≥ 2 non-collinear stripes.
+
+The intrinsics inherit the planar family's degeneracies (fronto-parallel
+focal↔distance trade-off, weak principal point under weak distortion, `k3`
+collinearity → `fix_k3: true`) — see `docs/notes/planar-intrinsics.md`.
+
+## Gauge
+
+- **No global gauge.** The plane lives in the physical camera frame, which is
+  the fixed reference; the board fixes each view's target frame; `K`, `d`,
+  sensor are shared; every `T_i` is an independent free block. `fix_poses: [0]`
+  in the default config is a stability/speed convention, **not** a gauge
+  necessity — noise-free data recovers exactly with pose 0 held (matrix test),
+  because the noise-free init is already exact. (Contrast rig extrinsics, where
+  a reference camera genuinely pins the rig frame.)
+- **S² sign gauge.** `(n̂, d)` and `(−n̂, −d)` name the same plane (the S²
+  double cover). The signed distance only flips sign; its magnitude — what the
+  residual squares — is invariant, so the solve is free to land on either
+  sheet. Downstream comparisons sign-align to a reference (the matrix test
+  aligns the recovered normal to GT before measuring the angle/distance).
+
+## Noise sensitivity
+
+For iid pixel noise with per-axis amplitude `a` (uniform `[−a, a]`) and
+`N ≫ #params`, the target reprojection approaches the planar floor
+(`≈ 0.765·a` mean error-norm) and the laser line-distance residual settles at
+`≈ 0.5·a` px. `n̂` is recovered to a small fraction of a degree; the stand-off
+`d` — the soft DOF — degrades fastest as tilt / depth-spread shrink. Measured
+(matrix test, 6 views, `fx = fy = 900`, working distance 0.50–0.62 m):
+
+| noise `a` | normal | distance | laser resid | reproj |
+|---:|---:|---:|---:|---:|
+| 0.00 px | 0.000° | 0.000 mm | 0.000 px | 0.000 px |
+| 0.15 px | ≤ 0.045° | ≤ 0.51 mm | ≈ 0.073 px | ≈ 0.113 px |
+| 0.30 px | ≤ 0.084° | ≤ 1.10 mm | ≈ 0.159 px | ≈ 0.226 px |
+
+Exact data reproduces GT to solver tolerance. The reprojection column tracks
+`0.765·a` (0.115 / 0.230), confirming the corners hit their noise floor and
+the plane is the only extra unknown.
+
+**Real-data anchor.** On the private `rtv3d`/`rtv3d_ref` Scheimpflug laser
+datasets, the point-to-plane laser residual measures **0.018–0.035 mm** at the
+working distance — the plane-consistency achieved on real hardware (a
+fit-quality metric, not GT recovery), consistent with the sub-millimetre
+synthetic distance bounds above.
+
+## Evidence
+
+- **Matrix test**: `crates/vision-calibration/tests/laserline_device_matrix.rs`
+  — GT grid (2 plane orientations × 2 working distances) × noise
+  `{0, 0.15, 0.30}` px, standard `run_calibration` (`step_init →
+  step_optimize`) pipeline; asserts normal (deg), distance (mm), and the
+  laser/reprojection floors per cell. Deterministic noise
+  (`UniformPixelNoise`, seed 7); runtime ~2.3 s.
+- **Property tests** (same file): `point_to_plane_residual_is_se3_invariant`
+  (`n̂·p + d` is unchanged by any SE(3) re-framing of point + plane — the
+  invariance the point-to-plane residual rests on) and
+  `plane_sign_flip_is_a_gauge` (the S² double-cover). 5000 deterministic cases
+  each.
+- **Pipeline / optim tests**:
+  `vision-calibration-pipeline/tests/laserline_device.rs` (pinhole +
+  Scheimpflug convergence, JSON roundtrip);
+  `optim::problems::laserline_bundle` unit tests (S² manifold for the normal,
+  per-feature residuals zero on perfect data, pose-count guards);
+  `optim::factors::laserline` (rig-chain residual = single-pose composition).
+- **Acceptance gates**: `calib-bench accept` on the `rtv3d` laser entries
+  (laser residual gated at the mm scale above); Q2 committed Fit records add
+  drift gates.
+- **Related**: ADR 0021 (laser-frame manifest, injected `LaserPixelExtractor`,
+  per-view laser images), ADR 0012 (per-feature laser residuals on export),
+  `docs/notes/planar-intrinsics.md` (shared projection/distortion + Zhang
+  init), `docs/notes/scheimpflug-intrinsics.md` (shared sensor stage).

--- a/docs/notes/rectification.md
+++ b/docs/notes/rectification.md
@@ -1,0 +1,63 @@
+# Stereo rectification — short note
+
+Family: Scheimpflug-aware stereo rectification
+(`vision-mvg::rectification::rectify_stereo_pair(left, right, cam1_se3_cam0,
+opts) -> StereoRectification`), re-exported as `vision_calibration::mvg::rectification`.
+This is deliberately a *short* pack: the C4 gate (below) already pins the
+family end-to-end, and the module doc carries the full derivation.
+
+## Model
+
+For a calibrated pair, find homographies `H_left`, `H_right` such that
+corresponding points land on the same image row — the precondition for 1-D
+disparity search. Because a pixel in this project's camera model (ADR 0005)
+is `K · H_tilt · x_n`, the Scheimpflug sensor tilt is just a projective
+factor on the normalized plane: pre-multiplying each camera's unprojection
+by `H_tilt⁻¹` collapses it to an equivalent frontal pinhole, after which the
+textbook Fusiello/Bouguet construction applies:
+
+```
+H_left  = K_rect · R_rect        · H_tilt0⁻¹ · K0⁻¹
+H_right = K_rect · (R_rect · Rᵀ) · H_tilt1⁻¹ · K1⁻¹
+```
+
+with `R = R_C1_C0` and `R_rect` the common orientation whose x-axis is the
+baseline. Zero tilt reduces exactly to pinhole rectification. Inputs are
+**undistorted** pixels — distortion is removed separately, mirroring
+OpenCV's `initUndistortRectifyMap` split.
+
+## Degeneracies and guards
+
+- **Zero baseline** (`‖t‖ < 1e-12`): no epipolar geometry to rectify —
+  rejected.
+- **Degenerate tilt homography** (tilt beyond ~80°, `MAX_TILT_RAD = 1.4`):
+  `H_tilt` loses invertibility long before this; physical Scheimpflug tilts
+  are a few degrees — rejected.
+- **Baseline nearly parallel to the optical axes** (forward motion): the
+  standard construction's `R_rect` degrades as the baseline leaves the
+  image plane; row alignment still holds but the rectified FOV distorts.
+  Not guarded — a property of the Fusiello construction itself.
+
+## Gauge
+
+Camera 0 is the reference: its frame is the rectification's world frame,
+and `K_rect` (from `RectifyOptions`) fixes the free intrinsic scale of the
+rectified pair. The row-alignment property is invariant to the choice of
+`K_rect`.
+
+## Evidence
+
+- **Row-alignment invariant**: 6 synthetic tests through the real core
+  Scheimpflug model (`crates/vision-mvg/src/rectification.rs` tests) —
+  rectified rows of corresponding points agree to `< 1e-6 px`; the zero-tilt
+  path reproduces pinhole rectification exactly.
+- **C4 / D4 gate (real data)**: the `rtv3d_ref_rectify` example
+  (examples-private) rectifies all oracle camera pairs of the `rtv3d_ref`
+  Scheimpflug rig (real `K`, asymmetric per-camera ~−5° tilts, rig
+  extrinsics) — worst rectified row disagreement **3.4e-13 px**.
+- **Downstream consumer**: the dense block matcher (`vision-mvg::dense`,
+  C5) and the app's Depth workspace run on these rectified pairs; the C5
+  bench (`data/stereo`) is an implicit integration gate.
+- **Related**: ADR 0005 (camera model; `H_tilt` as sensor stage),
+  `docs/notes/two-view-triangulation.md` (the epipolar geometry being
+  rectified), backlog C4-RECTIFY completion note (PR #74).

--- a/docs/notes/rig-extrinsics.md
+++ b/docs/notes/rig-extrinsics.md
@@ -1,0 +1,210 @@
+# Rig extrinsics — proof pack
+
+Family: multi-camera rig extrinsics from shared planar-target views
+(`RigExtrinsicsProblem`; per-camera intrinsics init in
+`vision-calibration-linear`, linear rig init in
+`vision-calibration-linear::extrinsics`, joint refinement in
+`vision-calibration-optim::problems::rig_extrinsics` /
+`rig_extrinsics_scheimpflug`). The pipeline lives in
+`vision-calibration-pipeline/src/rig_extrinsics/` and its shared
+sensor-axis helpers in `crate::rig_family` (ADR 0013).
+
+## Model
+
+A rigidly-coupled set of `C` cameras observes a planar target from `V`
+stations. Each camera keeps its own composable camera (ADR 0005); the
+extrinsics tie them to one **rig frame** `R`. Per observation `(cam i,
+view v, board point X_t)`:
+
+```
+pixel = K_i( sensor_i( distort_i( project( T_Ci_R · T_R_Tv · X_t ) ) ) )
+```
+
+- `T_Ci_R` (`cam_se3_rig`, ADR 0009): the camera-from-rig extrinsic,
+  constant across views — the unknowns of interest.
+- `T_R_Tv` (`rig_se3_target`): the rig-from-target pose of station `v`,
+  one SE(3) per view.
+- `project` / `distort` / `K`: pinhole + Brown–Conrady 5 + `FxFyCxCySkew`,
+  exactly the planar family's sub-models (see
+  `docs/notes/planar-intrinsics.md`).
+- `sensor_i`: `IdentitySensor` for `SensorMode::Pinhole`; the OpenCV-style
+  `HomographySensor(tilt_x, tilt_y)` for `SensorMode::Scheimpflug` (ADR
+  0013), one `ScheimpflugParams` per camera. Everything below is identical
+  across the two flavours except the sensor stage and its
+  `ScheimpflugFixMask`.
+
+The composite per-observation chain is a product of two SE(3)s
+(`ReprojChain::TwoSe3` in the optim IR): the shared extrinsic and the
+per-view rig pose. `RigHandeye` extends this exact model by replacing the
+free per-view `T_R_Tv` with a robot-kinematics-constrained chain
+(`T_R_Tv = handeye · T_base_gripper,v · target`); the extra hand-eye axis
+is covered separately in `docs/notes/hand-eye.md`.
+
+## Initialization
+
+Two stages, both closed-form (`rig_extrinsics/steps.rs`,
+`step_intrinsics_init_all` → `step_rig_init`):
+
+1. **Per-camera intrinsics.** Each camera is calibrated in isolation by
+   Zhang's method with iterative distortion (`rig_family::bootstrap_rig_intrinsics`
+   → `vision-calibration-linear`), yielding `K_i, d_i` and a per-view
+   `T_Ci_Tv` (`camera_se3_target`) from each camera's own DLT homographies.
+   Scheimpflug cameras use the tilt-aware linear init
+   (`scheimpflug_init`). A per-camera reprojection guard
+   (`guard_percam_reproj_errors`, 50 px ceiling) fails fast on a diverged
+   camera before its garbage poses can poison the rig fit.
+2. **Rig extrinsics.** `estimate_extrinsics_from_cam_target_poses`
+   (`vision-calibration-linear::extrinsics`) turns the per-camera poses
+   into rig transforms. With the rig frame pinned to the reference camera
+   `r` (`cam_to_rig[r] = I`), for every view where camera `i` and `r` both
+   see the target,
+   `T_R_Ci = T_Cr_Tv · (T_Ci_Tv)⁻¹`, and these per-view estimates are
+   averaged over co-observed views (arithmetic mean of translations,
+   hemisphere-corrected quaternion mean of rotations — an
+   initialization-grade SE(3) average). Each view's rig pose then follows
+   as `T_R_Tv = T_R_Ci · T_Ci_Tv`, averaged over the cameras that saw it.
+
+## Cost
+
+Non-linear refinement (`optimize_rig_extrinsics`) minimizes the total
+squared reprojection error over the whole rig:
+
+```
+E = Σ_i Σ_v Σ_j ρ( ‖ π_i( T_Ci_R · T_R_Tv · X_j ) − u_ivj ‖² )
+```
+
+Parameter blocks (optim IR, `build_rig_extrinsics_ir`): per-camera
+intrinsics `K_i`, per-camera distortion `d_i`, per-camera extrinsic
+`T_Ci_R` (SE(3) manifold), per-view rig pose `T_R_Tv` (SE(3) manifold),
+and — for Scheimpflug rigs — per-camera `ScheimpflugParams`. Intrinsics
+and distortion are **fixed by default** (`refine_intrinsics_in_rig_ba:
+false`, `CameraFixMask::all_fixed`), so the joint solve moves only the
+geometry; enabling refinement re-opens `K_i, d_i` under the usual
+`fix_k3`/`fix_tangential` masks. `ρ` is the configured robust loss
+(default none; Huber for detector tails). Factors are autodiff-generic
+(ADR 0008).
+
+## Identifiability and degeneracies
+
+- **Minimum data** (`validate_input`): `≥ 2` cameras and `≥ 3` views; each
+  camera needs `≥ 3` views with observations for its own Zhang init
+  (`views_to_planar_dataset`).
+- **Co-visibility / connectivity.** The relative pose `T_Ci_Cr` is only
+  observable from views where camera `i` and the reference `r` *both* see
+  the target. The linear init computes each non-reference extrinsic purely
+  from such shared views; if a camera never co-observes with the reference,
+  `estimate_extrinsics_from_cam_target_poses` returns
+  `"no overlapping views between camera i and reference r"`. In graph
+  terms the cameras must form a connected co-visibility graph *with the
+  reference in the same component* — the current linear init is stricter
+  still, requiring a **direct** reference↔camera edge (it does not chain
+  `i–k–r`). A disconnected graph is a hard failure, not a silent bad fit
+  (matrix test, `rig_extrinsics_rejects_disconnected_covisibility_graph`).
+- **Single shared view.** One co-observed view suffices for a rank-full
+  relative pose, but there is then no averaging: all pixel + pose noise
+  from that one station flows straight into the extrinsic. Extrinsic
+  variance drops roughly as `1/√(shared views)`; a healthy rig wants the
+  target co-visible across many diverse stations.
+- **All boards parallel.** If every station shares one plane normal, each
+  camera's own Zhang init is rank-deficient (the planar family's
+  plane-orientation degeneracy — see `docs/notes/planar-intrinsics.md`),
+  so the intrinsics feeding the rig fit are ill-posed. Independently,
+  pose diversity is what lets the SE(3) average of `T_R_Ci` resolve the
+  rotation cleanly; a pure-translation station set leaves the relative
+  rotation weakly constrained. The matrix test's stations mix pitch and
+  yaw for exactly this reason.
+- **Weak baseline.** A short inter-camera baseline weakly constrains the
+  translation DOF of `T_Ci_Cr` (see §noise sensitivity); the minimum is in
+  the right place, but its variance inflates.
+- **Per-camera intrinsics coupling.** With intrinsics fixed in the rig BA
+  (default), any residual focal/distortion error from stage 1 is absorbed
+  into the extrinsics and rig poses rather than corrected — a reason the
+  per-camera guard and a good stage-1 fit matter.
+
+## Gauge
+
+- **Rig-frame gauge (6 DOF).** The whole parameter set has one global
+  freedom: left-multiplying every `T_Ci_R` and every `T_R_Tv` by a common
+  `H` leaves all observations unchanged (the map
+  `(extrinsics, rig poses) ↦ {T_Ci_Tv}` has `H` in its kernel). The code
+  removes it by pinning the **reference camera** to identity and holding
+  that block fixed in BA: `cam_to_rig[reference_camera_idx] = I` in the
+  linear init, and `fix_extrinsics[r] = true` in
+  `RigExtrinsicsSolveOptions` (`rig_extrinsics/steps.rs`). The rig frame
+  therefore *is* the reference camera frame. Shifting the reference to a
+  different camera re-expresses every extrinsic (left-multiply by the old
+  reference-to-new-reference pose) but preserves the observable relative
+  inter-camera poses and the reprojection error — verified by
+  `rig_extrinsics_reference_camera_gauge_invariance` (relative pose agrees
+  to `< 5e-4` rad / `< 5e-4` m, reprojection error to `< 5e-3` px across a
+  reference-camera swap).
+- **First rig pose.** `fix_first_rig_pose` (default `true`) additionally
+  fixes view 0's `T_R_T0`. Because the reference-camera fix already removes
+  the full 6-DOF gauge, this is *not* required for gauge — it is an extra
+  constraint that locks station 0's target pose to its linear-init value
+  instead of jointly refining it. Empirically it is benign-to-mildly-
+  pessimizing: disabling it on the wide-baseline matrix cell leaves the
+  recovered relative pose unchanged and slightly *lowers* the mean
+  reprojection error (0.124 vs 0.134 px), consistent with a redundant
+  constraint rather than a gauge necessity. On exact data it is harmless
+  (the fixed value equals the ground-truth pose).
+
+## Noise sensitivity
+
+For iid pixel noise with per-axis amplitude `a` and `N ≫ #params`
+residuals, the post-fit mean reprojection approaches the noise floor
+(uniform `[−a, a]` per axis ⇒ expected error-norm mean `≈ 0.765·a`) and the
+extrinsic-parameter errors scale linearly in `a` through `(JᵀJ)⁻¹`. The
+inter-camera **translation** is the most sensitive DOF, and its sensitivity
+depends on rig geometry. Empirically (matrix test, two-camera rig, 8
+diverse stations at 0.6–0.8 m, per-camera independent noise streams):
+
+| geometry | metric | `a = 0` | `a = 0.15 px` | `a = 0.30 px` |
+|---|---|---:|---:|---:|
+| narrow (6 cm, ~parallel) | Δrot (rad) | 2e-14 | 2.7e-3 | 5.3e-3 |
+| narrow | Δtrans (m) | 1e-13 | 4.1e-3 | 8.2e-3 |
+| narrow | mean reproj (px) | 8e-13 | 0.116 | 0.232 |
+| wide (25 cm, ~8° converged) | Δrot (rad) | 3e-14 | 3.2e-3 | 6.4e-3 |
+| wide | Δtrans (m) | 2e-13 | 1.1e-2 | 2.2e-2 |
+| wide | mean reproj (px) | 1e-12 | 0.144 | 0.286 |
+
+Both rows scale cleanly with `a`. Two observations worth calling out:
+
+- **Rotation tracks noise almost geometry-independently** (≈ 2e-2 rad/px),
+  but **translation is worse on the wide, strongly-converged pair** (≈ 7e-2
+  m/px vs ≈ 2.7e-2 m/px narrow): the larger convergence angle couples the
+  ~6e-3 rad rotation error into a longer translation moment arm, so ~2 cm
+  of translation error at 0.3 px on the 25 cm baseline is ~3× the narrow
+  pair. The relative merit of narrow vs wide is thus a trade — wide gives
+  stiffer triangulation for downstream stereo but a noisier extrinsic
+  translation from this planar-target fit.
+- The rig's **shared** extrinsic is a stiffer constraint than the planar
+  family's independent per-view poses, so the wide-pair post-fit mean
+  (0.286 px at 0.3 px) sits slightly *above* the `0.765·a ≈ 0.23 px` floor —
+  the model cannot absorb per-camera noise into per-view freedom.
+- Exact data reproduces ground truth to solver tolerance (`< 1e-12` px,
+  `< 1e-13` m).
+
+## Evidence
+
+- **Matrix test**:
+  `crates/vision-calibration/tests/rig_extrinsics_matrix.rs` — GT grid
+  (narrow/wide 2-camera baseline) × noise `{0, 0.15, 0.30} px` through the
+  standard `step_intrinsics_init_all → step_intrinsics_optimize_all →
+  step_rig_init → step_rig_optimize` pipeline; asserts inter-camera
+  rotation/translation recovery and the reprojection floor per cell, plus
+  the reference-camera gauge-invariance and disconnected-graph degeneracy
+  property tests above. Runtime ~2 s.
+- **Pipeline unit tests**:
+  `rig_extrinsics/steps.rs::rig_optimize_keeps_reprojection_error_reasonable`
+  (exact-data rig converges to `< 1e-3` px and the state/export stats
+  agree), `extrinsics.rs` linear-init recovery (`< 1e-10` on exact poses,
+  including a missing-reference-view case).
+- **Acceptance gates**: `calib-bench accept` — the `stereo_left`/
+  `stereo_right` planar entries gate the per-camera intrinsics that feed
+  the rig; Q2 committed Fit records add drift gates.
+- **Related**: ADR 0013 (`rig_family` sensor-axis refactor; pinhole ↔
+  Scheimpflug unification), ADR 0009 (`frame_se3_frame` / SE(3) storage),
+  `docs/notes/planar-intrinsics.md` (the per-camera projection/distortion
+  sub-models), `docs/notes/hand-eye.md` (the hand-eye axis that extends the
+  per-view rig pose).

--- a/docs/notes/ringgrid-bias.md
+++ b/docs/notes/ringgrid-bias.md
@@ -1,0 +1,140 @@
+# Ring-grid ellipse-center bias — proof pack
+
+Family: coded ring-grid targets on the seeded Scheimpflug intrinsics route
+(`ScheimpflugIntrinsicsProblem`; detector `vision_calibration_detect::ringgrid`
+wrapping the external `ringgrid` crate; bench accept path
+`vision_calibration_bench::run::run_scheimpflug_intrinsics`).
+
+Question (backlog Q3-RINGGRID-BIAS): the ring-grid cameras floor at ~0.47 px
+mean reprojection, ~0.17 px above the puzzleboard sibling (`rtv3d_ref`, ~0.30 px)
+on the same rig. Is that gap the projected ellipse-center bias of the ring
+markers — a systematic, correctable projective effect — or detector noise?
+
+**Answer: it is not the projective bias.** That bias is ~0.09 px here and is
+already removed at the detector level; the residual floor is small-marker
+localization noise. No pipeline-side correction was added. Details below.
+
+## Mechanism
+
+A coded ring marker is two concentric circles (inner/outer radii `r_in`,
+`r_out`) on the board plane. Set lens distortion aside for a moment: the board
+plane → pixel map is then a single homography
+
+```
+H = K · H_tilt · [r1 r2 t]
+```
+
+with intrinsics `K`, the Scheimpflug tilt homography `H_tilt` (tilt is a
+homography acting on normalized coordinates — ADR 0022), and the planar-pose
+homography `[r1 r2 t]` from `camera_se3_target`. A circle with symmetric conic
+matrix `C` on the plane images to the conic
+
+```
+C' = H⁻ᵀ C H⁻¹.
+```
+
+The **ellipse center** of `C'` — the stationary point of its quadratic form,
+`center = −[[C'₀₀, C'₀₁],[C'₀₁, C'₁₁]]⁻¹ · [C'₀₂, C'₁₂]ᵀ` — is *not* the image
+`H·center` of the circle's plane center under a genuinely projective (non-affine)
+`H`. That offset is the ellipse-center bias. It vanishes exactly for an affine
+`H` (bottom row `[0 0 1]`) and grows with the perspective foreshortening across
+the marker's pixel extent, i.e. roughly as `(marker radius in px)² × |bottom row
+of H|`.
+
+Because a real lens applies (non-homographic) distortion, the observed edge is
+displaced by the distortion field; to first order that displacement is common to
+the marker's inner and outer edges *and* to the model's reprojection of the
+center, so it cancels out of the residual — the leftover is second order in the
+distortion gradient across the ~4 px marker.
+
+## Closed-form magnitude
+
+`crates/vision-calibration-bench/src/ringgrid_bias.rs` is the single source of
+truth for the conic-center math: `circle_conic`, `project_conic`
+(`C' = H⁻ᵀ C H⁻¹`), `conic_center`, and `predicted_center_bias(H, cx, cy, r) =
+center(H⁻ᵀ C H⁻¹) − H·(cx, cy)`. `diagnose` evaluates it per (view, marker) from
+an exported model + pose, using the no-distortion homography above.
+
+Evaluated on the six private ring-grid cameras with the *calibrated* model and
+poses (outer radius 4.8 mm, inner 3.2 mm), the predicted single-conic
+(outer-edge) bias is:
+
+| camera | n_obs | bias mean | median | p95 | max (px) |
+|--------|------:|----------:|-------:|----:|---------:|
+| cam0 | 1196 | 0.107 | 0.090 | 0.273 | 0.420 |
+| cam1 | 1041 | 0.109 | 0.092 | 0.294 | 0.434 |
+| cam2 |  576 | 0.094 | 0.092 | 0.154 | 0.241 |
+| cam3 | 1193 | 0.114 | 0.099 | 0.300 | 0.452 |
+| cam4 |  746 | 0.091 | 0.089 | 0.159 | 0.232 |
+| cam5 |  572 | 0.084 | 0.087 | 0.135 | 0.155 |
+
+The bias is ~0.09 px mean (max ≤ 0.45 px). It is small because the markers span
+only a few pixels (outer radius ≈ 3–4 px at this working distance and focal),
+and the bias scales with the square of the marker's pixel radius. This is an
+order of magnitude below the ~0.47 px residual floor and below the ~0.17 px gap
+to the puzzleboard sibling — so even entirely uncorrected it could not explain
+the gap.
+
+## Correction: why not
+
+The `ringgrid` detector (≥ 0.7, `CircleRefinementMethod::ProjectiveCenter`, on by
+default) already removes the *projective* part of this bias at the observation
+level, before calibration sees a center. It fits both the inner and outer edge
+conics and recovers their common projected center with an intrinsics-free
+two-conic pencil (Wang et al. 2019) that is exact under a homography — i.e. it
+cancels exactly the `C'`-center-vs-`H·center` offset derived above, for both
+perspective and Scheimpflug tilt. The detector's own path applies it in
+`finalize_premerge` / `run`; `vision_calibration_detect::RinggridDetector` uses
+that default.
+
+A model-based re-correction in the pipeline would therefore either (a)
+double-correct the already-removed bias (strictly harmful), or (b) merely
+reproduce the detector's projective correction, whose only unmodeled remainder
+is the second-order distortion term (negligible here). Per the workspace's
+honesty-over-heroics rule, **no correction was wired**. The conic-center math
+ships as a tested diagnostic module, not a pipeline stage; `FactorKind`, the
+optimization IR, the detector wrapper, and the pipeline are untouched.
+
+## Evidence
+
+`diagnose` also regresses the calibration residual vector `r = observed −
+projected` on the predicted bias vector `b` (outer conic). If the detector
+reported *naive* ellipse centers, the residual would *contain* `b` and the
+regression coefficient `Σ(r·b)/Σ|b|²` would be ≈ +1. Measured:
+
+| camera | residual mean | median | p95 | max (px) | resid/bias coeff | mean cos | corr(bias, radius) |
+|--------|-------------:|-------:|----:|---------:|-----------------:|---------:|-------------------:|
+| cam0 | 0.460 | 0.361 | 1.084 | 6.270 | −0.035 | 0.019 | −0.027 |
+| cam1 | 0.501 | 0.347 | 1.292 | 5.616 | +0.086 | −0.021 | +0.055 |
+| cam2 | 0.485 | 0.366 | 1.325 | 5.165 | +0.003 | 0.048 | +0.065 |
+| cam3 | 0.463 | 0.355 | 1.050 | 7.189 | −0.031 | 0.030 | −0.011 |
+| cam4 | 0.425 | 0.350 | 0.993 | 3.563 | +0.023 | 0.086 | −0.017 |
+| cam5 | 0.487 | 0.410 | 1.092 | 2.985 | −0.104 | 0.065 | +0.053 |
+
+The residual means reproduce the `calib-bench accept` per-camera means (0.4601,
+0.5008, 0.4852, 0.4625, 0.4248, 0.4867 px) to three decimals, validating the
+diagnostic. The regression coefficient is ≈ 0 (|·| ≤ 0.104) and the mean cosine
+between `r` and `b` is ≈ 0 (|·| ≤ 0.086): **the predicted projective bias is
+absent from the residual field** — the detector's two-conic pencil removed it —
+and what remains is orthogonal noise. `corr(bias, radius) ≈ 0` shows no
+peripheral-growth pattern in the (already tiny) bias.
+
+Conclusion: the ~0.47 px ring-grid floor is small-marker ellipse-fit /
+localization noise (ring markers a few pixels across, with the pencil amplifying
+edge-fit noise), not correctable projective ellipse-center bias. The Q3 outcome
+is a documented diagnostic plus a gate tightening, not a correction.
+
+- **Before/after:** detection, model, and residuals are unchanged (no
+  correction wired); the six per-camera accept means stay 0.4601 / 0.5008 /
+  0.4852 / 0.4625 / 0.4248 / 0.4867 px. The acceptance gate tightened from the
+  provisional 1.0 px to 0.7 px (~1.4× the worst mean); baselines are unchanged.
+- **Diagnostic module + tests:**
+  `crates/vision-calibration-bench/src/ringgrid_bias.rs`
+  (`conic_center_matches_sampled_ellipse_fit`,
+  `bias_is_nonzero_and_equals_center_minus_projection`,
+  `affine_homography_has_no_bias`; the `#[ignore]`d `diagnose_private_ringgrid`
+  reproduces the tables above from the private dataset under `--features
+  tier-b`).
+- **Related:** ADR 0022/0023 (seeded Scheimpflug route),
+  `docs/notes/scheimpflug-intrinsics.md`, `docs/notes/planar-intrinsics.md`
+  (the puzzleboard sibling's noise floor).

--- a/docs/notes/rtv3d-scale.md
+++ b/docs/notes/rtv3d-scale.md
@@ -12,8 +12,11 @@ comparison uses the *final* laser-informed joint-BA extrinsics (the
 calibration this project already ships and validates on all other criteria)
 instead of the intermediate hand-eye-stage extrinsics, our hexagon measures
 98.21 ± 0.41 mm — matching the oracle's own healthy-camera hexagon
-(98.13 ± 1.10 mm) to **0.08 %**. 5.2 mm is confirmed as the correct cell
-size; no board-spec correction is needed.
+(98.13 ± 1.10 mm) to **0.08 %** (all-6 ours mean; the same-population
+comparison restricted to the four cam-0–4 edges on both sides gives
+98.42 vs 98.13 mm, −0.29 % — either way well inside the edge-spread noise).
+5.2 mm is confirmed as the correct cell size; no board-spec correction is
+needed.
 
 ## 1. Where "~98.5 mm" comes from (oracle side)
 

--- a/docs/notes/rtv3d-scale.md
+++ b/docs/notes/rtv3d-scale.md
@@ -1,0 +1,160 @@
+# rtv3d absolute metric scale — Q5-RTV3D-SCALE
+
+Settles the scale discrepancy recorded in `docs/backlog.md` (Q5) and the
+2026-06-11 validation report: our calibration measured a hexagon-neighbor
+spacing of "90.1 mm" at a 5.2 mm ChArUco cell, while the legacy oracle
+(`artifacts.json`) "implied ~98.5 mm" — an apparent ~8.6–9.3 % gap that
+prompted speculation about a cell-size mix-up (5.2 vs 4.75/4.8/5.69 mm).
+
+**Verdict: no real scale ambiguity. The gap was a pipeline-stage bookkeeping
+artifact in the oracle-comparison tool, not a metric error.** Once the
+comparison uses the *final* laser-informed joint-BA extrinsics (the
+calibration this project already ships and validates on all other criteria)
+instead of the intermediate hand-eye-stage extrinsics, our hexagon measures
+98.21 ± 0.41 mm — matching the oracle's own healthy-camera hexagon
+(98.13 ± 1.10 mm) to **0.08 %**. 5.2 mm is confirmed as the correct cell
+size; no board-spec correction is needed.
+
+## 1. Where "~98.5 mm" comes from (oracle side)
+
+`artifacts.json`'s `extrinsic[i].camera_se3_sensor` is `T_{cam_i}_{rig}` (rig
+frame = cam 0, matching our convention). Inverting each and taking pairwise
+distances between *mechanical neighbors* (the rig is a hexagon: 0-1-2-3-4-5-0)
+gives:
+
+| edge | distance (mm) |
+|---|---:|
+| 0-1 | 96.25 |
+| 1-2 | 98.47 |
+| 2-3 | 98.85 |
+| 3-4 | 98.96 |
+| 4-5 | 173.23 (touches cam 5) |
+| 5-0 | 144.97 (touches cam 5) |
+
+Cams 0–4 give four internally-consistent edges: mean **98.13 mm**, std
+1.10 mm (1.1 % spread) — this is the precise source of the report's "~98.5 mm"
+figure (previously eyeballed/rounded). The two edges touching cam 5 are wildly
+off (145–173 mm vs the ~98 mm the other four edges agree on), consistent with
+the already-known oracle cam 5 degeneracy (`fx = 51`, 127 px reprojection).
+**The 98.5 mm figure never depended on cam 5 or cam 0's own suspect fx**
+(cam 0's oracle fx = 1642 vs ~2030 elsewhere is a separate, already-flagged
+oddity that doesn't enter a translation-norm calculation) — it is a clean,
+self-consistent measurement from the oracle's 4 good cameras.
+
+## 2. Where "90.1 mm" came from (our side) — and why it was wrong
+
+`rtv3d_rig.rs`'s `compare_to_oracle()` printed the extrinsic-scale table using
+`rig_export.cam_se3_rig` — the **hand-eye-stage** export, captured *before*
+stage 3 (laser-plane recovery) and stage 4 (joint rig + hand-eye + laser-plane
+BA). Re-deriving the same hexagon-neighbor-edge computation at that stage,
+current dataset/code (2026-07-08):
+
+| edge | hand-eye stage (mm) | joint-BA stage (mm) | oracle (mm) |
+|---|---:|---:|---:|
+| 0-1 | 88.95 | 98.84 | 96.25 |
+| 1-2 | 88.78 | 98.07 | 98.47 |
+| 2-3 | 88.41 | 98.44 | 98.85 |
+| 3-4 | 89.59 | 98.31 | 98.96 |
+| 4-5 | 88.79 | 97.50 | 173.23 |
+| 5-0 | 88.73 | 98.13 | 144.97 |
+| **mean ± std** | **88.88 ± 0.36 mm (0.40 %)** | **98.21 ± 0.41 mm (0.41 %)** | 98.13 ± 1.10 mm (clean 4) |
+
+The hand-eye-stage hexagon (88.9 mm) is what the 2026-06-11 report rounded to
+"90.1 mm" (the dataset/pipeline has moved slightly since; the exact value
+drifts run-to-run with unrelated fixes — see §3 for why that drift itself is
+evidence against a cell-size bug). Crucially: **the joint BA — which already
+runs in this same example, and whose reprojection/laser numbers are what the
+"beat the oracle" verdict is graded on — rescales the *entire* rig by a
+uniform +10.5 % between the hand-eye stage and the final joint-BA stage**, and
+lands within 0.08 % of the oracle's clean hexagon. The rig shape (hexagon
+regularity, ~0.4 % edge spread) is preserved at both stages; only the overall
+scale moves. This is the signature of an under-constrained scale direction
+being resolved by additional metric information, not of noise or a different
+local optimum.
+
+**Likely mechanism** (not required to close this ticket, noted for
+follow-up): the Scheimpflug tilt ↔ principal-point ↔ rig-pose valley already
+documented in the 2026-06-11 report (`cx = −217` for cam 2 when seeded from
+the oracle) gives the per-camera/rig-BA stage a shallow direction that trades
+scale against tilt/pose without much reprojection cost. Stage 4 freezes the
+per-camera tilts (already converged) and adds the laser point-to-plane term
+(weight 1e4), which pins the remaining degree of freedom down. The
+92-view-BA-only stage's scale is *not wrong because of a modeling bug*; it is
+simply less metrically constrained than the full joint solve, and the
+oracle-comparison tool was reading the weaker of the two.
+
+## 3. The cell-size-confusion hypothesis — rejected
+
+The dataset ships two cell-size fields for the *same* 22×22 board (both
+`ncols`/`nrows` = 22, `marker_scale`/`marker_size_rel` = 0.75):
+
+- `config.json` → `target.cellsize_mm = 5.2` (used throughout; matches the
+  Q5 pipeline default).
+- `board_charuco.json` → `cell_size_mm = 4.8` (already flagged wrong in the
+  2026-06-11 report — a real internal metadata inconsistency, but unrelated
+  to the oracle gap discussed here).
+
+No file in the dataset (`spec.json`, `config.json`, `board_charuco.json`,
+`dataset.json`, `artifacts.json`) contains any other cell-size value — in
+particular neither 4.75 mm nor 5.69 mm (the values the ratio 98.5/90.1 ≈ 1.093
+would imply if the gap were a pure cell-size scale factor) appear anywhere.
+Those numbers were back-calculated from the ratio, not read from a file.
+
+Two more facts argue against a fixed cell-size bug specifically:
+
+1. **The ratio isn't constant.** 8.6 % (2026-06-11 report, rounded) → 9.3 %
+   (90.1/98.5 exactly) → 10.4 % (88.88/98.13, current hand-eye stage) → 0.08 %
+   (98.21/98.13, current joint-BA stage) as the *same* 5.2 mm cell size ran
+   through different pipeline stages/commits over the past month. A cell-size
+   mislabeling would produce a fixed ratio (5.2/4.8 = 1.0833, or 5.2/4.75 =
+   1.0947) independent of which BA stage or commit is compared; this one
+   moves with pipeline stage and vanishes entirely once the laser-informed
+   stage is used.
+2. **The joint-BA hexagon is internally tight** (0.41 % edge-length spread,
+   as regular as the hand-eye-stage hexagon it superseded) — a real board
+   mis-scale would show up as increased reprojection error or degraded
+   hexagon regularity at the corrected scale, not as a clean rescale that
+   also happens to match an independent oracle.
+
+`artifacts.json`'s `meta` block is entirely empty (no date, device, or
+`quick_version`), so its capture provenance can't be independently confirmed
+— but its geometry (4 clean cameras, one known-broken) is not itself in
+question; only the earlier *comparison* was reading the wrong stage of our
+own pipeline.
+
+## 4. What would definitively settle it beyond this analysis
+
+A mechanical measurement of the physical camera-to-camera spacing on the rtv3d
+head (calipers/CMM between two adjacent housings, or the drawing dimension if
+one exists) would be the independent ground truth neither the oracle nor our
+own BA can provide. Given the internal consistency demonstrated here (two
+independent computations — ours and the oracle's — agreeing to 0.08 % at
+5.2 mm), this is now a confirmation exercise rather than a scale-hunting one.
+
+## 5. Reproduction
+
+```bash
+RTV3D_DATA_DIR=privatedata/rtv3d CELL_SIZE_MM=5.2 RTV3D_HANDEYE=eye_to_hand \
+  cargo run --manifest-path crates/vision-calibration-examples-private/Cargo.toml \
+  --example rtv3d_rig --release
+```
+
+The "hexagon neighbor-edge lengths" table (added to `compare_to_oracle()` in
+this ticket) prints the per-edge ours-vs-oracle comparison and the mean ±
+spread verdict directly; no external script is needed. `compare_to_oracle()`
+also now sources the extrinsic-scale table from the joint-BA extrinsics (when
+laser data is present) instead of the hand-eye-stage export, which is the
+concrete code fix behind this note.
+
+## Files touched
+
+- `crates/vision-calibration-examples-private/examples/rtv3d_rig.rs` — the
+  oracle-comparison scale table now prefers the joint-BA (laser-informed)
+  extrinsics over the hand-eye-stage export; added the hexagon neighbor-edge
+  diagnostic table.
+- `privatedata/rtv3d/spec.json` — **local-only, gitignored** — `description`
+  field annotated with this finding and a pointer to this note (no numeric
+  field changed; the transcribed mount translations remain a valid bootstrap
+  seed regardless of the ~10 % staleness, since seeded and generic
+  initialization converge to the same optimum — S3-SPEC-EXTRINSICS,
+  2026-07-02).

--- a/docs/notes/two-view-triangulation.md
+++ b/docs/notes/two-view-triangulation.md
@@ -1,0 +1,184 @@
+# Two-view geometry & triangulation — proof pack
+
+Family: relative pose and structure from two (or N) calibrated views. Solvers
+in `vision-geometry` (`epipolar::{fundamental, essential, decomposition}`,
+`homography`, `triangulation`, `camera_matrix`); orchestration and diagnostics
+in `vision-mvg` (`pose_recovery`, `cheirality`, `triangulation`, `degeneracy`,
+`robust`, `homography`). Crate split per ADR 0006.
+
+## Model
+
+Two pinhole views of a rigid scene. Pixel points are made calibrated by
+`x = K⁻¹ u` (`pixel_to_normalized`, ADR 0009 conventions), so `x₁, x₂` are
+normalized (`z = 1`) rays. Relative pose `(R, t)` maps camera 1 into camera 2:
+`X_c2 = R·X_c1 + t` (`R` = cam1→cam2, `t` up to scale).
+
+- **Epipolar constraint** (calibrated): `x₂ᵀ E x₁ = 0`, `E = [t]× R`, rank 2,
+  singular values `(σ, σ, 0)`.
+- **Fundamental** (uncalibrated, pixels): `u₂ᵀ F u₁ = 0`, `F = K₂⁻ᵀ E K₁⁻¹`,
+  rank 2.
+- **Homography** (planar scene *or* pure rotation): `x₂ ~ H x₁`,
+  `H = R + t nᵀ/d` (`homography_from_pose_and_plane`).
+- **Triangulation**: given projection matrices `P_i` and observations `x_i`,
+  find `X` with `x_i ~ P_i X̃`.
+
+## Solvers (initialization)
+
+- **Fundamental, normalized 8-point** (`fundamental_8point`): Hartley-normalize
+  each point set (`normalize_points_2d` — translate centroid to origin, scale to
+  mean distance `√2`), stack the 9-column epipolar design `A`, take the 1-D null
+  space, reshape to `F_raw`, force rank 2 by zeroing the smallest singular value
+  of the `3×3` SVD, then de-normalize `F = T₂ᵀ F_raw T₁`.
+- **Fundamental, 7-point** (`fundamental_7point`): minimal solver; a **2-D** null
+  space spans `F₁, F₂`, and `det(F₂ + λF₁) = 0` (a cubic via `solve_cubic_real`)
+  gives up to three rank-2 candidates.
+- **Essential, 5-point** (`essential_5point`, Nistér): a **4-D** null space
+  spans `E₁..E₄`; the ten cubic constraints (`build_polynomial_system`) are
+  reduced by Gauss-Jordan (LU) elimination to a `10×10` action matrix whose real
+  Schur eigenvalues yield up to ten candidate `E`. Calibrated coordinates are
+  already `O(1)`, so **no Hartley normalization** is applied (documented in
+  `essential.rs`).
+- **Essential, linear ≥8-point** (`essential_linear`): 1-D null space, then
+  projection onto the essential manifold (singular values → `(σ, σ, 0)`). Used
+  for the RANSAC refit on large inlier sets.
+- **Camera matrix DLT** (`dlt_camera_matrix`): normalized 6+-point DLT for
+  `P = K[R|t]`, with a coplanarity guard (scatter `σ_min/σ_max`) and a rank
+  guard; `rq_decompose` / `decompose_camera_matrix` recover `K, R, t`.
+
+**Hartley normalization rationale.** With raw pixels the `u·x` columns of the
+epipolar design are `O(10⁵)` while the last column is `O(1)`; the design is
+badly scaled and the recovered `F` fails `|u₂ᵀ F u₁|/‖F‖` by orders of
+magnitude. Centering and isotropic scaling equalize the columns. Regression:
+`fundamental_8point_epipolar_constraint_pixel_coords` asserts the normalized
+residual `< 1e-6` at pixel scale, which does not hold unnormalized.
+
+**Null-space extraction (P1-SVD-SWEEP).** The **1-D** homogeneous solves
+(8-point `F`, `essential_linear`, homography, camera-matrix, and triangulation
+DLTs) take their null vector from `vision_calibration_core::linalg::null_space`
+— the smallest-eigenvalue eigenvector of `AᵀA` via a *symmetric*
+eigendecomposition — **not** `A.svd(...)`. nalgebra's Golub-Kahan QR sweep can
+fail to converge (minutes-long hangs) on real dense designs, and the
+non-convergence persists even with `compute_u = false`; `AᵀA` is always `k×k`
+(`k ≤ 12` here) and converges in a few sweeps. The **multi-vector** null spaces
+(7-point's 2-D, 5-point's 4-D) still use `svd(true, true)` because `null_space`
+returns only the single smallest vector. (`ridge_lstsq`, the regularized
+normal-equation sibling, lives in `vision-calibration-linear` and is used by the
+calibration solvers, not this family.)
+
+## Pose recovery, the 4-fold ambiguity, and cheirality
+
+`decompose_essential` projects `E` to the manifold and returns **four**
+candidates `{R₁, R₂} × {+t, −t}` (`R₁ = U W Vᵀ`, `R₂ = U Wᵀ Vᵀ`,
+`t = ±u₃`), with a raw-`σ` degeneracy guard on the input (`σ₀ < 1e-10` or
+`σ₁/σ₀ < 0.1` ⇒ `Err` — catches rank-1 / zero `E`). Only one candidate places
+triangulated points in front of **both** cameras; `cheirality::select_pose`
+counts positive-depth points (`cheirality_count`) and picks the winner.
+
+`recover_relative_pose` samples up to 20 evenly-spaced 5-point subsets
+(deterministic, input-ordering independent), scores each candidate `E` by mean
+Sampson distance over **all** correspondences, decomposes, cheirality-selects,
+and tie-breaks by residual — then triangulates with the chosen pose. The robust
+variant (`recover_relative_pose_robust` → `estimate_essential`) runs 5-point +
+Sampson inside `ransac_fit`, refits inliers with `essential_linear`, and
+disambiguates cheirality on inliers only.
+
+## Cost
+
+The solvers minimize algebraic / Sampson error; the one geometric optimizer in
+the family is triangulation refinement. `refine_point` (a self-contained 3-DOF
+Gauss-Newton, 10 iterations) minimizes total squared reprojection error
+`Σ_i ‖π(P_i, X) − x_i‖²` — the maximum-likelihood point under isotropic Gaussian
+image noise — starting from the DLT estimate. **No midpoint or optimal
+(Hartley–Sturm polynomial) triangulator is implemented**; DLT seed + reprojection
+GN is the chosen path. Sampson distance (`residuals::sampson_distance`, the
+first-order geometric epipolar residual) is the RANSAC residual for `E`/`F`;
+symmetric transfer error serves `H`.
+
+## Triangulation and its failure modes
+
+`triangulate_point_linear` builds the `2N×4` DLT, solves it via `null_space`,
+guards rank with `dlt_rank_ok`, and rejects a point at infinity (`w ≈ 0`).
+`triangulate_point` appends `refine_point`; `triangulate_nview` adds diagnostics
+(RMS reprojection, **widest** pairwise parallax, all-view cheirality). Failure
+modes:
+
+- **Zero / low parallax** (narrow baseline or far points): rays are nearly
+  parallel, the DLT boundary singular value collapses, `dlt_rank_ok` rejects the
+  exactly-degenerate case, and near-degenerate points have depth variance `∝
+  1/parallax` (quantified below).
+- **Point on the baseline / near the epipole**: the two viewing rays are
+  collinear ⇒ rank-deficient ⇒ rejected per point. `triangulate_two_view_partial`
+  skips such points instead of failing the whole set (used by `analyze_scene`).
+- **Identical cameras** (zero baseline): rejected (`triangulation_rejects_identical_cameras`).
+
+## Identifiability and degeneracies
+
+- **Pure rotation** (`t = 0`): `E = [0]× R = 0` (rank 0) — `decompose_essential`
+  rejects it. There is no baseline, so triangulation is meaningless; the correct
+  model is `H = R`. `detect_pure_rotation` flags this from the **median parallax
+  angle** (scale-invariant) rather than `‖E‖` (which is scale-dependent and
+  would misfire on a down-scaled valid `E`).
+- **Planar scene**: coplanar structure makes the epipolar design rank-deficient
+  — `F`/`E` are under-determined, but `H` is well-posed. `detect_planar_scene`
+  compares homography vs essential inlier support. `dlt_camera_matrix` likewise
+  rejects coplanar 3D points (estimate a homography instead). The matrix and
+  property tests deliberately use **non-coplanar** clouds.
+- **Narrow baseline / low parallax**: `E` rank is fine, but the translation
+  *direction* and the reconstructed depth are ill-conditioned, degrading `∝
+  1/parallax`. This is the dominant real-data sensitivity (see below).
+- **Critical surfaces** (structure + both centers on a ruled quadric): a known
+  theoretical `F` ambiguity; not separately guarded, as the planar case
+  dominates in practice.
+
+## Gauge
+
+Two-view reconstruction is fixed only up to a **similarity** (7 DOF). The
+conventions pin most of it: fixing camera 1 at `[I | 0]` removes the 6-DOF rigid
+gauge, and `E` is defined only up to scale — `decompose_essential` returns a
+**unit** `‖t‖`, so metric depth is unobservable from two views. The remaining
+1-DOF scale must come from downstream context (a known baseline, frozen
+extrinsics, or bundle adjustment against metric structure). This is why the
+matrix test reports rotation and translation *direction* for pose recovery, and
+resolves scale for the triangulation cells by handing the solver the true metric
+cameras.
+
+## Noise sensitivity
+
+Grounded in the matrix test (42-point non-coplanar cloud, `f ≈ 800`, uniform
+per-axis pixel noise `a`). At `a = 0.5 px`:
+
+- **Rotation** error `0.06–0.12°`, nearly flat across baseline.
+- **Translation direction** climbs sharply as the baseline narrows —
+  `0.19°` (wide, `‖t‖ = 0.8`) → `0.32°` → `0.58°` → `1.91°` (narrow,
+  `‖t‖ = 0.10`): the parallax degeneracy made quantitative.
+- **Metric 3D triangulation** median error `9.6e-3` (wide) → `7.1e-2` (narrow),
+  a `~7×` spread at fixed noise, same `1/parallax` law.
+- **Post-fit reprojection** tracks the noise floor: median `≈ 0.15 px` at
+  `a = 0.5 px` (uniform `[−a, a]` per axis has error-norm mean `≈ 0.765·a`).
+- **Exact data**: rotation / t-direction at solver tolerance (`< 1e-3°`),
+  reprojection `~1e-13 px`, 3D error `~1e-15`.
+
+Parameter errors scale ~linearly in `a`; translation direction and depth
+additionally scale ~`1/parallax`.
+
+## Evidence
+
+- **Matrix test**: `crates/vision-mvg/tests/two_view_matrix.rs` — 4
+  baseline/parallax regimes (`wide-sideways`, `wide-rotated`, `medium`,
+  `narrow`) × noise `{0, 0.2, 0.5} px`; per cell asserts rotation deg,
+  translation-direction deg, reprojection px, and 3D error against the ground
+  truth, scaled to the noise floor.
+- **Property tests**: `crates/vision-mvg/tests/two_view_properties.rs` — over a
+  pose grid: `E = [t]× R` annihilates GT correspondences and decomposes to the
+  GT pose; estimated-`F` epipolar residual `< 1e-6`; triangulate → reproject
+  round trip (`< 1e-6 px`, `< 1e-6` in 3D).
+- **Unit tests** (per module): Hartley regression and the dense-DLT anti-hang
+  guard (`epipolar/fundamental.rs`, `homography.rs`), essential-manifold and
+  degeneracy guards (`epipolar/essential.rs`, `epipolar/decomposition.rs`),
+  cheirality (`cheirality.rs`), triangulation recovery/refinement
+  (`triangulation.rs`), and scene degeneracy detectors (`degeneracy.rs`).
+- **Related**: ADR 0006 (the `vision-geometry` / `vision-mvg` split); the
+  P1-SVD-SWEEP (`docs/report/2026-06-16-P1-SVD-SWEEP-finish-centralize.md`) —
+  `null_space` / `AᵀA` replacing dense SVD in the 1-D null-space solvers;
+  `docs/notes/planar-intrinsics.md` (Zhang init shares the Hartley-normalized
+  DLT homography).


### PR DESCRIPTION
Closes out Track Q of the production-grade program: Q3 (ringgrid bias), Q5 (rtv3d scale), Q8 (proof packs). No baseline refreezes were needed — every fit is bit-identical to the committed Q2 baselines (19/19 accept PASS, zero drift).

## Q3 — ringgrid ellipse-center bias: resolved as already-corrected-at-detector-level

- Diagnosis with closed-form conic-center math (`C' = H⁻ᵀCH⁻¹`): the predicted projective bias on the six private ring-grid cameras is **~0.09 px mean / ≤ 0.45 px max** — an order of magnitude below the ~0.47 px floor.
- Falsification: regressing the actual residual field on the predicted bias gives coefficient ≈ 0 (|coef| ≤ 0.10) — the bias is **absent from the residuals**, because `ringgrid` 0.7 defaults to `CircleRefinementMethod::ProjectiveCenter` (two-conic pencil) and removes it before calibration sees a center.
- Consequently **no pipeline correction was wired** (it would double-correct). The conic math ships as a tested diagnostic (`vision-calibration-bench::ringgrid_bias`, 3 unit tests + `#[ignore]`d E2E table generator); `FactorKind`/IR/detector wrapper untouched.
- Ring-grid accept gates tightened 1.0 → **0.7 px** (local `registry/private.json`); 6/6 PASS at the new bar. The remaining floor is small-marker localization noise (markers span a few px; bias scales with pixel-radius²) — detector-side territory, documented in `docs/notes/ringgrid-bias.md`.
- Stale backlog prose ("median ≈ 4.7 px, cam5 ~38 px" — pre-V8 numbers) corrected.

## Q5 — rtv3d metric scale: no ambiguity; comparison-stage artifact

- The oracle's "~98.5 mm" hexagon = 98.13 ± 1.10 mm from its 4 healthy cameras (edges touching degenerate cam5 excluded).
- Our "90.1 mm" came from the **hand-eye-stage** extrinsics — captured before the laser-informed joint BA. The final joint-BA hexagon is **98.21 ± 0.41 mm — matching the oracle to 0.08 %**. The 5.2 mm cell size is confirmed; the cell-size-confusion hypothesis is rejected (no 4.75/5.69 mm exists in any dataset file; the ratio moved with pipeline stage, which a cell-size bug cannot do).
- `rtv3d_rig.rs::compare_to_oracle()` now grades the joint-BA extrinsics (when laser data is present) and prints a permanent hexagon edge-length diagnostic. Full derivation in `docs/notes/rtv3d-scale.md`.

## Q8 — proof packs for every remaining family

Five new notes in `docs/notes/` (hand-eye, rig-extrinsics, laserline-bundle, two-view-triangulation, rectification short pack) + the Q3/Q5 notes above; index updated. Each pack = math note (model/cost/identifiability/gauge/noise, citing shipped modules) + synthetic-GT matrix test + property tests:

| family | new tests | headline numbers |
|---|---|---|
| hand-eye | `single_cam_handeye_matrix.rs` (facade) | 0.30 px noise → Δrot ≤ 1.4e-3 rad, Δt ≤ 0.9 mm; base-frame gauge invariant to 1e-14 (refinement off) |
| rig extrinsics | `rig_extrinsics_matrix.rs` (facade) | 0.30 px → Δtrans 8 mm (narrow) / 22 mm (wide); reference-camera gauge swap invariant; disconnected co-visibility rejected |
| laserline bundle | `laserline_device_matrix.rs` (facade) | 0.30 px → normal ≤ 0.084°, distance ≤ 1.1 mm; S² sign gauge + SE(3) point-to-plane invariance (5000 cases each) |
| two-view/triangulation | `two_view_matrix.rs`, `two_view_properties.rs` (vision-mvg) | parallax degeneracy quantified: t-dir error 0.19°→1.91° as baseline shrinks 8× at 0.5 px noise |

Findings recorded for the R-track: `fix_first_rig_pose` is redundant with the reference-camera gauge fix (mildly pessimizing — ADR 0024 candidate); robot-pose refinement mildly breaks hand-eye base-frame gauge (base-frame priors not Ad-invariant); linear rig init requires a direct reference↔camera co-visibility edge.

## Verification

- `cargo fmt` / `clippy --workspace --all-targets --all-features -D warnings` / `test --workspace --all-features` / `RUSTDOCFLAGS=-D warnings cargo doc` — clean
- examples-private clippy clean
- Full `calib-bench accept` (public + private registries, `tier-b laser`): 19 passed, 0 failed, 2 unavailable, zero baseline drift, ring-grid at the tightened 0.7 px gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
