### PR TITLE
release: v0.7.0 — lockstep bump, runbook, changelog

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -189,7 +189,8 @@ in CI:
    the one that `release-pypi.yml`'s `Verify tag/version sync` job
    reads directly. **Not** wired into `[workspace.package]`.
 4. `crates/vision-calibration-examples-private/Cargo.toml` (1 package
-   version + 4 path-dep pins). Out of the publish set but still
+   version + 6 path-dep pins — the count grows as it gains deps; grep,
+   don't trust this number). Out of the publish set but still
    compiled in CI.
 
 **Publish set (2026-06-17; DAG corrected 2026-07-04 to match

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,177 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-07-10
+
+`0.7.0` closes the production-grade program's Q (soundness close-out) and
+R (API/config revision) tracks, plus the C-track MVG surface (bundle
+adjustment, Scheimpflug-aware rectification, dense stereo matching), the
+S-track device-spec seeding layer, and the D1 typed-error ratchet across
+the remaining crates. It is the largest batch of pre-1.0 breaking changes
+since `0.5.0`, collected here rather than dribbled across patch releases.
+
+### Changed (breaking, pre-1.0)
+
+- **ADR 0024 config vocabulary (R2–R4).** All eight problem configs move
+  onto shared grouped structs — `IntrinsicsInitConfig` / `SolverConfig` /
+  `RobotPoseConfig` / `HandeyeInitConfig`
+  (`vision_calibration_pipeline::common::config`, facade re-exported) —
+  and one fix-mask idiom (`CameraFixMask` / `ScheimpflugFixMask`) instead
+  of boolean trios. `fix_intrinsics` + `fix_distortion` collapse into
+  `CameraFixMask`; `fix_first_pose` becomes `fix_poses = [0]`.
+  `fix_first_rig_pose` and `fix_first_camera_extrinsic` are **deleted** —
+  `reference_camera_idx` is now the sole gauge choice (this also fixed an
+  index-0 hard-coding bug; several committed baselines improved measurably,
+  e.g. `stereo_charuco` 0.5509 → 0.5359 px mean reprojection).
+  `RigExtrinsicsConfig`, `RigHandeyeConfig`, `LaserlineDeviceConfig`, and
+  `RigLaserlineDeviceConfig` all reshape to the grouped form; five old
+  `RigHandeye*` sub-structs are gone. `SensorMode::Scheimpflug`'s
+  `fix_scheimpflug_in_intrinsics` field is renamed `fix_scheimpflug`. See
+  [ADR 0024](docs/adrs/0024-config-vocabulary.md).
+- **R1 API-surface cleanup.** Deleted the deprecated
+  `pixel_to_gripper_point` shim and `LaserlinePlaneSolver::from_view`;
+  merged the duplicate `ScheimpflugFixMask` definitions into the one optim
+  type (pipeline re-exports it); consolidated residual/histogram
+  diagnostics under `vision_calibration::analysis`. New facade modules
+  (`dataset` / `dataset_runner` / `detect`) plus core `Mat3`,
+  `distort_to_pixel`, `pixel_to_normalized`, `CameraModel` let consumers go
+  facade-only.
+- **Export `kind` discriminator is now required (R7).** All eight
+  `*Export` types gain a shared `ExportKind` tag (snake_case serde +
+  JsonSchema) set at every construction site; deserialization is strict —
+  an export JSON without `kind` is now a hard error instead of a
+  best-effort field-shape guess. **Pre-0.7.0 export JSON must be
+  regenerated** before the app or a saved fixture can load it again.
+- **Two-view geometry solvers relocated (C1-FOLLOWUP).**
+  `homography` / `epipolar` / `triangulation` / `camera_matrix` move from
+  `vision_calibration::linear` to a new `vision_calibration::geometry`
+  module backed by the `vision-geometry` crate;
+  `vision-calibration-linear` now depends on `vision-geometry` and drops
+  ~1,800 LoC of duplicated solvers. `vision-geometry` / `vision-mvg` gain
+  typed `GeometryError` / `MvgError` (`thiserror`, `#[non_exhaustive]`),
+  replacing `anyhow` on their public surface.
+- **`vision-calibration-optim` / `-detect` / `-pipeline` / `-linear` are
+  fully typed-error, `anyhow`-free on their library surfaces (D1).**
+  New/changed error variants across all four crates (e.g. optim gains
+  `Error::numerical`, linear gains `NoValidMotionPairs`); no
+  `vision-calibration*` library crate carries `anyhow` in
+  `[dependencies]` any more (dev-only, for doctests).
+- **`PlanarIntrinsicsParams.camera` generalized to the model-agnostic
+  `CameraParams` enum (M-WIRE).** Was the concrete Brown-Conrady
+  `PinholeCamera`; `pinhole_camera()` now returns `Result` (errors for
+  extended models). `PlanarIntrinsicsConfig`, `ScheimpflugIntrinsicsConfig`,
+  and rig `SensorMode::Scheimpflug` gain `distortion_model: DistortionKind`
+  (`#[serde(default)]` → Brown-Conrady5, so existing configs keep working)
+  selecting between Brown-Conrady5, Rational8, ThinPrism9, and Division1.
+- **Python bindings (R5).** Result cameras are now polymorphic
+  (`PinholeCamera` / `PinholeScheimpflugCamera` with a `Distortion` union)
+  instead of one fixed dataclass shape; **`PinholeBrownConradyScheimpflugCamera`
+  is renamed `PinholeScheimpflugCamera`.** `distortion_model` and
+  `SensorMode` (`Pinhole` / `Scheimpflug`) are now mirrored on the
+  relevant config dataclasses.
+
+### Added
+
+- **`vision-mvg::bundle_adjust` (C3).** Frozen-intrinsics bundle
+  adjustment refining camera poses + 3D structure by reprojection error,
+  behind the `refine` feature; gauge fix via `fix_first_camera` (anchors
+  the lowest-index *observed* camera).
+- **`vision-mvg::rectification::rectify_stereo_pair` (C4).**
+  Scheimpflug-aware stereo rectification — sensor tilt collapses to a
+  homography on the normalized plane (`H_tilt⁻¹`), so a tilted-sensor pair
+  rectifies through standard Fusiello/Bouguet rectification and reduces
+  exactly to pinhole rectification at zero tilt. Validated against the
+  real Scheimpflug oracle dataset at 3.4e-13 px worst-case row
+  disagreement.
+- **`vision-mvg::dense` (C5).** Pure-Rust dense stereo matcher: ZNCC block
+  matching over summed-area tables with parabolic sub-pixel refinement and
+  three invalidation filters (min-correlation, uniqueness, left-right
+  consistency), plus opt-in Hirschmüller semi-global (SGM) cost
+  aggregation. ADR 0015 amended: the matcher ships pure-Rust in
+  `vision-mvg`; an OpenCV SGBM baseline is confined to the unpublished,
+  benchmark-only `vision-calibration-bench` crate.
+- **Facade `vision_calibration::mvg` (C-FACADE-MVG).** The MVG surface
+  (`pose_recovery`, `robust`, `cheirality`, `degeneracy`, `triangulation`,
+  `homography`, `rectification`, `residuals`, `dense`, `types`, `error`) is
+  now reachable from the facade, mirroring the `geometry` module; `refine`
+  gates `bundle_adjust`.
+- **`vision_calibration_dataset::device_spec` +
+  `vision_calibration_pipeline::device_seed`
+  ([ADR 0023](docs/adrs/0023-device-spec-seed-derivation.md), S1–S4).**
+  A `DeviceSpec` sidecar schema (datasheet-natural units: focal length,
+  pixel pitch, resolution, Scheimpflug mount angles, rig mechanical
+  layout) that derives ADR 0011 manual-init seeds — intrinsics, rig
+  layout, hand-eye mounts — instead of hand-coded per-example constants.
+  Facade re-export `vision_calibration::device_seed`; spec-seeded init is
+  now the **official calibration route**.
+- **`calib-bench accept` / `calib-bench basin` (S4, Q2, Q6).** One-command
+  acceptance harness iterating every registered dataset through the seeded
+  official route with a hard per-entry gate, committed Fit-record
+  baselines and drift gates (`--regression-tol`, `--freeze-baselines`),
+  and a convergence-basin study subcommand sweeping focal / tilt /
+  principal-point perturbations around the ADR 0023 seed.
+- **Proof-pack standard (Q1, Q8).** `docs/notes/README.md` documents the
+  Track Q math-note + synthetic-GT matrix test + property test + committed
+  Fit record pattern; math notes and matrix tests landed for planar
+  intrinsics, Scheimpflug intrinsics, hand-eye, rig extrinsics, laserline
+  bundle, and two-view/triangulation.
+- **App: Depth workspace (C-UI).** Dense stereo matching (block/SGM
+  toggle) through the C4 rectifier, plus depth-from-disparity reprojection
+  and an interactive 3D point cloud view (React-Three-Fiber, code-split).
+- **App: schema-driven TypeScript wire types (B-QUAL2).** `JsonSchema`
+  derives on all eight pipeline `Export` types generate
+  `app/src/types/generated/` via a `schema-export`-gated `emit_schemas`
+  binary; hand-written shape-sniffing (`exportShape.ts`) is deleted in
+  favor of the generated, `kind`-grounded `detectExportKind` (R7).
+- **App: run progress, cancel, and diagnostics (B-UX2 core).** Streamed
+  per-stage run progress with a working cancel button; sortable per-pose
+  residual stats table; cross-camera residual matrix; single-camera
+  laserline plane rendering in the 3D viewer.
+- **App: internal design system (B-UX1).** Shared `components/ui` set
+  (`Button`, `Panel`, `SectionHeader`, `Select`, `Table`, `Banner`, `Badge`,
+  `EmptyState`) adopted across all five workspaces; dark-mode contrast
+  fixes (light-mode `--brand` was failing WCAG AA).
+- **App: unsigned desktop bundles (B-DIST, `app-bundle.yml`).** macOS
+  (`.app` / `.dmg`) and Linux (AppImage / `.deb`) bundles built on
+  `workflow_dispatch` and `v*` tag pushes, uploaded as workflow-run
+  artifacts. Explicitly unsigned/unnotarized — see the workflow for
+  documented signing prerequisites.
+- **App CI (B-QUAL1, B-QUAL3, B-QUAL4).** ESLint 9 + Prettier + typecheck
+  jobs; 35 Vitest component tests; 7 Playwright smoke tests; repo-root
+  resolution no longer hard-codes an absolute path.
+- **Python: `run_rig_handeye_laserline` binding + `check_binding_parity.py`
+  guard (R5).** Closes the eighth problem-type binding gap found by the D3
+  parity audit; the parity script now runs in CI.
+- New tutorials: multiple-view geometry (C-MVG-TUTORIAL), distortion-model
+  selection, single-camera hand-eye, and an app walkthrough (R6).
+- ADR 0023 (DeviceSpec schema) and ADR 0024 (config vocabulary).
+
+### Fixed
+
+- **Exact 180° rotation mis-convergence (V8).** nalgebra's iterative
+  `Rotation3::from_matrix` silently mis-converges on exact 180° rotations
+  (wrong axis); the row-major pose loader and `base_se3_gripper` now use
+  an SVD polar-decomposition `nearest_rotation` instead. Robot poses at
+  exactly 180° (common on the rtv3d rigs) previously diverged hand-eye
+  calibration to ~1700 px reprojection error.
+- `bundle_adjust`'s gauge anchor now falls back to the lowest-index
+  *observed* camera instead of always fixing camera 0 (which left the
+  gauge free when camera 0 had no observations).
+- NaN-rejection regressions reintroduced by the D1 typed-error migration
+  (`ensure!(x > 0.0)` → `if x <= 0.0` is not NaN-equivalent) across 10
+  validation sites (robust-loss scales, robot-pose sigmas, bound checks).
+- Device-spec seed translations now convert the spec's millimetre drawing
+  units to the pipeline's metre world unit (caught before any consumer
+  shipped).
+- The synthetic dense-stereo fixture encoded the wrong disparity-sign
+  convention, silently failing any matcher that followed the documented
+  `d = x_left - x_right` convention.
+
+## [0.6.0] - 2026-06-17
+
+`0.6.0` promotes `vision-geometry` and `vision-mvg` to the crates.io
+publish set (nine publishable crates total). This section backfills the
+`Unreleased` entry that was never renamed/dated across the tag.
 
 ### Changed
 - **BREAKING (`vision-calibration-optim`): camera model as data in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,7 +3677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vision-calibration"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "calib-targets",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-bench"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "calib-targets",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "nalgebra",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-dataset"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "schemars",
  "serde",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-detect"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "calib-targets",
  "chess-corners",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-linear"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "log",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-optim"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "faer",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-pipeline"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-py"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "pyo3",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "vision-geometry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nalgebra",
  "thiserror 2.0.18",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "vision-mvg"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nalgebra",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 # MSRV is 1.93. Bumped from 1.88 on 2026-05-23 to drop the
 # `fixed`/`kiddo` lockfile pins that kept breaking under `cargo update`.
