### PR TITLE
R7: export kind discriminator (0.7.0 breaking window)

### DIFF
--- a/app/schemas-generated/diagnose_wire.json
+++ b/app/schemas-generated/diagnose_wire.json
@@ -502,6 +502,51 @@
       ],
       "type": "object"
     },
+    "ExportKind": {
+      "description": "Identifies which calibration `*Export` a JSON payload holds.\n\nOne variant per pipeline problem type, serialized as the snake_case module\nname in the `kind` field of every `*Export`. Consumers (the desktop app's\n`detectExportKind`, downstream tooling) read this single tag rather than\nsniffing field presence.",
+      "oneOf": [
+        {
+          "const": "planar_intrinsics",
+          "description": "[`PlanarIntrinsicsExport`](crate::planar_intrinsics::PlanarIntrinsicsExport).",
+          "type": "string"
+        },
+        {
+          "const": "scheimpflug_intrinsics",
+          "description": "[`ScheimpflugIntrinsicsExport`](crate::scheimpflug_intrinsics::ScheimpflugIntrinsicsExport).",
+          "type": "string"
+        },
+        {
+          "const": "single_cam_handeye",
+          "description": "[`SingleCamHandeyeExport`](crate::single_cam_handeye::SingleCamHandeyeExport).",
+          "type": "string"
+        },
+        {
+          "const": "laserline_device",
+          "description": "[`LaserlineDeviceExport`](crate::laserline_device::LaserlineDeviceExport).",
+          "type": "string"
+        },
+        {
+          "const": "rig_extrinsics",
+          "description": "[`RigExtrinsicsExport`](crate::rig_extrinsics::RigExtrinsicsExport).",
+          "type": "string"
+        },
+        {
+          "const": "rig_handeye",
+          "description": "[`RigHandeyeExport`](crate::rig_handeye::RigHandeyeExport).",
+          "type": "string"
+        },
+        {
+          "const": "rig_laserline_device",
+          "description": "[`RigLaserlineDeviceExport`](crate::rig_laserline_device::RigLaserlineDeviceExport).",
+          "type": "string"
+        },
+        {
+          "const": "rig_handeye_laserline",
+          "description": "[`RigHandeyeLaserlineExport`](crate::rig_handeye_laserline::RigHandeyeLaserlineExport).",
+          "type": "string"
+        }
+      ]
+    },
     "FeatureResidualHistogram": {
       "description": "Aggregate residual histogram for a (set of) reprojection error samples.\n\nBuckets are fixed at `[<=1, <=2, <=5, <=10, >10]` pixels — see\n[`REPROJECTION_HISTOGRAM_EDGES_PX`].",
       "properties": {
@@ -890,6 +935,14 @@
           ],
           "description": "Optional image manifest (ADR 0014, viewer-side contract). Per\naccepted view (pose = kept-view index, camera = 0): one frame\nfor the *target* image plus one of kind `laser` for the laser\nimage (ADR 0021 §5). `None` means \"no images shipped\"; the\ncalibration pipeline never reads this field."
         },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::LaserlineDevice`]."
+        },
         "mean_reproj_error": {
           "description": "Mean reprojection error (pixels).",
           "format": "double",
@@ -922,6 +975,7 @@
         }
       },
       "required": [
+        "kind",
         "estimate",
         "stats",
         "mean_reproj_error",
@@ -1139,6 +1193,14 @@
           ],
           "description": "Optional image manifest (ADR 0014, viewer-side contract). When\npopulated, downstream viewers (the diagnose UI) can locate the source\nimage for each `(pose, camera)` slot. `None` means \"no images\nshipped\"; the calibration pipeline never reads this field."
         },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::PlanarIntrinsics`]."
+        },
         "mean_reproj_error": {
           "description": "Mean reprojection error (pixels).",
           "format": "double",
@@ -1179,6 +1241,7 @@
         }
       },
       "required": [
+        "kind",
         "params",
         "report",
         "mean_reproj_error",
@@ -1290,6 +1353,14 @@
           ],
           "description": "Optional image manifest (ADR 0014, viewer-side contract). When\npopulated, downstream viewers (the diagnose UI) can locate the source\nimage for each `(pose, camera)` slot. Tiled multi-camera frames\n(e.g. 6× 720×540 horizontal strips on the puzzle 130×130 rig) point\nmultiple `FrameRef`s at the same `path` with disjoint ROIs. `None`\nmeans \"no images shipped\"; the calibration pipeline never reads\nthis field."
         },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::RigExtrinsics`]."
+        },
         "mean_reproj_error": {
           "description": "Mean reprojection error (pixels).",
           "format": "double",
@@ -1332,6 +1403,7 @@
         }
       },
       "required": [
+        "kind",
         "cameras",
         "cam_se3_rig",
         "rig_se3_target",
@@ -1409,6 +1481,14 @@
           ],
           "description": "Optional image manifest (ADR 0014, viewer-side contract). When\npopulated, downstream viewers (the diagnose UI) can locate the source\nimage for each `(pose, camera)` slot. Tiled multi-camera frames\n(e.g. 6× 720×540 horizontal strips on the puzzle 130×130 rig) point\nmultiple `FrameRef`s at the same `path` with disjoint ROIs. `None`\nmeans \"no images shipped\"; the calibration pipeline never reads\nthis field."
         },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::RigHandeye`]."
+        },
         "mean_reproj_error": {
           "description": "Mean reprojection error (pixels).",
           "format": "double",
@@ -1479,6 +1559,7 @@
         }
       },
       "required": [
+        "kind",
         "cameras",
         "cam_se3_rig",
         "handeye_mode",
@@ -1555,6 +1636,14 @@
             }
           ],
           "description": "Optional image manifest populated by app/dataset runners."
+        },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::RigHandeyeLaserline`]."
         },
         "laser_planes_cam": {
           "description": "Per-camera laser planes in camera frame.",
@@ -1642,6 +1731,7 @@
         }
       },
       "required": [
+        "kind",
         "laser_planes_rig",
         "laser_planes_cam",
         "per_camera_stats",
@@ -1767,6 +1857,14 @@
           ],
           "description": "Optional image manifest (ADR 0014, viewer-side contract). When\npopulated, downstream viewers (the diagnose / 3D / epipolar UIs)\ncan locate the source image for each `(pose, camera)` slot.\nTiled multi-camera frames (e.g. 6× 720×540 horizontal strips on\nthe puzzle 130×130 rig) point multiple `FrameRef`s at the same\n`path` with disjoint ROIs. `None` means \"no images shipped\"; the\ncalibration pipeline never reads this field."
         },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::RigLaserlineDevice`]."