@@ -33,16 +33,16 @@ homepage = "https://vitalyvorobyev.github.io/calibration-rs"
 repository = "https://github.com/VitalyVorobyev/calibration-rs"
 
 [workspace.dependencies]
-vision-calibration = { path = "./crates/vision-calibration", version = "0.6.0" }
-vision-calibration-core = { path = "./crates/vision-calibration-core", version = "0.6.0" }
-vision-calibration-linear = { path = "./crates/vision-calibration-linear", version = "0.6.0" }
-vision-calibration-optim = { path = "./crates/vision-calibration-optim", version = "0.6.0" }
-vision-calibration-pipeline = { path = "./crates/vision-calibration-pipeline", version = "0.6.0" }
-vision-calibration-dataset = { path = "./crates/vision-calibration-dataset", version = "0.6.0" }
-vision-calibration-detect = { path = "./crates/vision-calibration-detect", version = "0.6.0" }
-vision-calibration-bench = { path = "./crates/vision-calibration-bench", version = "0.6.0" }
-vision-geometry = { path = "./crates/vision-geometry", version = "0.6.0" }
-vision-mvg = { path = "./crates/vision-mvg", version = "0.6.0" }
+vision-calibration = { path = "./crates/vision-calibration", version = "0.7.0" }
+vision-calibration-core = { path = "./crates/vision-calibration-core", version = "0.7.0" }
+vision-calibration-linear = { path = "./crates/vision-calibration-linear", version = "0.7.0" }
+vision-calibration-optim = { path = "./crates/vision-calibration-optim", version = "0.7.0" }
+vision-calibration-pipeline = { path = "./crates/vision-calibration-pipeline", version = "0.7.0" }
+vision-calibration-dataset = { path = "./crates/vision-calibration-dataset", version = "0.7.0" }
+vision-calibration-detect = { path = "./crates/vision-calibration-detect", version = "0.7.0" }
+vision-calibration-bench = { path = "./crates/vision-calibration-bench", version = "0.7.0" }
+vision-geometry = { path = "./crates/vision-geometry", version = "0.7.0" }
+vision-mvg = { path = "./crates/vision-mvg", version = "0.7.0" }
 
 anyhow = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bench/examples support crates):
 Add the facade crate to your `Cargo.toml`:
 
 ```toml
-vision-calibration = "0.6"
+vision-calibration = "0.7"
 ```
 
 Or track `main` directly:

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -6432,7 +6432,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vision-calibration"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "vision-calibration-core",
  "vision-calibration-dataset",
@@ -6446,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nalgebra",
  "rand 0.10.1",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-dataset"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6466,7 +6466,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-detect"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "calib-targets",
  "chess-corners",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-linear"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "log",
  "nalgebra",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-optim"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "faer",
  "faer-ext",
@@ -6505,7 +6505,7 @@ dependencies = [
 
 [[package]]
 name = "vision-calibration-pipeline"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "glob",
  "image",
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "vision-geometry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nalgebra",
  "thiserror 2.0.18",
@@ -6547,7 +6547,7 @@ dependencies = [
 
 [[package]]
 name = "vision-mvg"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nalgebra",
  "thiserror 2.0.18",

--- a/crates/vision-calibration-examples-private/Cargo.toml
+++ b/crates/vision-calibration-examples-private/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vision-calibration-examples-private"
 description = "Private end-to-end calibration examples using private sensor datasets"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 authors = ["Vitaly Vorobyev <vit.vorobiev@gmail.com>"]
@@ -18,12 +18,12 @@ missing_docs = "warn"
 workspace = true
 
 [dependencies]
-vision-calibration = { path = "../vision-calibration", version = "0.6.0" }
-vision-calibration-core = { path = "../vision-calibration-core", version = "0.6.0" }
-vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.6.0" }
-vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.6.0" }
-vision-calibration-detect = { path = "../vision-calibration-detect", version = "0.6.0" }
-vision-mvg = { path = "../vision-mvg", version = "0.6.0" }
+vision-calibration = { path = "../vision-calibration", version = "0.7.0" }
+vision-calibration-core = { path = "../vision-calibration-core", version = "0.7.0" }
+vision-calibration-optim = { path = "../vision-calibration-optim", version = "0.7.0" }
+vision-calibration-pipeline = { path = "../vision-calibration-pipeline", version = "0.7.0" }
+vision-calibration-detect = { path = "../vision-calibration-detect", version = "0.7.0" }
+vision-mvg = { path = "../vision-mvg", version = "0.7.0" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/vision-calibration-py/pyproject.toml
+++ b/crates/vision-calibration-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "vision-calibration"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python bindings for calibration-rs end-to-end camera calibration"
 readme = "README.md"
 authors = [{ name = "Vitaly Vorobyev", email = "vit.vorobiev@gmail.com" }]

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -180,7 +180,17 @@ python -m unittest discover -s crates/vision-calibration-py/tests -p "test_*.py"
 python3 scripts/check_pyi_coverage.py --check
 python3 scripts/check_binding_parity.py --check
 
-# 6. Publish dry-run in DAG order (§2) — catches E0432-style path-dep
+# 6. Full local acceptance — public AND private registries. The laser
+#    datasets (rtv3d family) hard-fail without the `laser` feature; plain
+#    `tier-b` is only enough for the public kuka subset that CI runs.
+cargo run --release -p vision-calibration-bench --features "tier-b laser" \
+  --bin calib-bench -- accept \
+  --registry crates/vision-calibration-bench/registry/public.json
+cargo run --release -p vision-calibration-bench --features "tier-b laser" \
+  --bin calib-bench -- accept \
+  --registry crates/vision-calibration-bench/registry/private.json
+
+# 7. Publish dry-run in DAG order (§2) — catches E0432-style path-dep
 #    resolution failures (§4) before they wedge the real publish job.
 for c in vision-calibration-core vision-geometry vision-calibration-dataset \
          vision-calibration-detect vision-calibration-linear \
@@ -189,7 +199,7 @@ for c in vision-calibration-core vision-geometry vision-calibration-dataset \
   cargo publish -p "$c" --dry-run --locked || break
 done
 
-# 7. Trusted Publishing coverage (§3) — manual crates.io UI check, one page
+# 8. Trusted Publishing coverage (§3) — manual crates.io UI check, one page
 #    per crate in the DAG. No CLI shortcut; just go look.
 ```
 

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -1,0 +1,217 @@
+# Release Runbook
+
+A checklist to follow under pressure when cutting a `calibration-rs`
+release. For the *why* behind each rule see `.claude/CLAUDE.md`'s
+"Releasing — version-source lockstep" section — that is the source of
+truth this runbook distills; if the two disagree, fix this file.
+
+We are pre-1.0: breaking changes are expected and are batched into a
+single minor (`0.x.0`) bump rather than dribbled across patch releases.
+
+## 1. Version sources — must move together
+
+Four files, updated in the **same commit**:
+
+1. `Cargo.toml` → `[workspace.package] version` (~line 21).
+2. `Cargo.toml` → `[workspace.dependencies]` path-dep `version = "…"`
+   pins for every publishable workspace crate (~lines 33–45). As of
+   0.7.0 that is **nine** crates: `vision-calibration-core`,
+   `vision-geometry`, `vision-calibration-dataset`,
+   `vision-calibration-detect`, `vision-calibration-linear`,
+   `vision-calibration-optim`, `vision-mvg`,
+   `vision-calibration-pipeline`, `vision-calibration`.
+3. `crates/vision-calibration-py/pyproject.toml` → `[project] version`.
+   **Not** wired into `[workspace.package]` — `release-pypi.yml`'s
+   `Verify tag/version sync` job reads this file directly and will
+   skip the wheel/sdist build + PyPI upload if it drifts.
+4. `crates/vision-calibration-examples-private/Cargo.toml` → the
+   package `version` **plus every path-dep `version = "…"` pin inside
+   it**. This crate is outside the crates.io publish set but is still
+   compiled in CI, so a stale pin here breaks the examples build, not
+   the release. **Count the pins before assuming there are four** — the
+   pin count tracks how many published crates the private examples
+   depend on and has grown over time (6 as of 0.7.0: `vision-calibration`,
+   `vision-calibration-core`, `vision-calibration-optim`,
+   `vision-calibration-pipeline`, `vision-calibration-detect`,
+   `vision-mvg`). Grep the file, don't trust a remembered number.
+
+After editing all four, refresh the lockfile once:
+
+```bash
+cargo build --workspace   # only workspace-crate version strings change in Cargo.lock
+```
+
+### The app crate is a fifth place to check, not a fifth lockstep source
+
+`app/src-tauri/Cargo.toml` has its own product `version` (currently
+`0.1.0`, independent of the workspace — do not bump it as part of a
+library release) but pulls in `vision-calibration` via a **path** dep.
+Check whether that path dep (or any other workspace-crate path dep in
+this file) carries a `version = "…"` constraint:
+
+- If it does not (current state), nothing to edit in the `.toml`, but
+  its **committed** `Cargo.lock` still resolves the workspace crate's
+  version string and must be refreshed:
+  ```bash
+  cargo build --manifest-path app/src-tauri/Cargo.toml
+  ```
+- If a future change adds a version constraint there, bump it in step
+  1 above and rebuild the same way.
+
+## 2. Crates.io publish DAG (`release.yml`)
+
+Publish order follows the dependency graph, leaf crates first, facade
+last — `vision-calibration-py` is **not** in this job, it ships to PyPI
+via `release-pypi.yml`:
+
+```
+vision-calibration-core
+  → vision-geometry
+    → vision-calibration-dataset
+    → vision-calibration-detect
+      → vision-calibration-linear
+      → vision-calibration-optim
+        → vision-mvg
+          → vision-calibration-pipeline
+            → vision-calibration
+```
+
+`dataset` and `detect` have no internal deps but are non-optional deps
+of `pipeline`, so they must land before it. `vision-geometry` and
+`vision-mvg` are a standalone MVG island (no calibration-chain crate
+depends on them) but ship in DAG order anyway: geometry after core, mvg
+after geometry.
+
+The job is idempotent (skips a crate/version already on the index) and
+`sleep 20`s between publishes for index propagation, so a mid-release
+failure can be fixed and the tag-triggered workflow re-run safely.
+
+## 3. Per-crate Trusted Publishing gotcha (2026-07-08 incident)
+
+crates.io Trusted Publishing (OIDC, no long-lived token) is configured
+**per crate**, not per repo. Every crate in the DAG above needs its own
+Trusted Publisher entry on crates.io:
+
+- Repository: `VitalyVorobyev/calibration-rs`
+- Workflow: `release.yml`
+- Environment: `crates-io`
+
+**A crate that has never been published cannot have Trusted Publishing
+configured before its first upload** — crates.io only offers the
+"add a trusted publisher" UI on a crate that already exists. `release.yml`
+handles this gracefully for a first-ever publish (404 on the sparse
+index → warn and skip rather than hard-fail), but that means a newly
+promoted crate can silently sit **unpublished** across a whole release
+if nobody follows up with `cargo publish` by hand + the crates.io UI
+config. This is exactly what happened to `vision-mvg` in the 0.6.0
+release (`vision-geometry`/`vision-mvg` joined the publish set that
+release and `vision-mvg` never got a Trusted Publisher entry, so it
+quietly never reached crates.io until the gap was noticed and fixed
+out of band).
+
+**When a crate joins the publish set for the first time:**
+
+1. Publish it manually once: `cargo publish -p <crate>` with a real
+   token (or ask someone with crates.io ownership to do it).
+2. Immediately add the Trusted Publisher entry (repo / workflow /
+   environment above) on the new crate's crates.io settings page.
+3. Only then does the next tagged release pick it up automatically.
+
+**Pre-tag check:** for every crate in the DAG, confirm on crates.io
+that (a) the crate exists and (b) it has a Trusted Publisher entry for
+`release.yml` / `crates-io`. Don't assume "it published before, so it's
+fine" — go look, especially for crates newer than the last release you
+personally drove.
+
+### Earlier incident: PyPI pyproject drift (0.4.0 / 0.5.0)
+
+`0.4.0` and `0.5.0` shipped to crates.io but never reached PyPI:
+`crates/vision-calibration-py/pyproject.toml`'s `project.version` was
+not bumped alongside the workspace, which tripped `release-pypi.yml`'s
+`Verify tag/version sync` job and skipped the wheel/sdist build and
+upload for both tags. `0.5.1` was cut specifically to repair this.
+Lesson: the pyproject version is not part of `[workspace.package]` and
+is easy to forget — it's source #3 in §1 above precisely because of
+this incident.
+
+## 4. "Adding public API to a published crate is a release event"
+
+`0.6.0` exists because PR #67 added the public
+`vision_calibration_core::linalg` module to the **already-published**
+`core@0.5.1` without a version bump. Local `core@0.5.1` then diverged
+from the immutable registry `core@0.5.1`. Publishing `vision-geometry`
+(which re-exports `core::linalg`) failed `--dry-run` with `E0432`,
+because `cargo publish` strips path deps and resolves the registry's
+*old* `core@0.5.1`, which has no `linalg`.
+
+**Rule:** once a crate has a version on crates.io, any change to its
+public surface — new module, new item, changed signature — must ride a
+workspace-wide version bump. Never land public-API changes at the same
+version a crate was already published at, even mid-development on
+`main`, if there's any chance a dependent crate publishes before the
+next bump.
+
+## 5. Pre-tag checklist
+
+Run all of these locally before pushing the tag. All must pass.
+
+```bash
+# 1. All four version sources print the same vX.Y.Z (see §1 for what to grep —
+#    remember examples-private has more than one path-dep pin per crate).
+grep -RHn 'version = "' Cargo.toml \
+    crates/vision-calibration-py/pyproject.toml \
+    crates/vision-calibration-examples-private/Cargo.toml \
+  | grep -v 'edition\|rust-version'
+
+# 2. Full workspace gates.
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features
+
+# 3. Doc build with the same strictness publish-docs.yml uses (that workflow
+#    only runs on push-to-main, not on PRs — catch broken intra-doc-links here).
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+
+# 4. PyO3 build + runtime tests (release-pypi.yml's verify job repeats this).
+maturin develop -m crates/vision-calibration-py/Cargo.toml
+python -m unittest discover -s crates/vision-calibration-py/tests -p "test_*.py"
+
+# 5. Binding-surface sanity (cheap, catches drift before CI does).
+python3 scripts/check_pyi_coverage.py --check
+python3 scripts/check_binding_parity.py --check
+
+# 6. Publish dry-run in DAG order (§2) — catches E0432-style path-dep
+#    resolution failures (§4) before they wedge the real publish job.
+for c in vision-calibration-core vision-geometry vision-calibration-dataset \
+         vision-calibration-detect vision-calibration-linear \
+         vision-calibration-optim vision-mvg vision-calibration-pipeline \
+         vision-calibration; do
+  cargo publish -p "$c" --dry-run --locked || break
+done
+
+# 7. Trusted Publishing coverage (§3) — manual crates.io UI check, one page
+#    per crate in the DAG. No CLI shortcut; just go look.
+```
+
+## 6. Tag and what fires
+
+Tag format `vX.Y.Z` (matches `[workspace.package] version` and the
+pyproject version exactly — `release-pypi.yml`'s verify job hard-fails
+otherwise). Do not sign or amend after pushing; if a workflow fails
+mid-release, fix forward (the publish jobs are idempotent, see §2).
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Three workflows key off `push: tags: 'v*'`:
+
+| Workflow | Triggers | Produces |
+|---|---|---|
+| `release.yml` | tag push | gates (fmt/clippy/test) → publishes the nine crates to crates.io in DAG order (§2) → GitHub release with auto-generated notes |
+| `release-pypi.yml` | tag push | verifies tag/version sync → builds wheels (Linux/macOS/Windows, abi3-py310) + sdist → publishes to PyPI |
+| `app-bundle.yml` | tag push (also `workflow_dispatch`) | unsigned macOS (`.app`/`.dmg`) and Linux (AppImage/`.deb`) desktop bundles, uploaded as **workflow-run artifacts only** — not attached to the GitHub release, not signed/notarized |
+
+None of these push back to `main`; the version-bump PR that prepared
+the release is the only commit that touches version strings.


### PR DESCRIPTION
## Summary
Prepares the v0.7.0 release: all four version sources bumped in lockstep (workspace Cargo.toml + 9 dep pins, py pyproject.toml, examples-private with its actual 6 pins — CLAUDE.md's stale "4" corrected), both lockfiles refreshed, new `docs/RELEASE-RUNBOOK.md` (publish DAG, per-crate Trusted Publishing gotcha, pre-tag checklist), CHANGELOG 0.7.0 entry covering the full v0.6.0..HEAD range (C3–C5, D1, M-WIRE, S-track, Q-track, R-track, B-track — breaking changes first) plus the backfilled 0.6.0 section, README quick-start pin.

## Pre-tag battery (all green locally)
- `cargo test --release --workspace --all-features` — 54 suites OK
- Full acceptance: public 6/6, private 13/13 (needs `--features "tier-b laser"` — the runbook records this)
- maturin develop (0.7.0) + 42 Python tests OK; pyi + binding-parity checks OK
- `cargo publish --dry-run -p vision-calibration-core` OK
- fmt / clippy / doc `-D warnings` clean

After merge: tag `v0.7.0` on main → `release.yml` (crates.io ×9 + GitHub release), `release-pypi.yml` (wheels), `app-bundle.yml` (unsigned app bundles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)