+        },
         "laser_planes_cam": {
           "description": "Per-camera laser planes in their own camera frames.",
           "items": {
@@ -1823,6 +1921,7 @@
         }
       },
       "required": [
+        "kind",
         "laser_planes_rig",
         "laser_planes_cam",
         "per_camera_stats"
@@ -1842,6 +1941,14 @@
             }
           ],
           "description": "Optional pointer to the source images behind this export. When\npopulated, downstream viewers (the diagnose UI) can locate the\nsource image for each view. `None` means \"no images shipped\";\nthe calibration pipeline never reads this field."
+        },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::ScheimpflugIntrinsics`]."
         },
         "mean_reproj_error": {
           "description": "Mean per-point reprojection error in pixels.",
@@ -1883,6 +1990,7 @@
         }
       },
       "required": [
+        "kind",
         "params",
         "report",
         "mean_reproj_error",
@@ -2081,6 +2189,14 @@
           ],
           "description": "Optional pointer to the source images behind this export. When\npopulated, downstream viewers (the diagnose UI) can locate the\nsource image for each view. `None` means \"no images shipped\";\nthe calibration pipeline never reads this field."
         },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExportKind"
+            }
+          ],
+          "description": "Export-type discriminator (R7) — always [`ExportKind::SingleCamHandeye`]."
+        },
         "mean_reproj_error": {
           "description": "Mean reprojection error (pixels).",
           "format": "double",
@@ -2121,6 +2237,7 @@
         }
       },
       "required": [
+        "kind",
         "camera",
         "handeye_mode",
         "mean_reproj_error",

--- a/app/src/store/exportKind.test.ts
+++ b/app/src/store/exportKind.test.ts
@@ -2,101 +2,59 @@ import { describe, expect, it } from "vitest";
 import { detectExportKind, exportKindLabel, type ExportKind } from "./exportKind";
 import { PLANAR_EXPORT_FIXTURE } from "../test/exportFixtures";
 
-const ALL_KINDS: ExportKind[] = [
+const WIRE_KINDS: Exclude<ExportKind, "unknown">[] = [
   "planar_intrinsics",
   "scheimpflug_intrinsics",
   "single_cam_handeye",
   "laserline_device",
   "rig_extrinsics",
   "rig_handeye",
-  "rig_handeye_laserline",
   "rig_laserline_device",
-  "unknown",
+  "rig_handeye_laserline",
 ];
 
-// detectExportKind classifies a loaded export by its distinguishing required
-// fields — the actual shapes emitted by the pipeline (see the generated
-// `*Export` interfaces), not the speculative top-level `camera` /
-// `laser_planes_cam` probes of the retired exportShape.ts.
+const ALL_KINDS: ExportKind[] = [...WIRE_KINDS, "unknown"];
+
+// detectExportKind now reads the `kind` discriminator (R7) every pipeline
+// `*Export` serializes, validated against the known vocabulary — no more
+// probing which required fields are present.
 describe("detectExportKind", () => {
-  it("classifies single-camera intrinsics by params.camera.sensor", () => {
-    // Both planar and Scheimpflug exports are top-level identical; the sensor
-    // model tag inside params.camera is the only discriminator. The
-    // "identity" case reuses the canonical planar fixture (see
-    // src/test/exportFixtures.ts) instead of re-declaring its shape here.
+  it("returns the wire kind for every recognised tag", () => {
+    for (const kind of WIRE_KINDS) {
+      expect(detectExportKind({ kind })).toBe(kind);
+    }
+  });
+
+  it("classifies the shared planar fixture by its kind tag", () => {
     expect(detectExportKind(PLANAR_EXPORT_FIXTURE)).toBe("planar_intrinsics");
+  });
+
+  it("ignores field presence and trusts the tag", () => {
+    // A payload whose fields look like a rig export but whose tag says
+    // planar is classified by the tag: the discriminator is authoritative.
     expect(
       detectExportKind({
-        ...PLANAR_EXPORT_FIXTURE,
-        params: { camera: { sensor: { type: "scheimpflug" } } },
+        kind: "planar_intrinsics",
+        cameras: [],
+        handeye_mode: "EyeInHand",
       }),
-    ).toBe("scheimpflug_intrinsics");
-    // Missing/omitted sensor tag falls back to planar (the common case).
-    expect(detectExportKind({ params: { camera: {} } })).toBe("planar_intrinsics");
+    ).toBe("planar_intrinsics");
   });
 
-  it("classifies single-camera hand-eye by camera + handeye_mode", () => {
-    expect(detectExportKind({ camera: {}, handeye_mode: "EyeInHand" })).toBe(
-      "single_cam_handeye",
-    );
-  });
-
-  it("classifies a laserline device by estimate + stats", () => {
-    expect(detectExportKind({ estimate: {}, stats: {} })).toBe("laserline_device");
-  });
-
-  it("classifies rig exports by the cameras array + optional hand-eye", () => {
-    expect(detectExportKind({ cameras: [], cam_se3_rig: [], rig_se3_target: [] })).toBe(
-      "rig_extrinsics",
-    );
-    expect(detectExportKind({ cameras: [], handeye_mode: "EyeToHand" })).toBe(
-      "rig_handeye",
-    );
-  });
-
-  it("classifies laser-rig exports by laser_planes_rig + optional hand-eye", () => {
-    expect(
-      detectExportKind({
-        laser_planes_rig: [],
-        laser_planes_cam: [],
-        per_camera_stats: [],
-      }),
-    ).toBe("rig_laserline_device");
-    expect(
-      detectExportKind({ laser_planes_rig: [], handeye_mode: "EyeInHand", cameras: [] }),
-    ).toBe("rig_handeye_laserline");
-  });
-
-  it("returns unknown for unrecognised or empty shapes", () => {
+  it("returns unknown for a missing or unrecognised tag", () => {
     expect(detectExportKind({})).toBe("unknown");
-    expect(detectExportKind({ per_feature_residuals: {} })).toBe("unknown");
+    expect(detectExportKind({ kind: "not_a_real_kind" })).toBe("unknown");
+    // Fields but no tag (e.g. a hand-edited or pre-R7 payload): unknown.
+    expect(detectExportKind({ cameras: [], cam_se3_rig: [], rig_se3_target: [] })).toBe(
+      "unknown",
+    );
+  });
+
+  it("returns unknown for non-object or non-string-tag payloads", () => {
     expect(detectExportKind(null)).toBe("unknown");
     expect(detectExportKind("nope")).toBe("unknown");
-  });
-
-  it("returns unknown when params is present but not a plain object", () => {
-    // A malformed export could carry `params` as some other JSON type;
-    // that must not be misread as an empty/planar intrinsics export.
-    expect(detectExportKind({ params: "not-an-object" })).toBe("unknown");
-    expect(detectExportKind({ params: [] })).toBe("unknown");
-    expect(detectExportKind({ params: null })).toBe("unknown");
-  });
-
-  // Probe order runs most-specific first: a laser-rig hand-eye export carries
-  // `cameras` too, but the laser + hand-eye combination must win over the
-  // plain rig / single-cam classifications.
-  it("prefers the most specific kind when fields overlap", () => {
-    expect(
-      detectExportKind({
-        laser_planes_rig: [],
-        handeye_mode: "EyeInHand",
-        cameras: [],
-        camera: {},
-      }),
-    ).toBe("rig_handeye_laserline");
-    expect(detectExportKind({ cameras: [], handeye_mode: "EyeToHand", camera: {} })).toBe(
-      "rig_handeye",
-    );
+    expect(detectExportKind({ kind: 42 })).toBe("unknown");
+    expect(detectExportKind({ kind: null })).toBe("unknown");
   });
 });
 

--- a/app/src/store/exportKind.ts
+++ b/app/src/store/exportKind.ts
@@ -1,4 +1,5 @@
 import type {
+  ExportKind as WireExportKind,
   LaserlineDeviceExport,
   PlanarIntrinsicsExport,
   RigExtrinsicsExport,
@@ -10,8 +11,9 @@ import type {
 } from "../types/generated/diagnose-wire";
 
 /** Discriminated union over every calibration export the diagnose app can
- * load. Members are the generated (Rust-sourced) `*Export` interfaces, so
- * this stays in lockstep with the pipeline via `bun run generate:types`. */
+ * load. Members are the generated (Rust-sourced) `*Export` interfaces, each
+ * carrying its own `kind` discriminator (R7), so this stays in lockstep with
+ * the pipeline via `bun run generate:types`. */
 export type CalibrationExport =
   | PlanarIntrinsicsExport
   | ScheimpflugIntrinsicsExport
@@ -22,107 +24,47 @@ export type CalibrationExport =
   | RigLaserlineDeviceExport
   | RigHandeyeLaserlineExport;
 
-/** Discriminator for the loaded calibration export. */
-export type ExportKind =
-  | "planar_intrinsics"
-  | "scheimpflug_intrinsics"
-  | "single_cam_handeye"
-  | "laserline_device"
-  | "rig_extrinsics"
-  | "rig_handeye"
-  | "rig_handeye_laserline"
-  | "rig_laserline_device"
-  | "unknown";
+/** Discriminator for the loaded calibration export: the eight wire kinds
+ * (from the generated {@link WireExportKind}) plus a UI-only `"unknown"`
+ * sentinel for payloads that carry no recognised tag. */
+export type ExportKind = WireExportKind | "unknown";
 
-// Distinguishing field names, pinned to the generated interfaces via
-// `satisfies keyof …`. If a Rust field is renamed and the types are
-// regenerated, these stop compiling — which is the whole point: the
-// discriminator can no longer silently drift from the export shape.
-const F_HANDEYE_MODE = "handeye_mode" satisfies keyof RigHandeyeExport &
-  keyof SingleCamHandeyeExport &
-  keyof RigHandeyeLaserlineExport;
-const F_CAMERAS = "cameras" satisfies keyof RigExtrinsicsExport & keyof RigHandeyeExport;
-const F_CAMERA = "camera" satisfies keyof SingleCamHandeyeExport;
-const F_LASER_PLANES_RIG = "laser_planes_rig" satisfies keyof RigLaserlineDeviceExport &
-  keyof RigHandeyeLaserlineExport;
-const F_ESTIMATE = "estimate" satisfies keyof LaserlineDeviceExport;
-const F_STATS = "stats" satisfies keyof LaserlineDeviceExport;
-const F_PARAMS = "params" satisfies keyof PlanarIntrinsicsExport &
-  keyof ScheimpflugIntrinsicsExport;
-
-/** Narrows `value` to a plain (non-null, non-array) object — guards the
- * `params` cast below against malformed exports where the field exists
- * but isn't a record (e.g. a string or array). */
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/** Sensor-model tag inside `*IntrinsicsExport.params.camera.sensor`, the only
- * place planar and Scheimpflug single-camera exports differ (their top-level
- * shapes are identical). */
-function intrinsicsSensorTag(params: Record<string, unknown>): string | undefined {
-  const camera = params.camera as { sensor?: { type?: unknown } } | undefined;
-  const tag = camera?.sensor?.type;
-  return typeof tag === "string" ? tag : undefined;
-}
-
-/** Classify a loaded export by its distinguishing required fields.
+/** Human-readable labels for the diagnose header, keyed by wire kind.
  *
- * Grounded in the generated `*Export` shapes rather than the JSON-sniffing
- * of the retired `exportShape.ts`: those probes read top-level `camera` /
- * `laser_planes_cam` fields that the real exports never carry (they live
- * under `params` / `estimate`). Probe order runs most-specific first —
- * laser-rig before rig, rig before single-camera. */
+ * This `Record` is the single source of truth for both the label vocabulary
+ * *and* the set of recognised kinds (see {@link detectExportKind}). Typing it
+ * `Record<WireExportKind, string>` pins it to the generated union: adding or
+ * renaming a Rust `ExportKind` variant and regenerating the types forces a
+ * matching edit here, or the build fails. */
+const WIRE_KIND_LABELS: Record<WireExportKind, string> = {
+  planar_intrinsics: "Planar intrinsics",
+  scheimpflug_intrinsics: "Scheimpflug intrinsics",
+  single_cam_handeye: "Single-cam hand-eye",
+  laserline_device: "Laserline device",
+  rig_extrinsics: "Rig extrinsics",
+  rig_handeye: "Rig hand-eye",
+  rig_laserline_device: "Rig + laserline",
+  rig_handeye_laserline: "Rig hand-eye + laserline",
+};
+
+/** Narrows an arbitrary string to a known wire kind. */
+function isWireExportKind(kind: string): kind is WireExportKind {
+  return Object.prototype.hasOwnProperty.call(WIRE_KIND_LABELS, kind);
+}
+
+/** Classify a loaded export by its `kind` discriminator (R7).
+ *
+ * Every pipeline `*Export` serializes a required `kind` tag, so classification
+ * is a single field read validated against the known vocabulary — no more
+ * probing which required fields happen to be present. A payload that is not an
+ * object, or whose `kind` is missing / unrecognised, is `"unknown"`. */
 export function detectExportKind(data: unknown): ExportKind {
   if (data == null || typeof data !== "object") return "unknown";
-  const d = data as Record<string, unknown>;
-  const has = (k: string) => d[k] != null;
-
-  // Rig + laser flavours carry per-camera laser planes in the rig frame.
-  if (has(F_LASER_PLANES_RIG)) {
-    return has(F_HANDEYE_MODE) ? "rig_handeye_laserline" : "rig_laserline_device";
-  }
-  // Single-camera laser device: bundle estimate + laser stats, no rig planes.
-  if (has(F_ESTIMATE) && has(F_STATS)) return "laserline_device";
-  // Multi-camera rig: a `cameras` array (with or without hand-eye).
-  if (has(F_CAMERAS)) {
-    return has(F_HANDEYE_MODE) ? "rig_handeye" : "rig_extrinsics";
-  }
-  // Single-camera hand-eye: one `camera` plus a hand-eye mode.
-  if (has(F_CAMERA) && has(F_HANDEYE_MODE)) return "single_cam_handeye";
-  // Single-camera intrinsics: `params`; planar vs Scheimpflug by sensor model.
-  // `params` must be a plain object — a malformed export where it's some
-  // other JSON type (string, array, …) falls through to "unknown" instead
-  // of silently defaulting to planar.
-  const params = d[F_PARAMS];
-  if (isPlainObject(params)) {
-    return intrinsicsSensorTag(params) === "scheimpflug"
-      ? "scheimpflug_intrinsics"
-      : "planar_intrinsics";
-  }
-  return "unknown";
+  const kind = (data as { kind?: unknown }).kind;
+  return typeof kind === "string" && isWireExportKind(kind) ? kind : "unknown";
 }
 
 /** Human-readable label for an export kind, for the diagnose header. */
 export function exportKindLabel(kind: ExportKind): string {
-  switch (kind) {
-    case "planar_intrinsics":
-      return "Planar intrinsics";
-    case "scheimpflug_intrinsics":
-      return "Scheimpflug intrinsics";
-    case "single_cam_handeye":
-      return "Single-cam hand-eye";
-    case "laserline_device":
-      return "Laserline device";
-    case "rig_extrinsics":
-      return "Rig extrinsics";
-    case "rig_handeye":
-      return "Rig hand-eye";
-    case "rig_handeye_laserline":
-      return "Rig hand-eye + laserline";
-    case "rig_laserline_device":
-      return "Rig + laserline";
-    case "unknown":
-      return "Unknown export";
-  }
+  return kind === "unknown" ? "Unknown export" : WIRE_KIND_LABELS[kind];
 }

--- a/app/src/store/types.ts
+++ b/app/src/store/types.ts
@@ -1,5 +1,10 @@
 import type { FrameKey, ImageManifest, PerFeatureResiduals } from "../types";
-import type { Camera, Iso3Schema, LaserPlane } from "../types/generated/diagnose-wire";
+import type {
+  Camera,
+  ExportKind as WireExportKind,
+  Iso3Schema,
+  LaserPlane,
+} from "../types/generated/diagnose-wire";
 
 // The export discriminator now lives next to `detectExportKind`, its single
 // consumer-facing definition (B-QUAL2). Re-exported here so existing
@@ -34,6 +39,11 @@ export type LaserPlaneWire = LaserPlane;
  * optional and refined inside Viewer3DWorkspace / EpipolarWorkspace
  * once those phases land. */
 export interface AnyExport {
+  /** Export-type discriminator (R7). Present on every export the current
+   * pipeline emits; typed optional only because `AnyExport` is a loose
+   * structural view (a pre-R7 or hand-edited payload may omit it, in which
+   * case `detectExportKind` returns `"unknown"`). */
+  kind?: WireExportKind;
   per_feature_residuals: PerFeatureResiduals;
   image_manifest?: ImageManifest;
   /** All current exports carry this, but treat it as optional: exports

--- a/app/src/test/exportFixtures.ts
+++ b/app/src/test/exportFixtures.ts
@@ -50,6 +50,7 @@ export const LASER_RESIDUAL: LaserFeatureResidual = {
  * `DiagnoseWorkspace` / the e2e smoke spec to have one frame and one
  * residual to draw. */
 export const PLANAR_EXPORT_FIXTURE = {
+  kind: "planar_intrinsics",
   params: { camera: { sensor: { type: "identity" } } },
   per_feature_residuals: { target: [TARGET_RESIDUAL] },
   image_manifest: TARGET_MANIFEST,

--- a/app/src/types/generated/diagnose-wire.ts
+++ b/app/src/types/generated/diagnose-wire.ts
@@ -18,6 +18,23 @@
  */
 export type FrameKind = "target" | "laser";
 /**
+ * Identifies which calibration `*Export` a JSON payload holds.
+ *
+ * One variant per pipeline problem type, serialized as the snake_case module
+ * name in the `kind` field of every `*Export`. Consumers (the desktop app's
+ * `detectExportKind`, downstream tooling) read this single tag rather than
+ * sniffing field presence.
+ */
+export type ExportKind =
+  | "planar_intrinsics"
+  | "scheimpflug_intrinsics"
+  | "single_cam_handeye"
+  | "laserline_device"
+  | "rig_extrinsics"
+  | "rig_handeye"
+  | "rig_laserline_device"
+  | "rig_handeye_laserline";
+/**
  * Serializable distortion model parameters.
  */
 export type DistortionParams =
@@ -350,6 +367,10 @@ export interface LaserlineDeviceExport {
    * calibration pipeline never reads this field.
    */
   image_manifest?: ImageManifest | null;
+  /**
+   * Export-type discriminator (R7) — always [`ExportKind::LaserlineDevice`].
+   */
+  kind: ExportKind;
   /**
    * Mean reprojection error (pixels).
    */
@@ -793,6 +814,10 @@ export interface PlanarIntrinsicsExport {
    */
   image_manifest?: ImageManifest | null;
   /**
+   * Export-type discriminator (R7) — always [`ExportKind::PlanarIntrinsics`].
+   */
+  kind: ExportKind;
+  /**
    * Mean reprojection error (pixels).
    */
   mean_reproj_error: number;
@@ -876,6 +901,10 @@ export interface RigExtrinsicsExport {
    * this field.
    */
   image_manifest?: ImageManifest | null;
+  /**
+   * Export-type discriminator (R7) — always [`ExportKind::RigExtrinsics`].
+   */
+  kind: ExportKind;
   /**
    * Mean reprojection error (pixels).
    */
@@ -972,6 +1001,10 @@ export interface RigHandeyeExport {
    */
   image_manifest?: ImageManifest | null;
   /**
+   * Export-type discriminator (R7) — always [`ExportKind::RigHandeye`].
+   */
+  kind: ExportKind;
+  /**
    * Mean reprojection error (pixels).
    */
   mean_reproj_error: number;
@@ -1044,6 +1077,10 @@ export interface RigHandeyeLaserlineExport {
    * Optional image manifest populated by app/dataset runners.
    */
   image_manifest?: ImageManifest | null;
+  /**
+   * Export-type discriminator (R7) — always [`ExportKind::RigHandeyeLaserline`].
+   */
+  kind: ExportKind;
   /**
    * Per-camera laser planes in camera frame.
    */
@@ -1163,6 +1200,10 @@ export interface RigLaserlineDeviceExport {
    */
   image_manifest?: ImageManifest | null;
   /**
+   * Export-type discriminator (R7) — always [`ExportKind::RigLaserlineDevice`].
+   */
+  kind: ExportKind;
+  /**
    * Per-camera laser planes in their own camera frames.
    */
   laser_planes_cam: LaserPlane[];
@@ -1208,6 +1249,10 @@ export interface ScheimpflugIntrinsicsExport {
    * the calibration pipeline never reads this field.
    */
   image_manifest?: ImageManifest | null;
+  /**
+   * Export-type discriminator (R7) — always [`ExportKind::ScheimpflugIntrinsics`].
+   */
+  kind: ExportKind;
   /**
    * Mean per-point reprojection error in pixels.
    */
@@ -1287,6 +1332,10 @@ export interface SingleCamHandeyeExport {
    * the calibration pipeline never reads this field.
    */
   image_manifest?: ImageManifest | null;
+  /**
+   * Export-type discriminator (R7) — always [`ExportKind::SingleCamHandeye`].
+   */
+  kind: ExportKind;
   /**
    * Mean reprojection error (pixels).
    */

--- a/app/src/workspaces/DiagnoseWorkspace/DiagnoseWorkspace.test.tsx
+++ b/app/src/workspaces/DiagnoseWorkspace/DiagnoseWorkspace.test.tsx
@@ -37,6 +37,7 @@ const TARGET_MANIFEST_EXPORT = PLANAR_EXPORT_FIXTURE;
 // laser-kind frame + laser residuals — exercises the laser-view branch
 // (`hasLaser` in index.tsx).
 const LASER_MANIFEST_EXPORT = {
+  kind: "laserline_device",
   estimate: {},
   stats: {},
   per_feature_residuals: { target: [], laser: [LASER_RESIDUAL] },

--- a/app/src/workspaces/RunWorkspace/RunWorkspace.test.tsx
+++ b/app/src/workspaces/RunWorkspace/RunWorkspace.test.tsx
@@ -49,6 +49,7 @@ const DEFAULT_CONFIG = {
 const RUN_SUCCESS_RESPONSE = {
   kind: "ok",
   export: {
+    kind: "planar_intrinsics",
     per_feature_residuals: { target: [] },
     image_manifest: { root: ".", frames: [{ pose: 0, camera: 0, path: "frame0.png" }] },
     mean_reproj_error: 0.31,

--- a/crates/vision-calibration-pipeline/src/analysis/tests.rs
+++ b/crates/vision-calibration-pipeline/src/analysis/tests.rs
@@ -10,6 +10,7 @@
 
 use super::*;
 
+use crate::common::ExportKind;
 use nalgebra::{SVector, Translation3, UnitQuaternion, Vector3};
 use vision_calibration_core::{
     BrownConrady5, CorrespondenceView, FxFyCxCySkew, NoMeta, PerFeatureResiduals, RigView,
@@ -281,6 +282,7 @@ fn rig_handeye_report_with_rig_stage_has_three_levels() {
     let mut per_feature_residuals = PerFeatureResiduals::default();
     per_feature_residuals.target = target;
     let export = RigHandeyeExport {
+        kind: ExportKind::RigHandeye,
         cameras,
         sensors: None,
         cam_se3_rig: cam_se3_rig.clone(),

--- a/crates/vision-calibration-pipeline/src/common/export_kind.rs
+++ b/crates/vision-calibration-pipeline/src/common/export_kind.rs
@@ -1,0 +1,74 @@
+//! Export-type discriminator (R7).
+//!
+//! Every pipeline `*Export` carries a `kind: ExportKind` tag as its first
+//! field so consumers narrow on a single value instead of probing which
+//! required fields are present. The tag serializes snake_case
+//! (`"planar_intrinsics"`, …) — the same vocabulary as the problem-module
+//! names — and is **required** on deserialize: a missing tag is an error, not
+//! a silent default. The 0.7.0 breaking window regenerates every committed
+//! export so nothing relies on the pre-tag shape.
+
+use serde::{Deserialize, Serialize};
+
+/// Identifies which calibration `*Export` a JSON payload holds.
+///
+/// One variant per pipeline problem type, serialized as the snake_case module
+/// name in the `kind` field of every `*Export`. Consumers (the desktop app's
+/// `detectExportKind`, downstream tooling) read this single tag rather than
+/// sniffing field presence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ExportKind {
+    /// [`PlanarIntrinsicsExport`](crate::planar_intrinsics::PlanarIntrinsicsExport).
+    PlanarIntrinsics,
+    /// [`ScheimpflugIntrinsicsExport`](crate::scheimpflug_intrinsics::ScheimpflugIntrinsicsExport).
+    ScheimpflugIntrinsics,
+    /// [`SingleCamHandeyeExport`](crate::single_cam_handeye::SingleCamHandeyeExport).
+    SingleCamHandeye,
+    /// [`LaserlineDeviceExport`](crate::laserline_device::LaserlineDeviceExport).
+    LaserlineDevice,
+    /// [`RigExtrinsicsExport`](crate::rig_extrinsics::RigExtrinsicsExport).
+    RigExtrinsics,
+    /// [`RigHandeyeExport`](crate::rig_handeye::RigHandeyeExport).
+    RigHandeye,
+    /// [`RigLaserlineDeviceExport`](crate::rig_laserline_device::RigLaserlineDeviceExport).
+    RigLaserlineDevice,
+    /// [`RigHandeyeLaserlineExport`](crate::rig_handeye_laserline::RigHandeyeLaserlineExport).
+    RigHandeyeLaserline,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ExportKind::PlanarIntrinsics).unwrap(),
+            "\"planar_intrinsics\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ExportKind::RigHandeyeLaserline).unwrap(),
+            "\"rig_handeye_laserline\""
+        );
+    }
+
+    #[test]
+    fn roundtrips_every_variant() {
+        for kind in [
+            ExportKind::PlanarIntrinsics,
+            ExportKind::ScheimpflugIntrinsics,
+            ExportKind::SingleCamHandeye,
+            ExportKind::LaserlineDevice,
+            ExportKind::RigExtrinsics,
+            ExportKind::RigHandeye,
+            ExportKind::RigLaserlineDevice,
+            ExportKind::RigHandeyeLaserline,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: ExportKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+}

--- a/crates/vision-calibration-pipeline/src/common/mod.rs
+++ b/crates/vision-calibration-pipeline/src/common/mod.rs
@@ -19,10 +19,16 @@
 //! SolverConfig`, ...). Those are persisted configuration; the types at this
 //! module's top level are ephemeral per-call step overrides. Keeping them in
 //! separate modules avoids confusing the two.
+//!
+//! [`ExportKind`] is the shared export vocabulary (R7): the serde
+//! discriminator every `*Export` carries.
 
 /// Shared config sub-structs embedded by grouped top-level `*Config` types
 /// (ADR 0024).
 pub mod config;
+
+mod export_kind;
+pub use export_kind::ExportKind;
 
 /// Options for an intrinsics initialization step.
 ///

--- a/crates/vision-calibration-pipeline/src/dataset_runner/laser.rs
+++ b/crates/vision-calibration-pipeline/src/dataset_runner/laser.rs
@@ -871,6 +871,7 @@ fn rig_se3_target_from_chain(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::ExportKind;
     use serde_json::json;
     use std::io::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1229,6 +1230,7 @@ mod tests {
             skew: 0.0,
         };
         RigHandeyeExport {
+            kind: ExportKind::RigHandeye,
             cameras: (0..num_cameras)
                 .map(|_| make_pinhole_camera(k, BrownConrady5::default()))
                 .collect(),

--- a/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/laserline_device/problem.rs
@@ -12,6 +12,7 @@ use vision_calibration_optim::{
     LaserlineSolveOptions, LaserlineStats, compute_laserline_feature_residuals,
 };
 
+use crate::common::ExportKind;
 use crate::common::config::{IntrinsicsInitConfig, SolverConfig};
 use crate::session::{InvalidationPolicy, ProblemState, ProblemType};
 
@@ -141,6 +142,8 @@ pub struct LaserlineDeviceOutput {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct LaserlineDeviceExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::LaserlineDevice`].
+    pub kind: ExportKind,
     /// Pipeline output including optimized parameters and summary statistics.
     pub estimate: LaserlineEstimate,
     /// Laserline statistics payload.
@@ -251,6 +254,7 @@ impl ProblemType for LaserlineDeviceProblem {
         per_feature_residuals.target_hist_per_camera = Some(vec![target_hist]);
         per_feature_residuals.laser_hist_per_camera = Some(vec![laser_hist]);
         Ok(LaserlineDeviceExport {
+            kind: ExportKind::LaserlineDevice,
             estimate: output.estimate.clone(),
             stats: output.stats.clone(),
             mean_reproj_error: output.stats.mean_reproj_error,

--- a/crates/vision-calibration-pipeline/src/planar_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/planar_intrinsics/problem.rs
@@ -15,6 +15,7 @@ use vision_calibration_optim::{
     PlanarIntrinsicsSolveOptions, SolveReport,
 };
 
+use crate::common::ExportKind;
 use crate::common::config::{IntrinsicsInitConfig, SolverConfig};
 use crate::session::{InvalidationPolicy, ProblemState, ProblemType};
 
@@ -134,6 +135,8 @@ impl PlanarIntrinsicsConfig {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct PlanarIntrinsicsExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::PlanarIntrinsics`].
+    pub kind: ExportKind,
     /// Calibrated parameters.
     pub params: PlanarIntrinsicsParams,
     /// Solver report.
@@ -230,6 +233,7 @@ impl ProblemType for PlanarIntrinsicsProblem {
         per_feature_residuals.target = target;
         per_feature_residuals.target_hist_per_camera = Some(vec![target_hist]);
         Ok(PlanarIntrinsicsExport {
+            kind: ExportKind::PlanarIntrinsics,
             params: output.params.clone(),
             report: output.report.clone(),
             mean_reproj_error: output.mean_reproj_error,
@@ -661,6 +665,7 @@ mod tests {
         )
         .expect("valid params");
         let mut export = PlanarIntrinsicsExport {
+            kind: ExportKind::PlanarIntrinsics,
             params,
             report: SolveReport {
                 final_cost: 0.0,

--- a/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_extrinsics/problem.rs
@@ -17,6 +17,7 @@ use vision_calibration_optim::{
 
 pub use crate::rig_family::SensorMode;
 
+use crate::common::ExportKind;
 use crate::common::config::{IntrinsicsInitConfig, RigConfig, SolverConfig};
 use crate::session::{InvalidationPolicy, ProblemState, ProblemType};
 
@@ -147,6 +148,9 @@ impl RigExtrinsicsOutput {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigExtrinsicsExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::RigExtrinsics`].
+    pub kind: ExportKind,
+
     /// Per-camera calibrated intrinsics + distortion (pinhole core).
     pub cameras: Vec<PinholeCamera>,
 
@@ -386,6 +390,7 @@ impl ProblemType for RigExtrinsicsProblem {
         per_feature_residuals.target = target;
         per_feature_residuals.target_hist_per_camera = Some(target_hist_per_camera);
         Ok(RigExtrinsicsExport {
+            kind: ExportKind::RigExtrinsics,
             cameras: output.cameras().to_vec(),
             sensors: output.sensors().map(|s| s.to_vec()),
             cam_se3_rig,

--- a/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye/problem.rs
@@ -20,6 +20,7 @@ use vision_calibration_optim::{HandEyeParams, RobustLoss, SolveReport};
 
 pub use crate::rig_family::SensorMode;
 
+use crate::common::ExportKind;
 use crate::common::config::{
     HandeyeInitConfig, IntrinsicsInitConfig, RigConfig, RobotPoseConfig, SolverConfig,
 };
@@ -216,6 +217,9 @@ impl RigHandeyeOutput {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::RigHandeye`].
+    pub kind: ExportKind,
+
     /// Per-camera calibrated intrinsics + distortion (pinhole core).
     pub cameras: Vec<PinholeCamera>,
 
@@ -537,6 +541,7 @@ impl ProblemType for RigHandeyeProblem {
         per_feature_residuals.target = target;
         per_feature_residuals.target_hist_per_camera = Some(target_hist_per_camera);
         Ok(RigHandeyeExport {
+            kind: ExportKind::RigHandeye,
             cameras: output.cameras().to_vec(),
             sensors: output.sensors().map(|s| s.to_vec()),
             cam_se3_rig,

--- a/crates/vision-calibration-pipeline/src/rig_handeye_laserline/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_handeye_laserline/problem.rs
@@ -1,6 +1,7 @@
 //! [`ProblemType`] implementation for joint rig hand-eye laserline calibration.
 
 use crate::Error;
+use crate::common::ExportKind;
 use crate::common::config::{RobotPoseConfig, SolverConfig};
 use crate::rig_handeye::{RigHandeyeConfig, RigHandeyeProblem};
 use crate::rig_laserline_device::{RigLaserlineDeviceConfig, RigLaserlineDeviceProblem};
@@ -204,6 +205,8 @@ impl Default for RigHandeyeLaserlineBaConfig {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigHandeyeLaserlineExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::RigHandeyeLaserline`].
+    pub kind: ExportKind,
     /// Per-camera laser planes in rig frame.
     pub laser_planes_rig: Vec<LaserPlane>,
     /// Per-camera laser planes in camera frame.
@@ -414,6 +417,7 @@ pub(crate) fn export_joint(
     };
 
     Ok(RigHandeyeLaserlineExport {
+        kind: ExportKind::RigHandeyeLaserline,
         laser_planes_rig: estimate.planes_rig.clone(),
         laser_planes_cam: params.planes_cam.clone(),
         per_camera_stats: estimate.per_cam_stats.clone(),

--- a/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
+++ b/crates/vision-calibration-pipeline/src/rig_laserline_device/problem.rs
@@ -13,6 +13,7 @@ use vision_calibration_optim::{
     compute_rig_laserline_feature_residuals,
 };
 
+use crate::common::ExportKind;
 use crate::common::config::SolverConfig;
 use crate::session::{InvalidationPolicy, ProblemState, ProblemType};
 
@@ -146,6 +147,8 @@ impl Default for RigLaserlineDeviceConfig {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct RigLaserlineDeviceExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::RigLaserlineDevice`].
+    pub kind: ExportKind,
     /// Per-camera laser planes in rig frame.
     pub laser_planes_rig: Vec<LaserPlane>,
     /// Per-camera laser planes in their own camera frames.
@@ -359,6 +362,7 @@ impl ProblemType for RigLaserlineDeviceProblem {
         per_feature_residuals.target_hist_per_camera = Some(target_hist_per_camera);
         per_feature_residuals.laser_hist_per_camera = Some(laser_hist_per_camera);
         Ok(RigLaserlineDeviceExport {
+            kind: ExportKind::RigLaserlineDevice,
             laser_planes_rig: output.laser_planes_rig.clone(),
             laser_planes_cam: output.laser_planes_cam.clone(),
             per_camera_stats: output.per_camera_stats.clone(),
@@ -387,6 +391,7 @@ mod tests {
         // tests can. This keeps the manifest tests independent of the
         // upstream calibration setup needed to drive `export()`.
         RigLaserlineDeviceExport {
+            kind: ExportKind::RigLaserlineDevice,
             laser_planes_rig: Vec::new(),
             laser_planes_cam: Vec::new(),
             per_camera_stats: Vec::new(),

--- a/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
+++ b/crates/vision-calibration-pipeline/src/scheimpflug_intrinsics/problem.rs
@@ -8,6 +8,7 @@ use vision_calibration_core::{
 };
 use vision_calibration_optim::{DistortionKind, SolveReport};
 
+use crate::common::ExportKind;
 use crate::common::config::{IntrinsicsInitConfig, SolverConfig};
 use crate::session::{InvalidationPolicy, ProblemState, ProblemType};
 
@@ -117,6 +118,8 @@ pub struct ScheimpflugIntrinsicsResult {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct ScheimpflugIntrinsicsExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::ScheimpflugIntrinsics`].
+    pub kind: ExportKind,
     /// Estimated parameters.
     pub params: ScheimpflugIntrinsicsParams,
     /// Backend solve report.
@@ -209,6 +212,7 @@ impl ProblemType for ScheimpflugIntrinsicsProblem {
         per_feature_residuals.target = target;
         per_feature_residuals.target_hist_per_camera = Some(vec![target_hist]);
         Ok(ScheimpflugIntrinsicsExport {
+            kind: ExportKind::ScheimpflugIntrinsics,
             params: output.params.clone(),
             report: output.report.clone(),
             mean_reproj_error: output.mean_reproj_error,

--- a/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
+++ b/crates/vision-calibration-pipeline/src/single_cam_handeye/problem.rs
@@ -11,6 +11,7 @@ use vision_calibration_core::{
 };
 use vision_calibration_optim::{HandEyeEstimate, HandEyeMode, handeye_observer_se3_target};
 
+use crate::common::ExportKind;
 use crate::common::config::{
     HandeyeInitConfig, IntrinsicsInitConfig, RobotPoseConfig, SolverConfig,
 };
@@ -107,6 +108,9 @@ pub struct SingleCamHandeyeConfig {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SingleCamHandeyeExport {
+    /// Export-type discriminator (R7) — always [`ExportKind::SingleCamHandeye`].
+    pub kind: ExportKind,
+
     /// Calibrated camera (intrinsics + distortion).
     pub camera: PinholeCamera,
 
@@ -327,6 +331,7 @@ impl ProblemType for SingleCamHandeyeProblem {
         per_feature_residuals.target = target;
         per_feature_residuals.target_hist_per_camera = Some(vec![target_hist]);
         Ok(SingleCamHandeyeExport {
+            kind: ExportKind::SingleCamHandeye,
             camera,
             handeye_mode: config.handeye_init.handeye_mode,
             gripper_se3_camera,

--- a/crates/vision-calibration-pipeline/tests/rig_laserline_device.rs
+++ b/crates/vision-calibration-pipeline/tests/rig_laserline_device.rs
@@ -265,6 +265,7 @@ fn pinhole_upstream_converges_rig_laserline() {
         .map(|(k, dist)| vision_calibration_core::make_pinhole_camera(*k, *dist))
         .collect();
     let export: RigHandeyeExport = serde_json::from_value(serde_json::json!({
+        "kind": "rig_handeye",
         "cameras": cameras,
         "sensors": null, // pinhole rig
         "cam_se3_rig": upstream.cam_se3_rig,

--- a/crates/vision-calibration/src/lib.rs
+++ b/crates/vision-calibration/src/lib.rs
@@ -135,7 +135,7 @@ pub mod session {
 /// SolverConfig`, ...).
 pub mod common {
     pub use vision_calibration_pipeline::common::{
-        HandeyeInitOptions, HandeyeOptimizeOptions, IntrinsicsInitOptions,
+        ExportKind, HandeyeInitOptions, HandeyeOptimizeOptions, IntrinsicsInitOptions,
         IntrinsicsOptimizeOptions,
     };
 

--- a/crates/vision-calibration/tests/pixel_to_gripper_point.rs
+++ b/crates/vision-calibration/tests/pixel_to_gripper_point.rs
@@ -42,6 +42,7 @@ fn make_eye_in_hand_export() -> RigHandeyeExport {
 
     let json = format!(
         r#"{{
+            "kind": "rig_handeye",
             "cameras": [{camera_json}],
             "sensors": [{sensor_json}],
             "cam_se3_rig": [{identity_json}],
@@ -85,6 +86,7 @@ fn make_eye_to_hand_export() -> RigHandeyeExport {
 
     let json = format!(
         r#"{{
+            "kind": "rig_handeye",
             "cameras": [{camera_json}],
             "sensors": [{sensor_json}],
             "cam_se3_rig": [{identity_json}],

--- a/docs/adrs/0018-schema-driven-ui.md
+++ b/docs/adrs/0018-schema-driven-ui.md
@@ -130,3 +130,26 @@ generated from these schemas (`app/src-tauri/src/bin/emit_schemas.rs` →
 replacing the hand-written mirrors and `inferExportKind` shape-sniffing.
 Config schemas remain the runtime source for `<ConfigForm/>`; export
 schemas are build-time codegen inputs only. Shipped with the 0.7.0 bump.
+
+## Amendment (2026-07-10, R7 — export discriminator)
+
+Shape-sniffing on the consumer side was the last vestige of the
+"probe which required fields are present" contract. Every pipeline
+`*Export` now serializes a **required** `kind` discriminator — a shared
+`ExportKind` unit enum (`vision_calibration::common::ExportKind`,
+`#[serde(rename_all = "snake_case")]`, one variant per problem type),
+set on construction and carried as each export's first field. Consumers
+narrow on the single tag; deserialize is strict (a missing `kind`
+errors, no `serde(default)`), so the tag is a hard contract rather than
+best-effort. The 0.7.0 breaking window regenerated every committed
+export, so nothing depends on the pre-tag wire shape.
+
+The enum derives `JsonSchema`, so it flows through the same
+`emit_schemas` → `diagnose_wire.json` → `diagnose-wire.ts` pipeline as a
+`"planar_intrinsics" | "scheimpflug_intrinsics" | …` union. The app's
+`detectExportKind` collapsed from ~50 lines of field probes to a single
+validated read of `data.kind` against that generated union; the label
+`Record<ExportKind, string>` is now the single source of both the label
+vocabulary and the recognised-kind set (a renamed/added Rust variant
+fails the TypeScript build until the record is updated). Python export
+result parsers read specific keys and ignore `kind` harmlessly.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -142,16 +142,23 @@ two-view/triangulation.
   verified already on ADR-0024 shapes (zero stale fields); one genuinely
   stale `pixel_to_gripper_point` facade path fixed in the puzzle-130x130
   walkthrough (R1-audit casualty). Index updated.
-- [ ] R7-EXPORT-DISCRIMINATOR - (raised by the PR #99 altitude review; do
-  inside the v0.7.0 breaking window, small standalone PR) Add a serde
-  discriminator (`kind` tag) to the eight `*Export` types so consumers
-  narrow on a tag instead of probing required-field presence. Deletes the
-  app's `detectExportKind` probe module (`app/src/store/exportKind.ts`) —
-  TS narrows on `.kind` from the schemars-generated union for free.
-  Migration cost is one-time and bounded pre-1.0: regenerate committed
-  fixture exports, app recents invalidate naturally, private exports are
-  regenerate-on-load. Deferring past 0.7.0 locks a wire format that can't
-  gain a discriminator without another break.
+- [x] R7-EXPORT-DISCRIMINATOR - **Done 2026-07-10.** Added a shared
+  `ExportKind` unit enum (`vision-calibration-pipeline` `common/export_kind.rs`,
+  `#[serde(rename_all = "snake_case")]`, one variant per problem type; re-exported
+  as `vision_calibration::common::ExportKind`) and a **required** `kind` field —
+  the first field — on all eight `*Export` structs, set on construction.
+  Deserialize is strict (no `serde(default)`): a missing tag errors, making the
+  discriminator a hard contract. The enum derives `JsonSchema`, so it flows
+  through `emit_schemas` → `diagnose_wire.json` → `diagnose-wire.ts` as a
+  `"planar_intrinsics" | …` union. App `detectExportKind` collapsed from ~50
+  lines of field probes to a validated read of `data.kind`; a label
+  `Record<ExportKind, string>` is now the single source of both labels and the
+  recognised-kind set (pinned to the generated union). Regenerated committed
+  exports (`data/stereo{,_charuco}/viewer_export.json`) and every hand-built
+  export JSON in tests; Python export parsers ignore `kind` harmlessly (40 py
+  tests green). ADR 0018 amended. Gates: fmt/clippy/test/doc, src-tauri
+  fmt/clippy/test + `emit_schemas --check`, app lint/format/typecheck/vitest
+  (27)/e2e (7), TS-gen idempotent.
 
 ## B-QUAL / B-UX / B-DIST — app to production grade (Phase III)
 

--- a/docs/tutorials/per-feature-residuals.md
+++ b/docs/tutorials/per-feature-residuals.md
@@ -24,6 +24,11 @@ field. The container is always present (`Default` is empty); empty inner
 (e.g., `PlanarIntrinsicsExport.per_feature_residuals.laser` is always
 empty).
 
+Each `*Export` also serializes a required `kind` discriminator
+(`ExportKind`, snake_case — `"planar_intrinsics"`, `"rig_handeye"`, …) as
+its first field, so a consumer that loads raw JSON can narrow on the single
+tag instead of probing which fields are present.
+
 ```
 PerFeatureResiduals
 ├─ target: Vec<TargetFeatureResidual>     // per-corner reprojection records


### PR DESCRIPTION
## Summary

Adds a `kind` serde discriminator to all eight pipeline `*Export` types (shared `ExportKind` enum, snake_case, `JsonSchema`-derived), raised by the PR #99 altitude review — done now because the 0.7.0 breaking window is the one-time chance to give the wire format a real tag.

- Strict contract: deserializing an export without `kind` is a hard error (no `serde(default)`).
- App: `detectExportKind` shrinks from ~50 lines of required-field probing to a validated tag read pinned to the generated TS union (a renamed Rust variant fails the TS build).
- Python bindings unaffected (payload parsers ignore extra keys) — verified, 42 tests green.

**Breaking**: pre-existing export JSONs (private datasets, saved viewer exports) must be regenerated; the app classifies untagged exports as `unknown` until then. Committed fixtures and hand-built test exports are updated in this PR.

## Verification
fmt / clippy `--all-features -D warnings` / `test --workspace --all-features` / doc `-D warnings` / maturin + 42 Python tests / src-tauri gates + `emit_schemas --check` / app lint+format+typecheck + 27 vitest + 7 Playwright + TS drift check — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)